### PR TITLE
Simple order to candidate and committee

### DIFF
--- a/webservices/candidates/models.py
+++ b/webservices/candidates/models.py
@@ -2,13 +2,13 @@ class Candidate(object):
 
     # default fields for search
     default_fields = {
-        'dimcand_fields': 'cand_id',
+        'dimcand_fields': 'cand_id,',
         'cand_committee_link_fields':
-            'cmte_id,cmte_dsgn,cmte_tp,cand_election_yr',
-        'office_fields': 'office_district,office_state,office_tp',
-        'party_fields': 'party_affiliation_desc,party_affiliation',
-        'status_fields': 'election_yr,cand_status,ici_code',
-        'properties_fields': 'cand_nm',
+            'cmte_id,cmte_dsgn,cmte_tp,cand_election_yr,',
+        'office_fields': 'office_district,office_state,office_tp,',
+        'party_fields': 'party_affiliation_desc,party_affiliation,',
+        'status_fields': 'election_yr,cand_status,ici_code,',
+        'properties_fields': 'cand_nm,',
         'cmte_fields': 'P',
     }
 
@@ -38,9 +38,9 @@ class Candidate(object):
             com_query = ''
 
         return """
-            %s{{%s},/dimcandproperties{%s},/dimcandoffice{cand_election_yr-,dimoffice{%s},dimparty{%s}},
+            (%s{{%s max(dimcandproperties.cand_nm)},/dimcandproperties{%s},/dimcandoffice{cand_election_yr-,dimoffice{%s},dimparty{%s}},
                               %s
-                              /dimcandstatusici{%s}}
+                              /dimcandstatusici{%s}}).sort(max(dimcandproperties.cand_nm)+)
         """ % (
             self.viewable_table_name,
             show_fields['dimcand_fields'],

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -865,17 +865,17 @@ class NameSearch(Searchable):
 class Committee(object):
 
     default_fields = {
-        'dimcmte_fields': 'cmte_id,form_tp,load_date,expire_date',
-        'properties_fields': '*',
+        'dimcmte_fields': 'cmte_id,form_tp,load_date,expire_date,',
+        'properties_fields': '*,',
         'linkages_fields': 'cand_id,cmte_tp,cmte_dsgn,cand_election_yr,expire_date,link_date, /dimcand{/dimcandproperties{cand_nm,}, /dimcandoffice{/dimoffice{office_tp,office_tp_desc}}}',
-        'designation_fields': '*',
+        'designation_fields': '*,',
     }
 
     table_name_stem = 'cmte'
     viewable_table_name = "(dimcmte?exists(dimcmteproperties))"
     def query_text(self, show_fields):
         # We always need expire date and cand_id to sort the information
-        return '(%s{{%s},/dimcmteproperties{expire_date,%s}, /dimlinkages{cand_id,expire_date,%s}, /dimcmtetpdsgn{expire_date,%s}})' % (
+        return '(%s{{%s max(dimcmteproperties.cmte_nm)},/dimcmteproperties{expire_date,%s}, /dimlinkages{cand_id,expire_date,%s}, /dimcmtetpdsgn{expire_date,%s}}).sort(max(dimcmteproperties.cmte_nm)+)' % (
             self.viewable_table_name,
             show_fields['dimcmte_fields'],
             show_fields['properties_fields'],


### PR DESCRIPTION
We need to do more complex ordering in the future, but that will be much easier after we alter the import script and we are working off of pre-joined tables. For now, lets make it look pretty by making the default sorting by name.

This doesn't fully implement #176, but it makes it better.