### PR TITLE
Separate ``live`` and ``processed_live`` schemas to access

### DIFF
--- a/data/ddl/processed_schema.in_rds.sql
+++ b/data/ddl/processed_schema.in_rds.sql
@@ -1,0 +1,3485 @@
+-- Run in RDS to create the actual tables to store copies of FEC rows
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+--
+-- Name: processed_newdownload; Type: SCHEMA; Schema: -; Owner: ec2-user
+--
+
+CREATE SCHEMA processed_newdownload;
+GRANT ALL PRIVILEGES ON SCHEMA processed_newdownload TO openfec;
+
+
+SET search_path = processed_newdownload, pg_catalog;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: cand_status_ici; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE cand_status_ici (
+    cand_status_ici_sk numeric(10,0) NOT NULL,
+    cand_id character varying(9) NOT NULL,
+    election_yr numeric(4,0) NOT NULL,
+    ici_code character varying(1),
+    cand_status character varying(1),
+    cand_inactive_flg character varying(1),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.cand_status_ici OWNER TO "ec2-user";
+
+--
+-- Name: form_1; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_1 (
+    form_1_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    submit_dt date,
+    cmte_nm_chg_flg character varying(1),
+    cmte_addr_chg_flg character varying(1),
+    cmte_tp character varying(1),
+    cand_id character varying(9),
+    cand_nm character varying(90),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    cand_pty_affiliation character varying(3),
+    cand_pty_tp character varying(3),
+    affiliated_cmte_id character varying(9),
+    affiliated_cmte_nm character varying(200),
+    affiliated_cmte_st1 character varying(34),
+    affiliated_cmte_st2 character varying(34),
+    affiliated_cmte_city character varying(30),
+    affiliated_cmte_st character varying(2),
+    affiliated_cmte_zip character varying(9),
+    cmte_rltshp character varying(38),
+    org_tp character varying(1),
+    cust_rec_nm character varying(90),
+    cust_rec_st1 character varying(34),
+    cust_rec_st2 character varying(34),
+    cust_rec_city character varying(30),
+    cust_rec_st character varying(2),
+    cust_rec_zip character varying(9),
+    cust_rec_title character varying(20),
+    cust_rec_ph_num character varying(10),
+    tres_nm character varying(90),
+    tres_st1 character varying(34),
+    tres_st2 character varying(34),
+    tres_city character varying(30),
+    tres_st character varying(2),
+    tres_zip character varying(9),
+    tres_title character varying(20),
+    tres_ph_num character varying(10),
+    designated_agent_nm character varying(90),
+    designated_agent_st1 character varying(34),
+    designated_agent_st2 character varying(34),
+    designated_agent_city character varying(30),
+    designated_agent_st character varying(2),
+    designated_agent_zip character varying(9),
+    designated_agent_title character varying(20),
+    designated_agent_ph_num character varying(10),
+    bank_depository_nm character varying(200),
+    bank_depository_st1 character varying(34),
+    bank_depository_st2 character varying(34),
+    bank_depository_city character varying(30),
+    bank_depository_st character varying(2),
+    bank_depository_zip character varying(9),
+    sec_bank_depository_nm character varying(200),
+    sec_bank_depository_st1 character varying(34),
+    sec_bank_depository_st2 character varying(34),
+    sec_bank_depository_city character varying(30),
+    sec_bank_depository_st character varying(2),
+    sec_bank_depository_zip character varying(10),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    cmte_email character varying(90),
+    cmte_web_url character varying(90),
+    receipt_dt date,
+    filing_freq character varying(1),
+    cmte_dsgn character varying(1),
+    qual_dt date,
+    cmte_fax character varying(12),
+    efiling_cmte_tp character varying(1),
+    rpt_yr numeric(4,0),
+    leadership_pac character varying(1),
+    affiliated_relationship_cd character varying(3),
+    cmte_email_chg_flg character varying(1),
+    cmte_url_chg_flg character varying(1),
+    lobbyist_registrant_pac character varying(1),
+    affiliated_cand_id character varying(9),
+    affiliated_cand_l_nm character varying(30),
+    affiliated_cand_f_nm character varying(20),
+    affiliated_cand_m_nm character varying(20),
+    affiliated_cand_prefix character varying(10),
+    affiliated_cand_suffix character varying(10),
+    cand_l_nm character varying(30),
+    cand_f_nm character varying(20),
+    cand_m_nm character varying(20),
+    cand_prefix character varying(10),
+    cand_suffix character varying(10),
+    cust_rec_l_nm character varying(30),
+    cust_rec_f_nm character varying(20),
+    cust_rec_m_nm character varying(20),
+    cust_rec_prefix character varying(10),
+    cust_rec_suffix character varying(10),
+    tres_l_nm character varying(30),
+    tres_f_nm character varying(20),
+    tres_m_nm character varying(20),
+    tres_prefix character varying(10),
+    tres_suffix character varying(10),
+    designated_agent_l_nm character varying(30),
+    designated_agent_f_nm character varying(20),
+    designated_agent_m_nm character varying(20),
+    designated_agent_prefix character varying(10),
+    designated_agent_suffix character varying(10),
+    f3l_filing_freq character varying(1),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_1 OWNER TO "ec2-user";
+
+--
+-- Name: form_10; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_10 (
+    form_10_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    cand_nm character varying(38),
+    cand_id character varying(9),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    cmte_nm character varying(90),
+    st1 character varying(34),
+    st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    prev_exp_agg numeric(14,2),
+    exp_ttl_this_rpt numeric(14,2),
+    exp_ttl_cycl_to_dt numeric(14,2),
+    cand_sign_nm character varying(38),
+    sign_dt date,
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    form_tp_desc character varying(90),
+    cand_office_desc character varying(20),
+    cand_office_st_desc character varying(20),
+    cmte_st_desc character varying(20),
+    image_tp character varying(10),
+    last_update_dt date,
+    amndt_ind character varying(1),
+    receipt_dt date,
+    form_6_chk character varying(1),
+    contbr_employer character varying(38),
+    contbr_occupation character varying(38),
+    rpt_yr numeric(4,0),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_10 OWNER TO "ec2-user";
+
+--
+-- Name: form_11; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_11 (
+    form_11_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    cand_nm character varying(38),
+    cand_id character varying(9),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    oppos_cand_nm character varying(38),
+    oppos_cmte_nm character varying(90),
+    oppos_cmte_id character varying(9),
+    oppos_cmte_st1 character varying(34),
+    oppos_cmte_st2 character varying(34),
+    oppos_cmte_city character varying(18),
+    oppos_cmte_st character varying(2),
+    oppos_cmte_zip character varying(9),
+    form_10_recpt_dt date,
+    oppos_pers_fund_amt numeric(14,2),
+    election_tp character varying(5),
+    fec_election_tp_desc character varying(20),
+    reg_special_elect_tp character varying(1),
+    cand_tres_sign_nm character varying(38),
+    cand_tres_sign_dt date,
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    amndt_ind character varying(1),
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    cand_last_name character varying(30),
+    cand_first_name character varying(20),
+    cand_middle_name character varying(20),
+    cand_prefix character varying(10),
+    cand_suffix character varying(10),
+    oppos_cand_last_name character varying(30),
+    oppos_cand_first_name character varying(20),
+    oppos_cand_middle_name character varying(20),
+    oppos_cand_prefix character varying(10),
+    oppos_cand_suffix character varying(10),
+    cand_tres_last_name character varying(30),
+    cand_tres_first_name character varying(20),
+    cand_tres_middle_name character varying(20),
+    cand_tres_prefix character varying(10),
+    cand_tres_suffix character varying(10),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_11 OWNER TO "ec2-user";
+
+--
+-- Name: form_12; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_12 (
+    form_12_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    cand_nm character varying(38),
+    cand_id character varying(9),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    cmte_nm character varying(90),
+    st1 character varying(34),
+    st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    election_tp character varying(5),
+    reg_special_elect_tp character varying(1),
+    fec_election_tp_desc character varying(20),
+    hse_date_reached_100 date,
+    hse_pers_funds_amt numeric(14,2),
+    hse_form_11_prev_dt date,
+    sen_date_reached_110 date,
+    sen_pers_funds_amt numeric(14,2),
+    sen_form_11_prev_dt date,
+    cand_tres_sign_nm character varying(38),
+    cand_tres_sign_dt date,
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    amndt_ind character varying(1),
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    cand_last_name character varying(30),
+    cand_first_name character varying(20),
+    cand_middle_name character varying(20),
+    cand_prefix character varying(10),
+    cand_suffix character varying(10),
+    cand_tres_last_name character varying(30),
+    cand_tres_first_name character varying(20),
+    cand_tres_middle_name character varying(20),
+    cand_tres_prefix character varying(10),
+    cand_tres_suffix character varying(10),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_12 OWNER TO "ec2-user";
+
+--
+-- Name: form_13; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_13 (
+    form_13_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_addr_chg_flg character varying(1),
+    cmte_tp character varying(1),
+    rpt_tp character varying(3),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    ttl_dons_accepted numeric(14,2),
+    ttl_dons_refunded numeric(14,2),
+    net_dons numeric(14,2),
+    desig_officer_last_nm character varying(30),
+    desig_officer_first_nm character varying(20),
+    desig_officer_middle_nm character varying(20),
+    desig_officer_prefix character varying(10),
+    desig_officer_suffix character varying(10),
+    desig_officer_nm character varying(38),
+    receipt_dt date,
+    signature_dt date,
+    rpt_yr numeric(4,0),
+    original_report_dt date,
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_13 OWNER TO "ec2-user";
+
+--
+-- Name: form_1m; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_1m (
+    form_1m_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_tp character varying(1),
+    affiliation_dt date,
+    affiliated_cmte_id character varying(9),
+    affiliated_cmte_nm character varying(200),
+    fst_cand_id character varying(9),
+    fst_cand_nm character varying(90),
+    fst_cand_office character varying(1),
+    fst_cand_office_st character varying(2),
+    fst_cand_office_district character varying(2),
+    fst_cand_contb_dt date,
+    sec_cand_id character varying(9),
+    sec_cand_nm character varying(90),
+    sec_cand_office character varying(1),
+    sec_cand_office_st character varying(2),
+    sec_cand_office_district character varying(2),
+    sec_cand_contb_dt date,
+    trd_cand_id character varying(9),
+    trd_cand_nm character varying(90),
+    trd_cand_office character varying(1),
+    trd_cand_office_st character varying(2),
+    trd_cand_office_district character varying(2),
+    trd_cand_contb_dt date,
+    frth_cand_id character varying(9),
+    frth_cand_nm character varying(90),
+    frth_cand_office character varying(1),
+    frth_cand_office_st character varying(2),
+    frth_cand_office_district character varying(2),
+    frth_cand_contb_dt date,
+    fith_cand_id character varying(9),
+    fith_cand_nm character varying(90),
+    fith_cand_office character varying(1),
+    fith_cand_office_st character varying(2),
+    fith_cand_office_district character varying(2),
+    fith_cand_contb_dt date,
+    fiftyfirst_cand_contbr_dt date,
+    orig_registration_dt date,
+    qual_dt date,
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_1m OWNER TO "ec2-user";
+
+--
+-- Name: form_1s; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_1s (
+    form_1s_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    affiliated_cmte_id character varying(9),
+    affiliated_cmte_nm character varying(200),
+    affiliated_cmte_st1 character varying(34),
+    affiliated_cmte_st2 character varying(34),
+    affiliated_cmte_city character varying(30),
+    affiliated_cmte_st character varying(2),
+    affiliated_cmte_zip character varying(9),
+    cmte_rltshp character varying(38),
+    org_tp character varying(1),
+    designated_agent_nm character varying(200),
+    designated_agent_st1 character varying(34),
+    designated_agent_st2 character varying(34),
+    designated_agent_city character varying(30),
+    designated_agent_st character varying(2),
+    designated_agent_zip character varying(9),
+    designated_agent_title character varying(20),
+    designated_agent_ph_num character varying(10),
+    bank_depository_nm character varying(200),
+    bank_depository_st1 character varying(34),
+    bank_depository_st2 character varying(34),
+    bank_depository_city character varying(30),
+    bank_depository_st character varying(2),
+    bank_depository_zip character varying(9),
+    receipt_dt date,
+    joint_cmte_nm character varying(90),
+    joint_cmte_id character varying(9),
+    affiliated_relationship_cd character varying(3),
+    affiliated_cand_id character varying(9),
+    affiliated_cand_l_nm character varying(30),
+    affiliated_cand_f_nm character varying(20),
+    affiliated_cand_m_nm character varying(20),
+    affiliated_cand_prefix character varying(10),
+    affiliated_cand_suffix character varying(10),
+    designated_agent_l_nm character varying(30),
+    designated_agent_f_nm character varying(20),
+    designated_agent_m_nm character varying(20),
+    designated_agent_prefix character varying(10),
+    designated_agent_suffix character varying(10),
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_1s OWNER TO "ec2-user";
+
+--
+-- Name: form_2; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_2 (
+    form_2_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cand_id character varying(9),
+    cand_nm character varying(90),
+    cand_st1 character varying(34),
+    cand_st2 character varying(34),
+    cand_city character varying(30),
+    cand_st character varying(2),
+    cand_zip character varying(9),
+    addr_chg_flg character varying(1),
+    cand_pty_affiliation character varying(3),
+    cand_pty_affiliation_2 character varying(3),
+    cand_pty_affiliation_3 character varying(3),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    election_yr numeric(4,0),
+    pcc_cmte_id character varying(9),
+    pcc_cmte_nm character varying(200),
+    pcc_cmte_st1 character varying(34),
+    pcc_cmte_st2 character varying(34),
+    pcc_cmte_city character varying(30),
+    pcc_cmte_st character varying(2),
+    pcc_cmte_zip character varying(9),
+    addl_auth_cmte_id character varying(9),
+    addl_auth_cmte_nm character varying(200),
+    addl_auth_cmte_st1 character varying(34),
+    addl_auth_cmte_st2 character varying(34),
+    addl_auth_cmte_city character varying(18),
+    addl_auth_cmte_st character varying(2),
+    addl_auth_cmte_zip character varying(9),
+    cand_sign_nm character varying(90),
+    cand_sign_dt date,
+    receipt_dt date,
+    party_cd character varying(1),
+    cand_ici character varying(1),
+    cand_status character varying(1),
+    prim_pers_funds_decl numeric(14,2),
+    gen_pers_funds_decl numeric(14,2),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_2 OWNER TO "ec2-user";
+
+--
+-- Name: form_24; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_24 (
+    form_24_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_tp character varying(3),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_24 OWNER TO "ec2-user";
+
+--
+-- Name: form_2s; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_2s (
+    form_2s_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cand_id character varying(9),
+    auth_cmte_id character varying(9),
+    auth_cmte_nm character varying(90),
+    auth_cmte_st1 character varying(34),
+    auth_cmte_st2 character varying(34),
+    auth_cmte_city character varying(18),
+    auth_cmte_st character varying(2),
+    auth_cmte_zip character varying(9),
+    receipt_dt date,
+    amndt_ind character varying(1),
+    begin_image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_2s OWNER TO "ec2-user";
+
+--
+-- Name: form_3; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_3 (
+    form_3_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_addr_chg_flg character varying(1),
+    cmte_election_st character varying(2),
+    cmte_election_district character varying(2),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_dt date,
+    election_st character varying(2),
+    primary_election character varying(1),
+    general_election character varying(1),
+    special_election character varying(1),
+    runoff_election character varying(1),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    ttl_contb_per numeric(14,2),
+    ttl_contb_ref_per numeric(14,2),
+    net_contb_per numeric(14,2),
+    ttl_op_exp_per numeric(14,2),
+    ttl_offsets_to_op_exp_per numeric(14,2),
+    net_op_exp_per numeric(14,2),
+    coh_cop_i numeric(14,2),
+    debts_owed_to_cmte numeric(14,2),
+    debts_owed_by_cmte numeric(14,2),
+    indv_item_contb_per numeric(14,2),
+    indv_unitem_contb_per numeric(14,2),
+    ttl_indv_contb_per numeric(14,2),
+    pol_pty_cmte_contb_per numeric(14,2),
+    other_pol_cmte_contb_per numeric(14,2),
+    cand_contb_per numeric(14,2),
+    ttl_contb_column_ttl_per numeric(14,2),
+    tranf_from_other_auth_cmte_per numeric(14,2),
+    loans_made_by_cand_per numeric(14,2),
+    all_other_loans_per numeric(14,2),
+    ttl_loans_per numeric(14,2),
+    offsets_to_op_exp_per numeric(14,2),
+    other_receipts_per numeric(14,2),
+    ttl_receipts_per_i numeric(14,2),
+    op_exp_per numeric(14,2),
+    tranf_to_other_auth_cmte_per numeric(14,2),
+    loan_repymts_cand_loans_per numeric(14,2),
+    loan_repymts_other_loans_per numeric(14,2),
+    ttl_loan_repymts_per numeric(14,2),
+    ref_indv_contb_per numeric(14,2),
+    ref_pol_pty_cmte_contb_per numeric(14,2),
+    ref_other_pol_cmte_contb_per numeric(14,2),
+    ttl_contb_ref_col_ttl_per numeric(14,2),
+    other_disb_per numeric(14,2),
+    ttl_disb_per_i numeric(14,2),
+    coh_bop numeric(14,2),
+    ttl_receipts_ii numeric(14,2),
+    subttl_per numeric(14,2),
+    ttl_disb_per_ii numeric(14,2),
+    coh_cop_ii numeric(14,2),
+    ttl_contb_ytd numeric(14,2),
+    ttl_contb_ref_ytd numeric(14,2),
+    net_contb_ytd numeric(14,2),
+    ttl_op_exp_ytd numeric(14,2),
+    ttl_offsets_to_op_exp_ytd numeric(14,2),
+    net_op_exp_ytd numeric(14,2),
+    ttl_indv_item_contb_ytd numeric(14,2),
+    ttl_indv_unitem_contb_ytd numeric(14,2),
+    ttl_indv_contb_ytd numeric(14,2),
+    pol_pty_cmte_contb_ytd numeric(14,2),
+    other_pol_cmte_contb_ytd numeric(14,2),
+    cand_contb_ytd numeric(14,2),
+    ttl_contb_col_ttl_ytd numeric(14,2),
+    tranf_from_other_auth_cmte_ytd numeric(14,2),
+    loans_made_by_cand_ytd numeric(14,2),
+    all_other_loans_ytd numeric(14,2),
+    ttl_loans_ytd numeric(14,2),
+    offsets_to_op_exp_ytd numeric(14,2),
+    other_receipts_ytd numeric(14,2),
+    ttl_receipts_ytd numeric(14,2),
+    op_exp_ytd numeric(14,2),
+    tranf_to_other_auth_cmte_ytd numeric(14,2),
+    loan_repymts_cand_loans_ytd numeric(14,2),
+    loan_repymts_other_loans_ytd numeric(14,2),
+    ttl_loan_repymts_ytd numeric(14,2),
+    ref_indv_contb_ytd numeric(14,2),
+    ref_pol_pty_cmte_contb_ytd numeric(14,2),
+    ref_other_pol_cmte_contb_ytd numeric(14,2),
+    ref_ttl_contb_col_ttl_ytd numeric(14,2),
+    other_disb_ytd numeric(14,2),
+    ttl_disb_ytd numeric(14,2),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    grs_rcpt_auth_cmte_prim numeric(14,2),
+    agr_amt_contrib_pers_fund_prim numeric(14,2),
+    grs_rcpt_min_pers_contrib_prim numeric(14,2),
+    grs_rcpt_auth_cmte_gen numeric(14,2),
+    agr_amt_pers_contrib_gen numeric(14,2),
+    grs_rcpt_min_pers_contrib_gen numeric(14,2),
+    cand_id character varying(9),
+    cand_nm character varying(38),
+    f3z1_rpt_tp character varying(3),
+    f3z1_rpt_tp_desc character varying(30),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_3 OWNER TO "ec2-user";
+
+--
+-- Name: form_3l; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_3l (
+    form_3l_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(28),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_addr_chg_flg character varying(1),
+    cmte_election_st character varying(2),
+    cmte_election_district character varying(2),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_dt date,
+    election_st character varying(2),
+    semi_an_per_5c_5d character varying(1),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    semi_an_jan_jun_6b character varying(1),
+    semi_an_jul_dec_6b character varying(1),
+    qtr_mon_bundled_contb numeric(14,2),
+    semi_an_bundled_contb numeric(14,2),
+    tres_l_nm character varying(30),
+    tres_f_nm character varying(20),
+    tres_m_nm character varying(20),
+    tres_prefix character varying(10),
+    tres_suffix character varying(10),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_3l OWNER TO "ec2-user";
+
+--
+-- Name: form_3p; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_3p (
+    form_3p_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    addr_chg_flg character varying(1),
+    activity_primary character varying(1),
+    activity_general character varying(1),
+    term_rpt_flag character varying(1),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_dt date,
+    election_st character varying(2),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    coh_bop numeric(14,2),
+    ttl_receipts_sum_page_per numeric(14,2),
+    subttl_sum_page_per numeric(14,2),
+    ttl_disb_sum_page_per numeric(14,2),
+    coh_cop numeric(14,2),
+    debts_owed_to_cmte numeric(14,2),
+    debts_owed_by_cmte numeric(14,2),
+    exp_subject_limits numeric(14,2),
+    net_contb_sum_page_per numeric(14,2),
+    net_op_exp_sum_page_per numeric(14,2),
+    fed_funds_per numeric(14,2),
+    indv_contb_per numeric(14,2),
+    pol_pty_cmte_contb_per numeric(14,2),
+    other_pol_cmte_contb_per numeric(14,2),
+    cand_contb_per numeric(14,2),
+    ttl_contb_per numeric(14,2),
+    tranf_from_affilated_cmte_per numeric(14,2),
+    loans_received_from_cand_per numeric(14,2),
+    other_loans_received_per numeric(14,2),
+    ttl_loans_received_per numeric(14,2),
+    offsets_to_op_exp_per numeric(14,2),
+    offsets_to_fndrsg_exp_per numeric(14,2),
+    offsets_to_legal_acctg_per numeric(14,2),
+    ttl_offsets_to_op_exp_per numeric(14,2),
+    other_receipts_per numeric(14,2),
+    ttl_receipts_per numeric(14,2),
+    op_exp_per numeric(14,2),
+    tranf_to_other_auth_cmte_per numeric(14,2),
+    fndrsg_disb_per numeric(14,2),
+    exempt_legal_acctg_disb_per numeric(14,2),
+    repymts_loans_made_by_cand_per numeric(14,2),
+    repymts_other_loans_per numeric(14,2),
+    ttl_loan_repymts_made_per numeric(14,2),
+    ref_indv_contb_per numeric(14,2),
+    ref_pol_pty_cmte_contb_per numeric(14,2),
+    ref_other_pol_cmte_contb_per numeric(14,2),
+    ttl_contb_ref_per numeric(14,2),
+    other_disb_per numeric(14,2),
+    ttl_disb_per numeric(14,2),
+    items_on_hand_liquidated numeric(14,2),
+    alabama_per numeric(14,2),
+    alaska_per numeric(14,2),
+    arizona_per numeric(14,2),
+    arkansas_per numeric(14,2),
+    california_per numeric(14,2),
+    colorado_per numeric(14,2),
+    connecticut_per numeric(14,2),
+    delaware_per numeric(14,2),
+    district_columbia_per numeric(14,2),
+    florida_per numeric(14,2),
+    georgia_per numeric(14,2),
+    hawaii_per numeric(14,2),
+    idaho_per numeric(14,2),
+    illinois_per numeric(14,2),
+    indiana_per numeric(14,2),
+    iowa_per numeric(14,2),
+    kansas_per numeric(14,2),
+    kentucky_per numeric(14,2),
+    louisiana_per numeric(14,2),
+    maine_per numeric(14,2),
+    maryland_per numeric(14,2),
+    massachusetts_per numeric(14,2),
+    michigan_per numeric(14,2),
+    minnesota_per numeric(14,2),
+    mississippi_per numeric(14,2),
+    missouri_per numeric(14,2),
+    montana_per numeric(14,2),
+    nebraska_per numeric(14,2),
+    nevada_per numeric(14,2),
+    new_hampshire_per numeric(14,2),
+    new_jersey_per numeric(14,2),
+    new_mexico_per numeric(14,2),
+    new_york_per numeric(14,2),
+    north_carolina_per numeric(14,2),
+    north_dakota_per numeric(14,2),
+    ohio_per numeric(14,2),
+    oklahoma_per numeric(14,2),
+    oregon_per numeric(14,2),
+    pennsylvania_per numeric(14,2),
+    rhode_island_per numeric(14,2),
+    south_carolina_per numeric(14,2),
+    south_dakota_per numeric(14,2),
+    tennessee_per numeric(14,2),
+    texas_per numeric(14,2),
+    utah_per numeric(14,2),
+    vermont_per numeric(14,2),
+    virginia_per numeric(14,2),
+    washington_per numeric(14,2),
+    west_virginia_per numeric(14,2),
+    wisconsin_per numeric(14,2),
+    wyoming_per numeric(14,2),
+    puerto_rico_per numeric(14,2),
+    guam_per numeric(14,2),
+    virgin_islands_per numeric(14,2),
+    ttl_per numeric(14,2),
+    fed_funds_ytd numeric(14,2),
+    indv_contb_ytd numeric(14,2),
+    pol_pty_cmte_contb_ytd numeric(14,2),
+    other_pol_cmte_contb_ytd numeric(14,2),
+    cand_contb_ytd numeric(14,2),
+    ttl_contb_ytd numeric(14,2),
+    tranf_from_affiliated_cmte_ytd numeric(14,2),
+    loans_received_from_cand_ytd numeric(14,2),
+    other_loans_received_ytd numeric(14,2),
+    ttl_loans_received_ytd numeric(14,2),
+    offsets_to_op_exp_ytd numeric(14,2),
+    offsets_to_fndrsg_exp_ytd numeric(14,2),
+    offsets_to_legal_acctg_ytd numeric(14,2),
+    ttl_offsets_to_op_exp_ytd numeric(14,2),
+    other_receipts_ytd numeric(14,2),
+    ttl_receipts_ytd numeric(14,2),
+    op_exp_ytd numeric(14,2),
+    tranf_to_other_auth_cmte_ytd numeric(14,2),
+    fndrsg_disb_ytd numeric(14,2),
+    exempt_legal_acctg_disb_ytd numeric(14,2),
+    repymts_loans_made_cand_ytd numeric(14,2),
+    repymts_other_loans_ytd numeric(14,2),
+    ttl_loan_repymts_made_ytd numeric(14,2),
+    ref_indv_contb_ytd numeric(14,2),
+    ref_pol_pty_cmte_contb_ytd numeric(14,2),
+    ref_other_pol_cmte_contb_ytd numeric(14,2),
+    ttl_contb_ref_ytd numeric(14,2),
+    other_disb_ytd numeric(14,2),
+    ttl_disb_ytd numeric(14,2),
+    alabama_ytd numeric(14,2),
+    alaska_ytd numeric(14,2),
+    arizona_ytd numeric(14,2),
+    arkansas_ytd numeric(14,2),
+    california_ytd numeric(14,2),
+    colorado_ytd numeric(14,2),
+    connecticut_ytd numeric(14,2),
+    delaware_ytd numeric(14,2),
+    district_columbia_ytd numeric(14,2),
+    florida_ytd numeric(14,2),
+    georgia_ytd numeric(14,2),
+    hawaii_ytd numeric(14,2),
+    idaho_ytd numeric(14,2),
+    illinois_ytd numeric(14,2),
+    indiana_ytd numeric(14,2),
+    iowa_ytd numeric(14,2),
+    kansas_ytd numeric(14,2),
+    kentucky_ytd numeric(14,2),
+    louisiana_ytd numeric(14,2),
+    maine_ytd numeric(14,2),
+    maryland_ytd numeric(14,2),
+    massachusetts_ytd numeric(14,2),
+    michigan_ytd numeric(14,2),
+    minnesota_ytd numeric(14,2),
+    mississippi_ytd numeric(14,2),
+    missouri_ytd numeric(14,2),
+    montana_ytd numeric(14,2),
+    nebraska_ytd numeric(14,2),
+    nevada_ytd numeric(14,2),
+    new_hampshire_ytd numeric(14,2),
+    new_jersey_ytd numeric(14,2),
+    new_mexico_ytd numeric(14,2),
+    new_york_ytd numeric(14,2),
+    north_carolina_ytd numeric(14,2),
+    north_dakota_ytd numeric(14,2),
+    ohio_ytd numeric(14,2),
+    oklahoma_ytd numeric(14,2),
+    oregon_ytd numeric(14,2),
+    pennsylvania_ytd numeric(14,2),
+    rhode_island_ytd numeric(14,2),
+    south_carolina_ytd numeric(14,2),
+    south_dakota_ytd numeric(14,2),
+    tennessee_ytd numeric(14,2),
+    texas_ytd numeric(14,2),
+    utah_ytd numeric(14,2),
+    vermont_ytd numeric(14,2),
+    virginia_ytd numeric(14,2),
+    washington_ytd numeric(14,2),
+    west_virginia_ytd numeric(14,2),
+    wisconsin_ytd numeric(14,2),
+    wyoming_ytd numeric(14,2),
+    puerto_rico_ytd numeric(14,2),
+    guam_ytd numeric(14,2),
+    virgin_islands_ytd numeric(14,2),
+    ttl_ytd numeric(14,2),
+    tres_sign_nm character varying(38),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_3p OWNER TO "ec2-user";
+
+--
+-- Name: form_3p_line_31s; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_3p_line_31s (
+    form_3p31s_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    entity_tp character varying(3),
+    contbr_lender_nm character varying(90),
+    contbr_lender_st1 character varying(34),
+    contbr_lender_st2 character varying(34),
+    contbr_lender_city character varying(18),
+    contbr_lender_st character varying(2),
+    contbr_lender_zip character varying(9),
+    rpt_pgi character varying(5),
+    contbr_lender_employer character varying(38),
+    contbr_lender_occupation character varying(38),
+    contb_dt date,
+    fair_mkt_value_of_item numeric(14,2),
+    tran_code character varying(3),
+    tran_desc character varying(100),
+    cand_id character varying(9),
+    cand_nm character varying(38),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    conduit_cmte_id character varying(9),
+    conduit_cmte_nm character varying(90),
+    conduit_cmte_st1 character varying(34),
+    conduit_cmte_st2 character varying(34),
+    conduit_cmte_city character varying(18),
+    conduit_cmte_st character varying(2),
+    conduit_cmte_zip character varying(9),
+    memo_flag character varying(1),
+    memo_text character varying(100),
+    amndt_ind character varying(1),
+    tran_id character varying(32),
+    receipt_dt date,
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_3p_line_31s OWNER TO "ec2-user";
+
+--
+-- Name: form_3ps; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_3ps (
+    form_3ps_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    alabama numeric(14,2),
+    alaska numeric(14,2),
+    arizona numeric(14,2),
+    arkansas numeric(14,2),
+    california numeric(14,2),
+    colorado numeric(14,2),
+    connecticut numeric(14,2),
+    delaware numeric(14,2),
+    district_columbia numeric(14,2),
+    florida numeric(14,2),
+    georgia numeric(14,2),
+    hawaii numeric(14,2),
+    idaho numeric(14,2),
+    illinois numeric(14,2),
+    indiana numeric(14,2),
+    iowa numeric(14,2),
+    kansas numeric(14,2),
+    kentucky numeric(14,2),
+    louisiana numeric(14,2),
+    maine numeric(14,2),
+    maryland numeric(14,2),
+    massachusetts numeric(14,2),
+    michigan numeric(14,2),
+    minnesota numeric(14,2),
+    mississippi numeric(14,2),
+    missouri numeric(14,2),
+    montana numeric(14,2),
+    nebraska numeric(14,2),
+    nevada numeric(14,2),
+    new_hampshire numeric(14,2),
+    new_jersey numeric(14,2),
+    new_mexico numeric(14,2),
+    new_york numeric(14,2),
+    north_carolina numeric(14,2),
+    north_dakota numeric(14,2),
+    ohio numeric(14,2),
+    oklahoma numeric(14,2),
+    oregon numeric(14,2),
+    pennsylvania numeric(14,2),
+    rhode_island numeric(14,2),
+    south_carolina numeric(14,2),
+    south_dakota numeric(14,2),
+    tennessee numeric(14,2),
+    texas numeric(14,2),
+    utah numeric(14,2),
+    vermont numeric(14,2),
+    virginia numeric(14,2),
+    washington numeric(14,2),
+    west_virginia numeric(14,2),
+    wisconsin numeric(14,2),
+    wyoming numeric(14,2),
+    puerto_rico numeric(14,2),
+    guam numeric(14,2),
+    virgin_islands numeric(14,2),
+    ttl numeric(14,2),
+    election_dt date,
+    day_after_election_dt date,
+    net_contb numeric(14,2),
+    net_exp numeric(14,2),
+    fed_funds numeric(14,2),
+    indv_contb_other_loans numeric(14,2),
+    pol_pty_cmte_contb_other_loans numeric(14,2),
+    pac_contb_other_loans numeric(14,2),
+    cand_contb_other_loans numeric(14,2),
+    ttl_contb_other_loans numeric(14,2),
+    tranf_from_affiliated_cmte numeric(14,2),
+    loans_received_from_cand numeric(14,2),
+    other_loans_received numeric(14,2),
+    ttl_loans numeric(14,2),
+    op_exp numeric(14,2),
+    fndrsg_exp numeric(14,2),
+    legal_and_acctg_exp numeric(14,2),
+    ttl_offsets_to_op_exp numeric(14,2),
+    other_receipts numeric(14,2),
+    ttl_receipts numeric(14,2),
+    op_exp2 numeric(14,2),
+    tranf_to_other_auth_cmte numeric(14,2),
+    fndrsg_disb numeric(14,2),
+    exempt_legal_and_acctg_disb numeric(14,2),
+    loan_repymts_made_by_cand numeric(14,2),
+    other_repymts numeric(14,2),
+    ttl_loan_repymts_made numeric(14,2),
+    ref_indv_contb numeric(14,2),
+    ref_pol_pty_contb numeric(14,2),
+    ref_other_pol_cmte_contb numeric(14,2),
+    ttl_contb_ref numeric(14,2),
+    other_disb numeric(14,2),
+    ttl_disb numeric(14,2),
+    receipt_dt date,
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_3ps OWNER TO "ec2-user";
+
+--
+-- Name: form_3s; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_3s (
+    form_3s_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    ttl_contb numeric(14,2),
+    ttl_contb_ref numeric(14,2),
+    net_contb numeric(14,2),
+    ttl_op_exp numeric(14,2),
+    ttl_offsets_to_op_exp numeric(14,2),
+    net_op_exp numeric(14,2),
+    indv_item_contb numeric(14,2),
+    indv_unitem_contb numeric(14,2),
+    ttl_indv_contb numeric(14,2),
+    pol_pty_cmte_contb numeric(14,2),
+    other_pol_cmte_contb numeric(14,2),
+    cand_contb numeric(14,2),
+    ttl_contb_column_ttl numeric(14,2),
+    tranf_from_other_auth_cmte numeric(14,2),
+    loans_made_by_cand numeric(14,2),
+    all_other_loans numeric(14,2),
+    ttl_loans numeric(14,2),
+    offsets_to_op_exp numeric(14,2),
+    other_receipts numeric(14,2),
+    ttl_receipts numeric(14,2),
+    op_exp numeric(14,2),
+    tranf_to_other_auth_cmte numeric(14,2),
+    loan_repymts_cand_loans numeric(14,2),
+    loan_repymts_other_loans numeric(14,2),
+    ttl_loan_repymts numeric(14,2),
+    ref_indv_contb numeric(14,2),
+    ref_pol_pty_cmte_contb numeric(14,2),
+    ref_other_pol_cmte_contb numeric(14,2),
+    ttl_contb_ref_col_ttl numeric(14,2),
+    other_disb numeric(14,2),
+    ttl_disb numeric(14,2),
+    election_dt date,
+    day_after_election_dt date,
+    receipt_dt date,
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_3s OWNER TO "ec2-user";
+
+--
+-- Name: form_3x; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_3x (
+    form_3x_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_addr_chg_flg character varying(1),
+    qual_cmte_flg character varying(1),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_dt date,
+    election_st character varying(2),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    coh_bop numeric(14,2),
+    ttl_receipts_sum_page_per numeric(14,2),
+    subttl_sum_page_per numeric(14,2),
+    ttl_disb_sum_page_per numeric(14,2),
+    coh_cop numeric(14,2),
+    debts_owed_to_cmte numeric(14,2),
+    debts_owed_by_cmte numeric(14,2),
+    indv_item_contb_per numeric(14,2),
+    indv_unitem_contb_per numeric(14,2),
+    ttl_indv_contb numeric(14,2),
+    pol_pty_cmte_contb_per_i numeric(14,2),
+    other_pol_cmte_contb_per_i numeric(14,2),
+    ttl_contb_col_ttl_per numeric(14,2),
+    tranf_from_affiliated_pty_per numeric(14,2),
+    all_loans_received_per numeric(14,2),
+    loan_repymts_received_per numeric(14,2),
+    offsets_to_op_exp_per_i numeric(14,2),
+    fed_cand_contb_ref_per numeric(14,2),
+    other_fed_receipts_per numeric(14,2),
+    tranf_from_nonfed_acct_per numeric(14,2),
+    ttl_receipts_per numeric(14,2),
+    ttl_fed_receipts_per numeric(14,2),
+    shared_fed_op_exp_per numeric(14,2),
+    shared_nonfed_op_exp_per numeric(14,2),
+    other_fed_op_exp_per numeric(14,2),
+    ttl_op_exp_per numeric(14,2),
+    tranf_to_affliliated_cmte_per numeric(14,2),
+    fed_cand_cmte_contb_per numeric(14,2),
+    indt_exp_per numeric(14,2),
+    coord_exp_by_pty_cmte_per numeric(14,2),
+    loan_repymts_made_per numeric(14,2),
+    loans_made_per numeric(14,2),
+    indv_contb_ref_per numeric(14,2),
+    pol_pty_cmte_contb_per_ii numeric(14,2),
+    other_pol_cmte_contb_per_ii numeric(14,2),
+    ttl_contb_ref_per_i numeric(14,2),
+    other_disb_per numeric(14,2),
+    ttl_disb_per numeric(14,2),
+    ttl_fed_disb_per numeric(14,2),
+    ttl_contb_per numeric(14,2),
+    ttl_contb_ref_per_ii numeric(14,2),
+    net_contb_per numeric(14,2),
+    ttl_fed_op_exp_per numeric(14,2),
+    offsets_to_op_exp_per_ii numeric(14,2),
+    net_op_exp_per numeric(14,2),
+    coh_begin_calendar_yr numeric(14,2),
+    calendar_yr numeric(4,0),
+    ttl_receipts_sum_page_ytd numeric(14,2),
+    subttl_sum_ytd numeric(14,2),
+    ttl_disb_sum_page_ytd numeric(14,2),
+    coh_coy numeric(14,2),
+    indv_item_contb_ytd numeric(14,2),
+    indv_unitem_contb_ytd numeric(14,2),
+    ttl_indv_contb_ytd numeric(14,2),
+    pol_pty_cmte_contb_ytd_i numeric(14,2),
+    other_pol_cmte_contb_ytd_i numeric(14,2),
+    ttl_contb_col_ttl_ytd numeric(14,2),
+    tranf_from_affiliated_pty_ytd numeric(14,2),
+    all_loans_received_ytd numeric(14,2),
+    loan_repymts_received_ytd numeric(14,2),
+    offsets_to_op_exp_ytd_i numeric(14,2),
+    fed_cand_cmte_contb_ytd numeric(14,2),
+    other_fed_receipts_ytd numeric(14,2),
+    tranf_from_nonfed_acct_ytd numeric(14,2),
+    ttl_receipts_ytd numeric(14,2),
+    ttl_fed_receipts_ytd numeric(14,2),
+    shared_fed_op_exp_ytd numeric(14,2),
+    shared_nonfed_op_exp_ytd numeric(14,2),
+    other_fed_op_exp_ytd numeric(14,2),
+    ttl_op_exp_ytd numeric(14,2),
+    tranf_to_affilitated_cmte_ytd numeric(14,2),
+    fed_cand_cmte_contb_ref_ytd numeric(14,2),
+    indt_exp_ytd numeric(14,2),
+    coord_exp_by_pty_cmte_ytd numeric(14,2),
+    loan_repymts_made_ytd numeric(14,2),
+    loans_made_ytd numeric(14,2),
+    indv_contb_ref_ytd numeric(14,2),
+    pol_pty_cmte_contb_ytd_ii numeric(14,2),
+    other_pol_cmte_contb_ytd_ii numeric(14,2),
+    ttl_contb_ref_ytd_i numeric(14,2),
+    other_disb_ytd numeric(14,2),
+    ttl_disb_ytd numeric(14,2),
+    ttl_fed_disb_ytd numeric(14,2),
+    ttl_contb_ytd numeric(14,2),
+    ttl_contb_ref_ytd_ii numeric(14,2),
+    net_contb_ytd numeric(14,2),
+    ttl_fed_op_exp_ytd numeric(14,2),
+    offsets_to_op_exp_ytd_ii numeric(14,2),
+    net_op_exp_ytd numeric(14,2),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    multicand_flg character varying(1),
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    tranf_from_nonfed_levin_per numeric(14,2),
+    ttl_nonfed_tranf_per numeric(14,2),
+    shared_fed_actvy_fed_shr_per numeric(14,2),
+    shared_fed_actvy_nonfed_per numeric(14,2),
+    non_alloc_fed_elect_actvy_per numeric(14,2),
+    ttl_fed_elect_actvy_per numeric(14,2),
+    tranf_from_nonfed_levin_ytd numeric(14,2),
+    ttl_nonfed_tranf_ytd numeric(14,2),
+    shared_fed_actvy_fed_shr_ytd numeric(14,2),
+    shared_fed_actvy_nonfed_ytd numeric(14,2),
+    non_alloc_fed_elect_actvy_ytd numeric(14,2),
+    ttl_fed_elect_actvy_ytd numeric(14,2),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_3x OWNER TO "ec2-user";
+
+--
+-- Name: form_3z; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_3z (
+    form_3z_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    pcc_id character varying(9),
+    pcc_nm character varying(90),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    auth_cmte_id character varying(9),
+    auth_cmte_nm character varying(90),
+    indv_contb numeric(14,2),
+    pol_pty_contb numeric(14,2),
+    other_pol_cmte_contb numeric(14,2),
+    cand_contb numeric(14,2),
+    ttl_contb numeric(14,2),
+    tranf_from_other_auth_cmte numeric(14,2),
+    loans_made_by_cand numeric(14,2),
+    all_other_loans numeric(14,2),
+    ttl_loans numeric(14,2),
+    offsets_to_op_exp numeric(14,2),
+    other_receipts numeric(14,2),
+    ttl_receipts numeric(14,2),
+    op_exp numeric(14,2),
+    tranf_to_other_auth_cmte numeric(14,2),
+    repymts_loans_made_cand numeric(14,2),
+    repymts_all_other_loans numeric(14,2),
+    ttl_loan_repymts numeric(14,2),
+    ref_indv_contb numeric(14,2),
+    ref_pol_pty_cmte_contb numeric(14,2),
+    ref_other_pol_cmte_contb numeric(14,2),
+    ttl_contb_ref numeric(14,2),
+    other_disb numeric(14,2),
+    ttl_disb numeric(14,2),
+    coh_bop numeric(14,2),
+    coh_cop numeric(14,2),
+    debts_owed_to_cmte numeric(14,2),
+    debts_owed_by_cmte numeric(14,2),
+    net_contb numeric(14,2),
+    net_op_exp numeric(14,2),
+    receipt_dt date,
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_3z OWNER TO "ec2-user";
+
+--
+-- Name: form_4; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_4 (
+    form_4_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_tp character varying(1),
+    cmte_desc character varying(40),
+    rpt_tp character varying(3),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    coh_bop numeric(14,2),
+    ttl_receipts_sum_page_per numeric(14,2),
+    subttl_sum_page_per numeric(14,2),
+    ttl_disb_sum_page_per numeric(14,2),
+    coh_cop numeric(14,2),
+    debts_owed_to_cmte_per numeric(14,2),
+    debts_owed_by_cmte_per numeric(14,2),
+    convn_exp_per numeric(14,2),
+    ref_reb_ret_convn_exp_per numeric(14,2),
+    exp_subject_limits_per numeric(14,2),
+    exp_prior_yrs_subject_lim_per numeric(14,2),
+    ttl_exp_subject_limits numeric(14,2),
+    fed_funds_per numeric(14,2),
+    item_convn_exp_contb_per numeric(14,2),
+    unitem_convn_exp_contb_per numeric(14,2),
+    subttl_convn_exp_contb_per numeric(14,2),
+    tranf_from_affiliated_cmte_per numeric(14,2),
+    loans_received_per numeric(14,2),
+    loan_repymts_received_per numeric(14,2),
+    subttl_loan_repymts_per numeric(14,2),
+    item_ref_reb_ret_per numeric(14,2),
+    unitem_ref_reb_ret_per numeric(14,2),
+    subttl_ref_reb_ret_per numeric(14,2),
+    item_other_ref_reb_ret_per numeric(14,2),
+    unitem_other_ref_reb_ret_per numeric(14,2),
+    subttl_other_ref_reb_ret_per numeric(14,2),
+    item_other_income_per numeric(14,2),
+    unitem_other_income_per numeric(14,2),
+    subttl_other_income_per numeric(14,2),
+    ttl_receipts_per numeric(14,2),
+    item_convn_exp_disb_per numeric(14,2),
+    unitem_convn_exp_disb_per numeric(14,2),
+    subttl_convn_exp_disb_per numeric(14,2),
+    tranf_to_affiliated_cmte_per numeric(14,2),
+    loans_made_per numeric(14,2),
+    loan_repymts_made_per numeric(14,2),
+    subttl_loan_repymts_disb_per numeric(14,2),
+    item_other_disb_per numeric(14,2),
+    unitem_other_disb_per numeric(14,2),
+    subttl_other_disb_per numeric(14,2),
+    ttl_disb_per numeric(14,2),
+    coh_begin_calendar_yr numeric(14,2),
+    calendar_yr numeric(4,0),
+    ttl_receipts_sum_page_ytd numeric(14,2),
+    subttl_sum_page_ytd numeric(14,2),
+    ttl_disb_sum_page_ytd numeric(14,2),
+    coh_coy numeric(14,2),
+    convn_exp_ytd numeric(14,2),
+    ref_reb_ret_convn_exp_ytd numeric(14,2),
+    exp_subject_limits_ytd numeric(14,2),
+    exp_prior_yrs_subject_lim_ytd numeric(14,2),
+    ttl_exp_subject_limits_ytd numeric(14,2),
+    fed_funds_ytd numeric(14,2),
+    subttl_convn_exp_contb_ytd numeric(14,2),
+    tranf_from_affiliated_cmte_ytd numeric(14,2),
+    subttl_loan_repymts_ytd numeric(14,2),
+    subttl_ref_reb_ret_deposit_ytd numeric(14,2),
+    subttl_other_ref_reb_ret_ytd numeric(14,2),
+    subttl_other_income_ytd numeric(14,2),
+    ttl_receipts_ytd numeric(14,2),
+    subttl_convn_exp_disb_ytd numeric(14,2),
+    tranf_to_affiliated_cmte_ytd numeric(14,2),
+    subttl_loan_repymts_disb_ytd numeric(14,2),
+    subttl_other_disb_ytd numeric(14,2),
+    ttl_disb_ytd numeric(14,2),
+    tres_sign_nm character varying(38),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(11),
+    end_image_num character varying(11),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_4 OWNER TO "ec2-user";
+
+--
+-- Name: form_5; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_5 (
+    form_5_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    indv_org_id character varying(9),
+    indv_org_nm character varying(90),
+    indv_org_st1 character varying(34),
+    indv_org_st2 character varying(34),
+    indv_org_city character varying(18),
+    indv_org_st character varying(2),
+    indv_org_zip character varying(9),
+    addr_chg_flg character varying(1),
+    qual_nonprofit_corp_ind character varying(1),
+    indv_org_employer character varying(38),
+    indv_org_occupation character varying(38),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_tp character varying(2),
+    election_dt date,
+    election_st character varying(2),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    ttl_indt_contb numeric(14,2),
+    ttl_indt_exp numeric(14,2),
+    filer_nm character varying(38),
+    filer_sign_nm character varying(38),
+    filer_sign_dt date,
+    notary_sign_dt date,
+    notary_commission_exprtn_dt date,
+    notary_nm character varying(38),
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    entity_tp character varying(3),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_5 OWNER TO "ec2-user";
+
+--
+-- Name: form_6; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_6 (
+    form_6_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    filer_cmte_nm character varying(200),
+    filer_cmte_st1 character varying(34),
+    filer_cmte_st2 character varying(34),
+    filer_cmte_city character varying(30),
+    filer_cmte_st character varying(2),
+    filer_cmte_zip character varying(9),
+    cand_id character varying(9),
+    cand_nm character varying(90),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    signer_last_name character varying(30),
+    signer_first_name character varying(20),
+    signer_middle_name character varying(20),
+    signer_prefix character varying(10),
+    signer_suffix character varying(10),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_6 OWNER TO "ec2-user";
+
+--
+-- Name: form_7; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_7 (
+    form_7_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    org_id character varying(9),
+    org_nm character varying(90),
+    org_st1 character varying(34),
+    org_st2 character varying(34),
+    org_city character varying(18),
+    org_st character varying(2),
+    org_zip character varying(9),
+    org_tp character varying(1),
+    rpt_tp character varying(3),
+    election_dt date,
+    election_st character varying(2),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    ttl_communication_cost numeric(14,2),
+    filer_sign_nm character varying(38),
+    filer_sign_dt date,
+    filer_title character varying(20),
+    receipt_dt date,
+    rpt_pgi character varying(1),
+    amndt_ind character varying(1),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_7 OWNER TO "ec2-user";
+
+--
+-- Name: form_8; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_8 (
+    form_8_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    coh numeric(14,2),
+    calender_yr date,
+    ttl_liquidated_assets numeric(14,2),
+    ttl_assets numeric(14,2),
+    ytd_reciepts numeric(14,2),
+    ytd_disb numeric(14,2),
+    ttl_amt_debts_owed numeric(14,2),
+    ttl_num_cred_owed numeric(8,0),
+    ttl_num_cred_part2 numeric(8,0),
+    ttl_amt_debts_owed_part2 numeric(14,2),
+    ttl_amt_paid_cred numeric(14,2),
+    term_flg character varying(1),
+    term_dt_desc character varying(15),
+    addl_auth_cmte_flg character varying(1),
+    add_auth_cmte_desc character varying(300),
+    sufficient_amt_to_pay_ttl_flg character varying(1),
+    sufficient_amt_to_pay_desc character varying(100),
+    prev_debt_settlement_plan_flg character varying(1),
+    residual_funds_flg character varying(1),
+    residual_funds_desc character varying(100),
+    remaining_amt_flg character varying(1),
+    remaining_amt_desc character varying(100),
+    tres_sign_nm character varying(38),
+    tres_sign_dt date,
+    receipt_dt date,
+    amndt_ind character varying(1),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_8 OWNER TO "ec2-user";
+
+--
+-- Name: form_9; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_9 (
+    form_9_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    ind_org_corp_nm character varying(90),
+    ind_org_corp_st1 character varying(34),
+    ind_org_corp_st2 character varying(34),
+    ind_org_corp_city character varying(18),
+    ind_org_corp_st character varying(2),
+    ind_org_corp_zip character varying(9),
+    addr_chg_flg character varying(1),
+    ind_org_corp_emp character varying(38),
+    ind_org_corp_occup character varying(38),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    pub_distrib_dt date,
+    qual_nonprofit_flg character varying(18),
+    segr_bank_acct_flg character varying(1),
+    ind_custod_nm character varying(38),
+    ind_custod_st1 character varying(34),
+    ind_custod_st2 character varying(34),
+    ind_custod_city character varying(18),
+    ind_custod_st character varying(2),
+    ind_custod_zip character varying(9),
+    ind_custod_emp character varying(38),
+    ind_custod_occup character varying(38),
+    ttl_dons_this_stmt numeric(14,2),
+    ttl_disb_this_stmt numeric(14,2),
+    filer_sign_nm character varying(38),
+    filer_sign_dt date,
+    begin_image_num character varying(11),
+    end_image_num character varying(11),
+    last_update_dt date,
+    amndt_ind character varying(1),
+    receipt_dt date,
+    rpt_tp character varying(3),
+    comm_title character varying(40),
+    rpt_yr numeric(4,0),
+    entity_tp character varying(3),
+    filer_cd character varying(3),
+    filer_cd_desc character varying(20),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_9 OWNER TO "ec2-user";
+
+--
+-- Name: form_99_misc; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE form_99_misc (
+    form_99_misc_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    text_field character varying(4000),
+    to_from_ind character varying(1),
+    receipt_dt date,
+    text_cd character varying(3),
+    text_cd_desc character varying(40),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+);
+
+
+ALTER TABLE processed_newdownload.form_99_misc OWNER TO "ec2-user";
+
+--
+-- Name: log_audit_dml; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE log_audit_dml (
+    dml_id numeric(8,0) NOT NULL,
+    run_id numeric(8,0),
+    audit_id numeric(8,0),
+    dml_type character varying(12) NOT NULL,
+    target_table character varying(32) NOT NULL,
+    start_time timestamp without time zone NOT NULL,
+    row_count numeric(10,0),
+    dml_desc character varying(100),
+    cpu_minutes numeric(8,4),
+    elapsed_minutes numeric(8,4),
+    start_cpu_time numeric NOT NULL,
+    start_clock_time numeric NOT NULL
+);
+
+
+ALTER TABLE processed_newdownload.log_audit_dml OWNER TO "ec2-user";
+
+--
+-- Name: log_audit_module; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE log_audit_module (
+    audit_id numeric(8,0) NOT NULL,
+    run_id numeric(8,0),
+    module_name character varying(65) NOT NULL,
+    start_time timestamp without time zone NOT NULL,
+    input_parameters character varying(500),
+    error_message character varying(4000),
+    cpu_minutes numeric(8,4),
+    elapsed_minutes numeric(8,4),
+    start_cpu_time numeric NOT NULL,
+    start_clock_time numeric NOT NULL
+);
+
+
+ALTER TABLE processed_newdownload.log_audit_module OWNER TO "ec2-user";
+
+--
+-- Name: log_audit_process; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE log_audit_process (
+    run_id numeric(8,0) NOT NULL,
+    session_id numeric(22,0) NOT NULL,
+    process_name character varying(30),
+    interface_name character varying(6) NOT NULL,
+    module_name character varying(65) NOT NULL,
+    start_time timestamp without time zone NOT NULL,
+    input_parameters character varying(500),
+    messages character varying(4000),
+    cpu_minutes numeric(8,4),
+    elapsed_minutes numeric(8,4),
+    start_cpu_time numeric NOT NULL,
+    start_clock_time numeric NOT NULL
+);
+
+
+ALTER TABLE processed_newdownload.log_audit_process OWNER TO "ec2-user";
+
+--
+-- Name: log_dml_errors; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE log_dml_errors (
+    "ora_err_number$" numeric,
+    "ora_err_mesg$" character varying(2000),
+    "ora_err_rowid$" character varying,
+    "ora_err_optyp$" character varying(2),
+    "ora_err_tag$" character varying(100),
+    seq_no numeric(10,0),
+    form_tp character varying(100),
+    file_num character varying(100),
+    receipt_dt character varying(100),
+    begin_image_num character varying(100),
+    end_image_num character varying(100),
+    image_num character varying(100),
+    cmte_id character varying(100),
+    auth_cmte_id character varying(100),
+    pcc_cmte_id character varying(100),
+    pcc_id character varying(100),
+    cand_id character varying(100),
+    sub_id character varying(100),
+    load_date date
+);
+
+
+ALTER TABLE processed_newdownload.log_dml_errors OWNER TO "ec2-user";
+
+--
+-- Name: ref_cand_ici; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE ref_cand_ici (
+    cand_ici_cd character(1) NOT NULL,
+    cand_ici_desc character varying(100),
+    incumbent_flg character(1),
+    open_flg character(1)
+);
+
+
+ALTER TABLE processed_newdownload.ref_cand_ici OWNER TO "ec2-user";
+
+--
+-- Name: ref_cand_status; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE ref_cand_status (
+    cand_status_cd character(1) NOT NULL,
+    cand_status_desc character varying(100)
+);
+
+
+ALTER TABLE processed_newdownload.ref_cand_status OWNER TO "ec2-user";
+
+--
+-- Name: ref_cmte_dsgn; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE ref_cmte_dsgn (
+    cmte_dsgn character(1) NOT NULL,
+    cmte_dsgn_desc character varying(90)
+);
+
+
+ALTER TABLE processed_newdownload.ref_cmte_dsgn OWNER TO "ec2-user";
+
+--
+-- Name: ref_cmte_type; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE ref_cmte_type (
+    cmte_tp character(1) NOT NULL,
+    cmte_tp_desc character varying(90),
+    explanation character varying(1000)
+);
+
+
+ALTER TABLE processed_newdownload.ref_cmte_type OWNER TO "ec2-user";
+
+--
+-- Name: ref_election; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE ref_election (
+    election_tp character(1) NOT NULL,
+    election_tp_desc character varying(100)
+);
+
+
+ALTER TABLE processed_newdownload.ref_election OWNER TO "ec2-user";
+
+--
+-- Name: ref_entity_type; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE ref_entity_type (
+    entity_tp character varying(3) NOT NULL,
+    entity_tp_desc character varying(100)
+);
+
+
+ALTER TABLE processed_newdownload.ref_entity_type OWNER TO "ec2-user";
+
+--
+-- Name: ref_form_type; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE ref_form_type (
+    form_tp character varying(15) NOT NULL,
+    form_tp_desc character varying(100),
+    form_nm character varying(1000),
+    obsolete_flg character(1) DEFAULT 'N'::bpchar,
+    obsolete_date date
+);
+
+
+ALTER TABLE processed_newdownload.ref_form_type OWNER TO "ec2-user";
+
+--
+-- Name: ref_office; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE ref_office (
+    office_tp character(1) NOT NULL,
+    office_tp_desc character varying(100)
+);
+
+
+ALTER TABLE processed_newdownload.ref_office OWNER TO "ec2-user";
+
+--
+-- Name: ref_org_type; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE ref_org_type (
+    org_tp character(1) NOT NULL,
+    org_tp_desc character varying(90)
+);
+
+
+ALTER TABLE processed_newdownload.ref_org_type OWNER TO "ec2-user";
+
+--
+-- Name: ref_party; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE ref_party (
+    party_cd character varying(3) NOT NULL,
+    party_desc character varying(100)
+);
+
+
+ALTER TABLE processed_newdownload.ref_party OWNER TO "ec2-user";
+
+--
+-- Name: ref_report_type; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE ref_report_type (
+    rpt_tp character varying(3) NOT NULL,
+    rpt_tp_desc character varying(100)
+);
+
+
+ALTER TABLE processed_newdownload.ref_report_type OWNER TO "ec2-user";
+
+--
+-- Name: ref_state; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE ref_state (
+    state_cd character varying(2) NOT NULL,
+    state_nm character varying(90)
+);
+
+
+ALTER TABLE processed_newdownload.ref_state OWNER TO "ec2-user";
+
+--
+-- Name: ref_transaction_code; Type: TABLE; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE TABLE ref_transaction_code (
+    transaction_cd character varying(3) NOT NULL,
+    transaction_desc character varying(100)
+);
+
+
+ALTER TABLE processed_newdownload.ref_transaction_code OWNER TO "ec2-user";
+
+--
+-- Name: cand_ici_cd_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY ref_cand_ici
+    ADD CONSTRAINT cand_ici_cd_sk PRIMARY KEY (cand_ici_cd);
+
+
+--
+-- Name: cand_status_cd_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY ref_cand_status
+    ADD CONSTRAINT cand_status_cd_sk PRIMARY KEY (cand_status_cd);
+
+
+--
+-- Name: cand_status_ici_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY cand_status_ici
+    ADD CONSTRAINT cand_status_ici_sk PRIMARY KEY (cand_status_ici_sk);
+
+
+--
+-- Name: cmte_dsgn_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY ref_cmte_dsgn
+    ADD CONSTRAINT cmte_dsgn_sk PRIMARY KEY (cmte_dsgn);
+
+
+--
+-- Name: cmte_tp_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY ref_cmte_type
+    ADD CONSTRAINT cmte_tp_sk PRIMARY KEY (cmte_tp);
+
+
+--
+-- Name: election_tp_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY ref_election
+    ADD CONSTRAINT election_tp_sk PRIMARY KEY (election_tp);
+
+
+--
+-- Name: entity_tp_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY ref_entity_type
+    ADD CONSTRAINT entity_tp_sk PRIMARY KEY (entity_tp);
+
+
+--
+-- Name: form_10_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_10
+    ADD CONSTRAINT form_10_sk PRIMARY KEY (form_10_sk);
+
+
+--
+-- Name: form_11_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_11
+    ADD CONSTRAINT form_11_sk PRIMARY KEY (form_11_sk);
+
+
+--
+-- Name: form_12_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_12
+    ADD CONSTRAINT form_12_sk PRIMARY KEY (form_12_sk);
+
+
+--
+-- Name: form_13_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_13
+    ADD CONSTRAINT form_13_sk PRIMARY KEY (form_13_sk);
+
+
+--
+-- Name: form_1_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_1
+    ADD CONSTRAINT form_1_sk PRIMARY KEY (form_1_sk);
+
+
+--
+-- Name: form_1m_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_1m
+    ADD CONSTRAINT form_1m_sk PRIMARY KEY (form_1m_sk);
+
+
+--
+-- Name: form_1s_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_1s
+    ADD CONSTRAINT form_1s_sk PRIMARY KEY (form_1s_sk);
+
+
+--
+-- Name: form_24_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_24
+    ADD CONSTRAINT form_24_sk PRIMARY KEY (form_24_sk);
+
+
+--
+-- Name: form_2_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_2
+    ADD CONSTRAINT form_2_sk PRIMARY KEY (form_2_sk);
+
+
+--
+-- Name: form_2s_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_2s
+    ADD CONSTRAINT form_2s_sk PRIMARY KEY (form_2s_sk);
+
+
+--
+-- Name: form_3_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_3
+    ADD CONSTRAINT form_3_sk PRIMARY KEY (form_3_sk);
+
+
+--
+-- Name: form_3l_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_3l
+    ADD CONSTRAINT form_3l_sk PRIMARY KEY (form_3l_sk);
+
+
+--
+-- Name: form_3p31s_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_3p_line_31s
+    ADD CONSTRAINT form_3p31s_sk PRIMARY KEY (form_3p31s_sk);
+
+
+--
+-- Name: form_3p_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_3p
+    ADD CONSTRAINT form_3p_sk PRIMARY KEY (form_3p_sk);
+
+
+--
+-- Name: form_3ps_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_3ps
+    ADD CONSTRAINT form_3ps_sk PRIMARY KEY (form_3ps_sk);
+
+
+--
+-- Name: form_3s_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_3s
+    ADD CONSTRAINT form_3s_sk PRIMARY KEY (form_3s_sk);
+
+
+--
+-- Name: form_3x_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_3x
+    ADD CONSTRAINT form_3x_sk PRIMARY KEY (form_3x_sk);
+
+
+--
+-- Name: form_3z_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_3z
+    ADD CONSTRAINT form_3z_sk PRIMARY KEY (form_3z_sk);
+
+
+--
+-- Name: form_4_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_4
+    ADD CONSTRAINT form_4_sk PRIMARY KEY (form_4_sk);
+
+
+--
+-- Name: form_5_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_5
+    ADD CONSTRAINT form_5_sk PRIMARY KEY (form_5_sk);
+
+
+--
+-- Name: form_6_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_6
+    ADD CONSTRAINT form_6_sk PRIMARY KEY (form_6_sk);
+
+
+--
+-- Name: form_7_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_7
+    ADD CONSTRAINT form_7_sk PRIMARY KEY (form_7_sk);
+
+
+--
+-- Name: form_8_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_8
+    ADD CONSTRAINT form_8_sk PRIMARY KEY (form_8_sk);
+
+
+--
+-- Name: form_99_misc_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_99_misc
+    ADD CONSTRAINT form_99_misc_sk PRIMARY KEY (form_99_misc_sk);
+
+
+--
+-- Name: form_9_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY form_9
+    ADD CONSTRAINT form_9_sk PRIMARY KEY (form_9_sk);
+
+
+--
+-- Name: form_tp_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY ref_form_type
+    ADD CONSTRAINT form_tp_sk PRIMARY KEY (form_tp);
+
+
+--
+-- Name: office_tp_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY ref_office
+    ADD CONSTRAINT office_tp_sk PRIMARY KEY (office_tp);
+
+
+--
+-- Name: org_tp_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY ref_org_type
+    ADD CONSTRAINT org_tp_sk PRIMARY KEY (org_tp);
+
+
+--
+-- Name: party_cd_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY ref_party
+    ADD CONSTRAINT party_cd_sk PRIMARY KEY (party_cd);
+
+
+--
+-- Name: rpt_tp_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY ref_report_type
+    ADD CONSTRAINT rpt_tp_sk PRIMARY KEY (rpt_tp);
+
+
+--
+-- Name: state_cd_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY ref_state
+    ADD CONSTRAINT state_cd_sk PRIMARY KEY (state_cd);
+
+
+--
+-- Name: transaction_cd_sk; Type: CONSTRAINT; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+ALTER TABLE ONLY ref_transaction_code
+    ADD CONSTRAINT transaction_cd_sk PRIMARY KEY (transaction_cd);
+
+
+--
+-- Name: cndici_candid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX cndici_candid_idx ON cand_status_ici USING btree (cand_id);
+
+
+--
+-- Name: cndici_elyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX cndici_elyr_idx ON cand_status_ici USING btree (election_yr);
+
+
+--
+-- Name: cndici_etldt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX cndici_etldt_idx ON cand_status_ici USING btree (etl_complete_date);
+
+
+--
+-- Name: cndici_icicd_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX cndici_icicd_idx ON cand_status_ici USING btree (ici_code);
+
+
+--
+-- Name: cndici_inactv_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX cndici_inactv_idx ON cand_status_ici USING btree (cand_inactive_flg);
+
+
+--
+-- Name: cndici_status_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX cndici_status_idx ON cand_status_ici USING btree (cand_status);
+
+
+--
+-- Name: f10_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f10_cmteid_idx ON form_10 USING btree (filer_cmte_id);
+
+
+--
+-- Name: f10_etldt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f10_etldt_idx ON form_10 USING btree (etl_complete_date);
+
+
+--
+-- Name: f10_rcpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f10_rcpdt_idx ON form_10 USING btree (receipt_dt);
+
+
+--
+-- Name: f10_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f10_subid_idx ON form_10 USING btree (sub_id);
+
+
+--
+-- Name: f11_canid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f11_canid_idx ON form_11 USING btree (cand_id);
+
+
+--
+-- Name: f11_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f11_etlcmpdt_idx ON form_11 USING btree (etl_complete_date);
+
+
+--
+-- Name: f11_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f11_rptyr_idx ON form_11 USING btree (rpt_yr);
+
+
+--
+-- Name: f11_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f11_subid_idx ON form_11 USING btree (sub_id);
+
+
+--
+-- Name: f12_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f12_cmteid_idx ON form_12 USING btree (filer_cmte_id);
+
+
+--
+-- Name: f12_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f12_etlcmpdt_idx ON form_12 USING btree (etl_complete_date);
+
+
+--
+-- Name: f12_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f12_rptyr_idx ON form_12 USING btree (rpt_yr);
+
+
+--
+-- Name: f12_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f12_subid_idx ON form_12 USING btree (sub_id);
+
+
+--
+-- Name: f13_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f13_cmteid_idx ON form_13 USING btree (cmte_id);
+
+
+--
+-- Name: f13_cvgenddt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f13_cvgenddt_idx ON form_13 USING btree (cvg_end_dt);
+
+
+--
+-- Name: f13_cvgstdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f13_cvgstdt_idx ON form_13 USING btree (cvg_start_dt);
+
+
+--
+-- Name: f13_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f13_etlcmpdt_idx ON form_13 USING btree (etl_complete_date);
+
+
+--
+-- Name: f13_mrf_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f13_mrf_idx ON form_13 USING btree (mrf_rec);
+
+
+--
+-- Name: f13_rpttp_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f13_rpttp_idx ON form_13 USING btree (rpt_tp);
+
+
+--
+-- Name: f13_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f13_rptyr_idx ON form_13 USING btree (rpt_yr);
+
+
+--
+-- Name: f13_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f13_subid_idx ON form_13 USING btree (sub_id);
+
+
+--
+-- Name: f24_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f24_cmteid_idx ON form_24 USING btree (cmte_id);
+
+
+--
+-- Name: f24_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f24_etlcmpdt_idx ON form_24 USING btree (etl_complete_date);
+
+
+--
+-- Name: f24_rpttp_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f24_rpttp_idx ON form_24 USING btree (rpt_tp);
+
+
+--
+-- Name: f24_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f24_rptyr_idx ON form_24 USING btree (rpt_yr);
+
+
+--
+-- Name: f24_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f24_subid_idx ON form_24 USING btree (sub_id);
+
+
+--
+-- Name: f3_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3_cmteid_idx ON form_3 USING btree (cmte_id);
+
+
+--
+-- Name: f3_cvgenddt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3_cvgenddt_idx ON form_3 USING btree (cvg_end_dt);
+
+
+--
+-- Name: f3_cvgstdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3_cvgstdt_idx ON form_3 USING btree (cvg_start_dt);
+
+
+--
+-- Name: f3_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3_etlcmpdt_idx ON form_3 USING btree (etl_complete_date);
+
+
+--
+-- Name: f3_mrf_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3_mrf_idx ON form_3 USING btree (mrf_rec);
+
+
+--
+-- Name: f3_rpttp_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3_rpttp_idx ON form_3 USING btree (rpt_tp);
+
+
+--
+-- Name: f3_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3_rptyr_idx ON form_3 USING btree (rpt_yr);
+
+
+--
+-- Name: f3_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3_subid_idx ON form_3 USING btree (sub_id);
+
+
+--
+-- Name: f3_typ_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3_typ_idx ON form_3 USING btree (two_yr_period);
+
+
+--
+-- Name: f3l_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3l_cmteid_idx ON form_3l USING btree (cmte_id);
+
+
+--
+-- Name: f3l_cvgenddt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3l_cvgenddt_idx ON form_3l USING btree (cvg_end_dt);
+
+
+--
+-- Name: f3l_cvgstdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3l_cvgstdt_idx ON form_3l USING btree (cvg_start_dt);
+
+
+--
+-- Name: f3l_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3l_etlcmpdt_idx ON form_3l USING btree (etl_complete_date);
+
+
+--
+-- Name: f3l_mrf_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3l_mrf_idx ON form_3l USING btree (mrf_rec);
+
+
+--
+-- Name: f3l_rpttp_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3l_rpttp_idx ON form_3l USING btree (rpt_tp);
+
+
+--
+-- Name: f3l_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3l_rptyr_idx ON form_3l USING btree (rpt_yr);
+
+
+--
+-- Name: f3l_typ_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3l_typ_idx ON form_3l USING btree (two_yr_period);
+
+
+--
+-- Name: f3p3l_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3p3l_cmteid_idx ON form_3p_line_31s USING btree (filer_cmte_id);
+
+
+--
+-- Name: f3p3l_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3p3l_etlcmpdt_idx ON form_3p_line_31s USING btree (etl_complete_date);
+
+
+--
+-- Name: f3p3l_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3p3l_subid_idx ON form_3p_line_31s USING btree (sub_id);
+
+
+--
+-- Name: f3p_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3p_cmteid_idx ON form_3p USING btree (cmte_id);
+
+
+--
+-- Name: f3p_cvgenddt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3p_cvgenddt_idx ON form_3p USING btree (cvg_end_dt);
+
+
+--
+-- Name: f3p_cvgstdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3p_cvgstdt_idx ON form_3p USING btree (cvg_start_dt);
+
+
+--
+-- Name: f3p_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3p_etlcmpdt_idx ON form_3p USING btree (etl_complete_date);
+
+
+--
+-- Name: f3p_mrf_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3p_mrf_idx ON form_3p USING btree (mrf_rec);
+
+
+--
+-- Name: f3p_rpttp_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3p_rpttp_idx ON form_3p USING btree (rpt_tp);
+
+
+--
+-- Name: f3p_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3p_rptyr_idx ON form_3p USING btree (rpt_yr);
+
+
+--
+-- Name: f3p_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3p_subid_idx ON form_3p USING btree (sub_id);
+
+
+--
+-- Name: f3p_typ_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3p_typ_idx ON form_3p USING btree (two_yr_period);
+
+
+--
+-- Name: f3ps_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3ps_cmteid_idx ON form_3ps USING btree (cmte_id);
+
+
+--
+-- Name: f3ps_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3ps_etlcmpdt_idx ON form_3ps USING btree (etl_complete_date);
+
+
+--
+-- Name: f3ps_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3ps_subid_idx ON form_3ps USING btree (sub_id);
+
+
+--
+-- Name: f3s_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3s_cmteid_idx ON form_3s USING btree (cmte_id);
+
+
+--
+-- Name: f3s_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3s_etlcmpdt_idx ON form_3s USING btree (etl_complete_date);
+
+
+--
+-- Name: f3s_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3s_subid_idx ON form_3s USING btree (sub_id);
+
+
+--
+-- Name: f3x_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3x_cmteid_idx ON form_3x USING btree (cmte_id);
+
+
+--
+-- Name: f3x_cvgenddt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3x_cvgenddt_idx ON form_3x USING btree (cvg_end_dt);
+
+
+--
+-- Name: f3x_cvgstdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3x_cvgstdt_idx ON form_3x USING btree (cvg_start_dt);
+
+
+--
+-- Name: f3x_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3x_etlcmpdt_idx ON form_3x USING btree (etl_complete_date);
+
+
+--
+-- Name: f3x_mrf_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3x_mrf_idx ON form_3x USING btree (mrf_rec);
+
+
+--
+-- Name: f3x_rpttp_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3x_rpttp_idx ON form_3x USING btree (rpt_tp);
+
+
+--
+-- Name: f3x_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3x_rptyr_idx ON form_3x USING btree (rpt_yr);
+
+
+--
+-- Name: f3x_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3x_subid_idx ON form_3x USING btree (sub_id);
+
+
+--
+-- Name: f3x_typ_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3x_typ_idx ON form_3x USING btree (two_yr_period);
+
+
+--
+-- Name: f3z_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3z_etlcmpdt_idx ON form_3z USING btree (etl_complete_date);
+
+
+--
+-- Name: f3z_pccid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3z_pccid_idx ON form_3z USING btree (pcc_id);
+
+
+--
+-- Name: f3z_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f3z_subid_idx ON form_3z USING btree (sub_id);
+
+
+--
+-- Name: f4_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f4_cmteid_idx ON form_4 USING btree (cmte_id);
+
+
+--
+-- Name: f4_cvgenddt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f4_cvgenddt_idx ON form_4 USING btree (cvg_end_dt);
+
+
+--
+-- Name: f4_cvgstdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f4_cvgstdt_idx ON form_4 USING btree (cvg_start_dt);
+
+
+--
+-- Name: f4_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f4_etlcmpdt_idx ON form_4 USING btree (etl_complete_date);
+
+
+--
+-- Name: f4_mrf_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f4_mrf_idx ON form_4 USING btree (mrf_rec);
+
+
+--
+-- Name: f4_rpttp_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f4_rpttp_idx ON form_4 USING btree (rpt_tp);
+
+
+--
+-- Name: f4_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f4_rptyr_idx ON form_4 USING btree (rpt_yr);
+
+
+--
+-- Name: f4_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f4_subid_idx ON form_4 USING btree (sub_id);
+
+
+--
+-- Name: f4_typ_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f4_typ_idx ON form_4 USING btree (two_yr_period);
+
+
+--
+-- Name: f5_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f5_etlcmpdt_idx ON form_5 USING btree (etl_complete_date);
+
+
+--
+-- Name: f5_indorgid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f5_indorgid_idx ON form_5 USING btree (indv_org_id);
+
+
+--
+-- Name: f5_rpttp_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f5_rpttp_idx ON form_5 USING btree (rpt_tp);
+
+
+--
+-- Name: f5_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f5_rptyr_idx ON form_5 USING btree (rpt_yr);
+
+
+--
+-- Name: f5_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f5_subid_idx ON form_5 USING btree (sub_id);
+
+
+--
+-- Name: f6_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f6_etlcmpdt_idx ON form_6 USING btree (etl_complete_date);
+
+
+--
+-- Name: f6_fcmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f6_fcmteid_idx ON form_6 USING btree (filer_cmte_id);
+
+
+--
+-- Name: f6_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f6_rptyr_idx ON form_6 USING btree (rpt_yr);
+
+
+--
+-- Name: f6_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f6_subid_idx ON form_6 USING btree (sub_id);
+
+
+--
+-- Name: f7_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f7_etlcmpdt_idx ON form_7 USING btree (etl_complete_date);
+
+
+--
+-- Name: f7_orgid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f7_orgid_idx ON form_7 USING btree (org_id);
+
+
+--
+-- Name: f7_rpttp_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f7_rpttp_idx ON form_7 USING btree (rpt_tp);
+
+
+--
+-- Name: f7_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f7_rptyr_idx ON form_7 USING btree (rpt_yr);
+
+
+--
+-- Name: f7_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f7_subid_idx ON form_7 USING btree (sub_id);
+
+
+--
+-- Name: f8_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f8_cmteid_idx ON form_8 USING btree (cmte_id);
+
+
+--
+-- Name: f8_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f8_etlcmpdt_idx ON form_8 USING btree (etl_complete_date);
+
+
+--
+-- Name: f8_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f8_rptyr_idx ON form_8 USING btree (rpt_yr);
+
+
+--
+-- Name: f8_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f8_subid_idx ON form_8 USING btree (sub_id);
+
+
+--
+-- Name: f99_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f99_cmteid_idx ON form_99_misc USING btree (cmte_id);
+
+
+--
+-- Name: f99_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f99_etlcmpdt_idx ON form_99_misc USING btree (etl_complete_date);
+
+
+--
+-- Name: f99_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f99_rptyr_idx ON form_99_misc USING btree (rpt_yr);
+
+
+--
+-- Name: f99_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f99_subid_idx ON form_99_misc USING btree (sub_id);
+
+
+--
+-- Name: f9_cmteid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f9_cmteid_idx ON form_9 USING btree (cmte_id);
+
+
+--
+-- Name: f9_cvgenddt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f9_cvgenddt_idx ON form_9 USING btree (cvg_end_dt);
+
+
+--
+-- Name: f9_cvgstdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f9_cvgstdt_idx ON form_9 USING btree (cvg_start_dt);
+
+
+--
+-- Name: f9_etlcmpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f9_etlcmpdt_idx ON form_9 USING btree (etl_complete_date);
+
+
+--
+-- Name: f9_mrf_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f9_mrf_idx ON form_9 USING btree (mrf_rec);
+
+
+--
+-- Name: f9_rpttp_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f9_rpttp_idx ON form_9 USING btree (rpt_tp);
+
+
+--
+-- Name: f9_rptyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f9_rptyr_idx ON form_9 USING btree (rpt_yr);
+
+
+--
+-- Name: f9_subid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX f9_subid_idx ON form_9 USING btree (sub_id);
+
+
+--
+-- Name: form_1_u01; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE UNIQUE INDEX form_1_u01 ON form_1 USING btree (sub_id);
+
+
+--
+-- Name: form_1m_u01; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE UNIQUE INDEX form_1m_u01 ON form_1m USING btree (sub_id);
+
+
+--
+-- Name: form_1s_u01; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE UNIQUE INDEX form_1s_u01 ON form_1s USING btree (sub_id);
+
+
+--
+-- Name: form_2_u01; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE UNIQUE INDEX form_2_u01 ON form_2 USING btree (sub_id);
+
+
+--
+-- Name: form_2s_u01; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE UNIQUE INDEX form_2s_u01 ON form_2s USING btree (sub_id);
+
+
+--
+-- Name: form_3l_u01; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE UNIQUE INDEX form_3l_u01 ON form_3l USING btree (sub_id);
+
+
+--
+-- Name: frm1_cmdgn_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm1_cmdgn_idx ON form_1 USING btree (cmte_dsgn);
+
+
+--
+-- Name: frm1_cmid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm1_cmid_idx ON form_1 USING btree (cmte_id);
+
+
+--
+-- Name: frm1_cmst_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm1_cmst_idx ON form_1 USING btree (cmte_st);
+
+
+--
+-- Name: frm1_cmtp_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm1_cmtp_idx ON form_1 USING btree (cmte_tp);
+
+
+--
+-- Name: frm1_etldt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm1_etldt_idx ON form_1 USING btree (etl_complete_date);
+
+
+--
+-- Name: frm1_rcpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm1_rcpdt_idx ON form_1 USING btree (receipt_dt);
+
+
+--
+-- Name: frm1m_cmid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm1m_cmid_idx ON form_1m USING btree (cmte_id);
+
+
+--
+-- Name: frm1m_cmst_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm1m_cmst_idx ON form_1m USING btree (cmte_st);
+
+
+--
+-- Name: frm1m_cmtp_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm1m_cmtp_idx ON form_1m USING btree (cmte_tp);
+
+
+--
+-- Name: frm1m_etldt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm1m_etldt_idx ON form_1m USING btree (etl_complete_date);
+
+
+--
+-- Name: frm1m_rcpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm1m_rcpdt_idx ON form_1m USING btree (receipt_dt);
+
+
+--
+-- Name: frm1s_cmid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm1s_cmid_idx ON form_1s USING btree (cmte_id);
+
+
+--
+-- Name: frm1s_etldt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm1s_etldt_idx ON form_1s USING btree (etl_complete_date);
+
+
+--
+-- Name: frm1s_rcpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm1s_rcpdt_idx ON form_1s USING btree (receipt_dt);
+
+
+--
+-- Name: frm2_cndist_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm2_cndist_idx ON form_2 USING btree (cand_office_district);
+
+
+--
+-- Name: frm2_cnid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm2_cnid_idx ON form_2 USING btree (cand_id);
+
+
+--
+-- Name: frm2_cnofc_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm2_cnofc_idx ON form_2 USING btree (cand_office);
+
+
+--
+-- Name: frm2_cnofcst_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm2_cnofcst_idx ON form_2 USING btree (cand_office_st);
+
+
+--
+-- Name: frm2_elyr_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm2_elyr_idx ON form_2 USING btree (election_yr);
+
+
+--
+-- Name: frm2_etldt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm2_etldt_idx ON form_2 USING btree (etl_complete_date);
+
+
+--
+-- Name: frm2_rcpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm2_rcpdt_idx ON form_2 USING btree (receipt_dt);
+
+
+--
+-- Name: frm2s_cnid_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm2s_cnid_idx ON form_2s USING btree (cand_id);
+
+
+--
+-- Name: frm2s_etldt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm2s_etldt_idx ON form_2s USING btree (etl_complete_date);
+
+
+--
+-- Name: frm2s_rcpdt_idx; Type: INDEX; Schema: processed_newdownload; Owner: ec2-user; Tablespace:
+--
+
+CREATE INDEX frm2s_rcpdt_idx ON form_2s USING btree (receipt_dt);
+
+
+--
+-- PostgreSQL database dump complete
+--
+grant all privileges on schema processed_newdownload to openfec;
+grant usage on schema processed_newdownload to webro;
+grant all privileges on all tables in schema processed_newdownload to openfec;
+grant select on all tables in schema processed_newdownload to webro;
+grant all privileges on all tables in schema processed_newdownload to openfec;
+

--- a/data/ddl/processed_schema.to_rds.live.sql
+++ b/data/ddl/processed_schema.to_rds.live.sql
@@ -1,0 +1,2112 @@
+-- run on data access machine to create foreign tables in RDS
+
+DROP SCHEMA processed_live;
+CREATE SCHEMA processed_live;
+
+CREATE FOREIGN TABLE processed_live.cand_status_ici (
+    cand_status_ici_sk numeric(10,0) NOT NULL,
+    cand_id character varying(9) NOT NULL,
+    election_yr numeric(4,0) NOT NULL,
+    ici_code character varying(1),
+    cand_status character varying(1),
+    cand_inactive_flg character varying(1),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'cand_status_ici');
+
+
+
+
+--
+-- Name: form_1; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_1 (
+    form_1_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    submit_dt date,
+    cmte_nm_chg_flg character varying(1),
+    cmte_addr_chg_flg character varying(1),
+    cmte_tp character varying(1),
+    cand_id character varying(9),
+    cand_nm character varying(90),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    cand_pty_affiliation character varying(3),
+    cand_pty_tp character varying(3),
+    affiliated_cmte_id character varying(9),
+    affiliated_cmte_nm character varying(200),
+    affiliated_cmte_st1 character varying(34),
+    affiliated_cmte_st2 character varying(34),
+    affiliated_cmte_city character varying(30),
+    affiliated_cmte_st character varying(2),
+    affiliated_cmte_zip character varying(9),
+    cmte_rltshp character varying(38),
+    org_tp character varying(1),
+    cust_rec_nm character varying(90),
+    cust_rec_st1 character varying(34),
+    cust_rec_st2 character varying(34),
+    cust_rec_city character varying(30),
+    cust_rec_st character varying(2),
+    cust_rec_zip character varying(9),
+    cust_rec_title character varying(20),
+    cust_rec_ph_num character varying(10),
+    tres_nm character varying(90),
+    tres_st1 character varying(34),
+    tres_st2 character varying(34),
+    tres_city character varying(30),
+    tres_st character varying(2),
+    tres_zip character varying(9),
+    tres_title character varying(20),
+    tres_ph_num character varying(10),
+    designated_agent_nm character varying(90),
+    designated_agent_st1 character varying(34),
+    designated_agent_st2 character varying(34),
+    designated_agent_city character varying(30),
+    designated_agent_st character varying(2),
+    designated_agent_zip character varying(9),
+    designated_agent_title character varying(20),
+    designated_agent_ph_num character varying(10),
+    bank_depository_nm character varying(200),
+    bank_depository_st1 character varying(34),
+    bank_depository_st2 character varying(34),
+    bank_depository_city character varying(30),
+    bank_depository_st character varying(2),
+    bank_depository_zip character varying(9),
+    sec_bank_depository_nm character varying(200),
+    sec_bank_depository_st1 character varying(34),
+    sec_bank_depository_st2 character varying(34),
+    sec_bank_depository_city character varying(30),
+    sec_bank_depository_st character varying(2),
+    sec_bank_depository_zip character varying(10),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    cmte_email character varying(90),
+    cmte_web_url character varying(90),
+    receipt_dt date,
+    filing_freq character varying(1),
+    cmte_dsgn character varying(1),
+    qual_dt date,
+    cmte_fax character varying(12),
+    efiling_cmte_tp character varying(1),
+    rpt_yr numeric(4,0),
+    leadership_pac character varying(1),
+    affiliated_relationship_cd character varying(3),
+    cmte_email_chg_flg character varying(1),
+    cmte_url_chg_flg character varying(1),
+    lobbyist_registrant_pac character varying(1),
+    affiliated_cand_id character varying(9),
+    affiliated_cand_l_nm character varying(30),
+    affiliated_cand_f_nm character varying(20),
+    affiliated_cand_m_nm character varying(20),
+    affiliated_cand_prefix character varying(10),
+    affiliated_cand_suffix character varying(10),
+    cand_l_nm character varying(30),
+    cand_f_nm character varying(20),
+    cand_m_nm character varying(20),
+    cand_prefix character varying(10),
+    cand_suffix character varying(10),
+    cust_rec_l_nm character varying(30),
+    cust_rec_f_nm character varying(20),
+    cust_rec_m_nm character varying(20),
+    cust_rec_prefix character varying(10),
+    cust_rec_suffix character varying(10),
+    tres_l_nm character varying(30),
+    tres_f_nm character varying(20),
+    tres_m_nm character varying(20),
+    tres_prefix character varying(10),
+    tres_suffix character varying(10),
+    designated_agent_l_nm character varying(30),
+    designated_agent_f_nm character varying(20),
+    designated_agent_m_nm character varying(20),
+    designated_agent_prefix character varying(10),
+    designated_agent_suffix character varying(10),
+    f3l_filing_freq character varying(1),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_1');
+
+
+
+
+--
+-- Name: form_10; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_10 (
+    form_10_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    cand_nm character varying(38),
+    cand_id character varying(9),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    cmte_nm character varying(90),
+    st1 character varying(34),
+    st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    prev_exp_agg numeric(14,2),
+    exp_ttl_this_rpt numeric(14,2),
+    exp_ttl_cycl_to_dt numeric(14,2),
+    cand_sign_nm character varying(38),
+    sign_dt date,
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    form_tp_desc character varying(90),
+    cand_office_desc character varying(20),
+    cand_office_st_desc character varying(20),
+    cmte_st_desc character varying(20),
+    image_tp character varying(10),
+    last_update_dt date,
+    amndt_ind character varying(1),
+    receipt_dt date,
+    form_6_chk character varying(1),
+    contbr_employer character varying(38),
+    contbr_occupation character varying(38),
+    rpt_yr numeric(4,0),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_10');
+
+
+
+
+--
+-- Name: form_11; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_11 (
+    form_11_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    cand_nm character varying(38),
+    cand_id character varying(9),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    oppos_cand_nm character varying(38),
+    oppos_cmte_nm character varying(90),
+    oppos_cmte_id character varying(9),
+    oppos_cmte_st1 character varying(34),
+    oppos_cmte_st2 character varying(34),
+    oppos_cmte_city character varying(18),
+    oppos_cmte_st character varying(2),
+    oppos_cmte_zip character varying(9),
+    form_10_recpt_dt date,
+    oppos_pers_fund_amt numeric(14,2),
+    election_tp character varying(5),
+    fec_election_tp_desc character varying(20),
+    reg_special_elect_tp character varying(1),
+    cand_tres_sign_nm character varying(38),
+    cand_tres_sign_dt date,
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    amndt_ind character varying(1),
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    cand_last_name character varying(30),
+    cand_first_name character varying(20),
+    cand_middle_name character varying(20),
+    cand_prefix character varying(10),
+    cand_suffix character varying(10),
+    oppos_cand_last_name character varying(30),
+    oppos_cand_first_name character varying(20),
+    oppos_cand_middle_name character varying(20),
+    oppos_cand_prefix character varying(10),
+    oppos_cand_suffix character varying(10),
+    cand_tres_last_name character varying(30),
+    cand_tres_first_name character varying(20),
+    cand_tres_middle_name character varying(20),
+    cand_tres_prefix character varying(10),
+    cand_tres_suffix character varying(10),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_11');
+
+
+
+
+--
+-- Name: form_12; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_12 (
+    form_12_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    cand_nm character varying(38),
+    cand_id character varying(9),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    cmte_nm character varying(90),
+    st1 character varying(34),
+    st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    election_tp character varying(5),
+    reg_special_elect_tp character varying(1),
+    fec_election_tp_desc character varying(20),
+    hse_date_reached_100 date,
+    hse_pers_funds_amt numeric(14,2),
+    hse_form_11_prev_dt date,
+    sen_date_reached_110 date,
+    sen_pers_funds_amt numeric(14,2),
+    sen_form_11_prev_dt date,
+    cand_tres_sign_nm character varying(38),
+    cand_tres_sign_dt date,
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    amndt_ind character varying(1),
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    cand_last_name character varying(30),
+    cand_first_name character varying(20),
+    cand_middle_name character varying(20),
+    cand_prefix character varying(10),
+    cand_suffix character varying(10),
+    cand_tres_last_name character varying(30),
+    cand_tres_first_name character varying(20),
+    cand_tres_middle_name character varying(20),
+    cand_tres_prefix character varying(10),
+    cand_tres_suffix character varying(10),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_12');
+
+
+
+
+--
+-- Name: form_13; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_13 (
+    form_13_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_addr_chg_flg character varying(1),
+    cmte_tp character varying(1),
+    rpt_tp character varying(3),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    ttl_dons_accepted numeric(14,2),
+    ttl_dons_refunded numeric(14,2),
+    net_dons numeric(14,2),
+    desig_officer_last_nm character varying(30),
+    desig_officer_first_nm character varying(20),
+    desig_officer_middle_nm character varying(20),
+    desig_officer_prefix character varying(10),
+    desig_officer_suffix character varying(10),
+    desig_officer_nm character varying(38),
+    receipt_dt date,
+    signature_dt date,
+    rpt_yr numeric(4,0),
+    original_report_dt date,
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_13');
+
+
+
+
+--
+-- Name: form_1m; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_1m (
+    form_1m_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_tp character varying(1),
+    affiliation_dt date,
+    affiliated_cmte_id character varying(9),
+    affiliated_cmte_nm character varying(200),
+    fst_cand_id character varying(9),
+    fst_cand_nm character varying(90),
+    fst_cand_office character varying(1),
+    fst_cand_office_st character varying(2),
+    fst_cand_office_district character varying(2),
+    fst_cand_contb_dt date,
+    sec_cand_id character varying(9),
+    sec_cand_nm character varying(90),
+    sec_cand_office character varying(1),
+    sec_cand_office_st character varying(2),
+    sec_cand_office_district character varying(2),
+    sec_cand_contb_dt date,
+    trd_cand_id character varying(9),
+    trd_cand_nm character varying(90),
+    trd_cand_office character varying(1),
+    trd_cand_office_st character varying(2),
+    trd_cand_office_district character varying(2),
+    trd_cand_contb_dt date,
+    frth_cand_id character varying(9),
+    frth_cand_nm character varying(90),
+    frth_cand_office character varying(1),
+    frth_cand_office_st character varying(2),
+    frth_cand_office_district character varying(2),
+    frth_cand_contb_dt date,
+    fith_cand_id character varying(9),
+    fith_cand_nm character varying(90),
+    fith_cand_office character varying(1),
+    fith_cand_office_st character varying(2),
+    fith_cand_office_district character varying(2),
+    fith_cand_contb_dt date,
+    fiftyfirst_cand_contbr_dt date,
+    orig_registration_dt date,
+    qual_dt date,
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_1m');
+
+
+
+
+--
+-- Name: form_1s; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_1s (
+    form_1s_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    affiliated_cmte_id character varying(9),
+    affiliated_cmte_nm character varying(200),
+    affiliated_cmte_st1 character varying(34),
+    affiliated_cmte_st2 character varying(34),
+    affiliated_cmte_city character varying(30),
+    affiliated_cmte_st character varying(2),
+    affiliated_cmte_zip character varying(9),
+    cmte_rltshp character varying(38),
+    org_tp character varying(1),
+    designated_agent_nm character varying(200),
+    designated_agent_st1 character varying(34),
+    designated_agent_st2 character varying(34),
+    designated_agent_city character varying(30),
+    designated_agent_st character varying(2),
+    designated_agent_zip character varying(9),
+    designated_agent_title character varying(20),
+    designated_agent_ph_num character varying(10),
+    bank_depository_nm character varying(200),
+    bank_depository_st1 character varying(34),
+    bank_depository_st2 character varying(34),
+    bank_depository_city character varying(30),
+    bank_depository_st character varying(2),
+    bank_depository_zip character varying(9),
+    receipt_dt date,
+    joint_cmte_nm character varying(90),
+    joint_cmte_id character varying(9),
+    affiliated_relationship_cd character varying(3),
+    affiliated_cand_id character varying(9),
+    affiliated_cand_l_nm character varying(30),
+    affiliated_cand_f_nm character varying(20),
+    affiliated_cand_m_nm character varying(20),
+    affiliated_cand_prefix character varying(10),
+    affiliated_cand_suffix character varying(10),
+    designated_agent_l_nm character varying(30),
+    designated_agent_f_nm character varying(20),
+    designated_agent_m_nm character varying(20),
+    designated_agent_prefix character varying(10),
+    designated_agent_suffix character varying(10),
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_1s');
+
+
+
+
+--
+-- Name: form_2; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_2 (
+    form_2_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cand_id character varying(9),
+    cand_nm character varying(90),
+    cand_st1 character varying(34),
+    cand_st2 character varying(34),
+    cand_city character varying(30),
+    cand_st character varying(2),
+    cand_zip character varying(9),
+    addr_chg_flg character varying(1),
+    cand_pty_affiliation character varying(3),
+    cand_pty_affiliation_2 character varying(3),
+    cand_pty_affiliation_3 character varying(3),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    election_yr numeric(4,0),
+    pcc_cmte_id character varying(9),
+    pcc_cmte_nm character varying(200),
+    pcc_cmte_st1 character varying(34),
+    pcc_cmte_st2 character varying(34),
+    pcc_cmte_city character varying(30),
+    pcc_cmte_st character varying(2),
+    pcc_cmte_zip character varying(9),
+    addl_auth_cmte_id character varying(9),
+    addl_auth_cmte_nm character varying(200),
+    addl_auth_cmte_st1 character varying(34),
+    addl_auth_cmte_st2 character varying(34),
+    addl_auth_cmte_city character varying(18),
+    addl_auth_cmte_st character varying(2),
+    addl_auth_cmte_zip character varying(9),
+    cand_sign_nm character varying(90),
+    cand_sign_dt date,
+    receipt_dt date,
+    party_cd character varying(1),
+    cand_ici character varying(1),
+    cand_status character varying(1),
+    prim_pers_funds_decl numeric(14,2),
+    gen_pers_funds_decl numeric(14,2),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_2');
+
+
+
+
+--
+-- Name: form_24; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_24 (
+    form_24_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_tp character varying(3),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_24');
+
+
+
+
+--
+-- Name: form_2s; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_2s (
+    form_2s_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cand_id character varying(9),
+    auth_cmte_id character varying(9),
+    auth_cmte_nm character varying(90),
+    auth_cmte_st1 character varying(34),
+    auth_cmte_st2 character varying(34),
+    auth_cmte_city character varying(18),
+    auth_cmte_st character varying(2),
+    auth_cmte_zip character varying(9),
+    receipt_dt date,
+    amndt_ind character varying(1),
+    begin_image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_2s');
+
+
+
+
+--
+-- Name: form_3; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_3 (
+    form_3_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_addr_chg_flg character varying(1),
+    cmte_election_st character varying(2),
+    cmte_election_district character varying(2),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_dt date,
+    election_st character varying(2),
+    primary_election character varying(1),
+    general_election character varying(1),
+    special_election character varying(1),
+    runoff_election character varying(1),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    ttl_contb_per numeric(14,2),
+    ttl_contb_ref_per numeric(14,2),
+    net_contb_per numeric(14,2),
+    ttl_op_exp_per numeric(14,2),
+    ttl_offsets_to_op_exp_per numeric(14,2),
+    net_op_exp_per numeric(14,2),
+    coh_cop_i numeric(14,2),
+    debts_owed_to_cmte numeric(14,2),
+    debts_owed_by_cmte numeric(14,2),
+    indv_item_contb_per numeric(14,2),
+    indv_unitem_contb_per numeric(14,2),
+    ttl_indv_contb_per numeric(14,2),
+    pol_pty_cmte_contb_per numeric(14,2),
+    other_pol_cmte_contb_per numeric(14,2),
+    cand_contb_per numeric(14,2),
+    ttl_contb_column_ttl_per numeric(14,2),
+    tranf_from_other_auth_cmte_per numeric(14,2),
+    loans_made_by_cand_per numeric(14,2),
+    all_other_loans_per numeric(14,2),
+    ttl_loans_per numeric(14,2),
+    offsets_to_op_exp_per numeric(14,2),
+    other_receipts_per numeric(14,2),
+    ttl_receipts_per_i numeric(14,2),
+    op_exp_per numeric(14,2),
+    tranf_to_other_auth_cmte_per numeric(14,2),
+    loan_repymts_cand_loans_per numeric(14,2),
+    loan_repymts_other_loans_per numeric(14,2),
+    ttl_loan_repymts_per numeric(14,2),
+    ref_indv_contb_per numeric(14,2),
+    ref_pol_pty_cmte_contb_per numeric(14,2),
+    ref_other_pol_cmte_contb_per numeric(14,2),
+    ttl_contb_ref_col_ttl_per numeric(14,2),
+    other_disb_per numeric(14,2),
+    ttl_disb_per_i numeric(14,2),
+    coh_bop numeric(14,2),
+    ttl_receipts_ii numeric(14,2),
+    subttl_per numeric(14,2),
+    ttl_disb_per_ii numeric(14,2),
+    coh_cop_ii numeric(14,2),
+    ttl_contb_ytd numeric(14,2),
+    ttl_contb_ref_ytd numeric(14,2),
+    net_contb_ytd numeric(14,2),
+    ttl_op_exp_ytd numeric(14,2),
+    ttl_offsets_to_op_exp_ytd numeric(14,2),
+    net_op_exp_ytd numeric(14,2),
+    ttl_indv_item_contb_ytd numeric(14,2),
+    ttl_indv_unitem_contb_ytd numeric(14,2),
+    ttl_indv_contb_ytd numeric(14,2),
+    pol_pty_cmte_contb_ytd numeric(14,2),
+    other_pol_cmte_contb_ytd numeric(14,2),
+    cand_contb_ytd numeric(14,2),
+    ttl_contb_col_ttl_ytd numeric(14,2),
+    tranf_from_other_auth_cmte_ytd numeric(14,2),
+    loans_made_by_cand_ytd numeric(14,2),
+    all_other_loans_ytd numeric(14,2),
+    ttl_loans_ytd numeric(14,2),
+    offsets_to_op_exp_ytd numeric(14,2),
+    other_receipts_ytd numeric(14,2),
+    ttl_receipts_ytd numeric(14,2),
+    op_exp_ytd numeric(14,2),
+    tranf_to_other_auth_cmte_ytd numeric(14,2),
+    loan_repymts_cand_loans_ytd numeric(14,2),
+    loan_repymts_other_loans_ytd numeric(14,2),
+    ttl_loan_repymts_ytd numeric(14,2),
+    ref_indv_contb_ytd numeric(14,2),
+    ref_pol_pty_cmte_contb_ytd numeric(14,2),
+    ref_other_pol_cmte_contb_ytd numeric(14,2),
+    ref_ttl_contb_col_ttl_ytd numeric(14,2),
+    other_disb_ytd numeric(14,2),
+    ttl_disb_ytd numeric(14,2),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    grs_rcpt_auth_cmte_prim numeric(14,2),
+    agr_amt_contrib_pers_fund_prim numeric(14,2),
+    grs_rcpt_min_pers_contrib_prim numeric(14,2),
+    grs_rcpt_auth_cmte_gen numeric(14,2),
+    agr_amt_pers_contrib_gen numeric(14,2),
+    grs_rcpt_min_pers_contrib_gen numeric(14,2),
+    cand_id character varying(9),
+    cand_nm character varying(38),
+    f3z1_rpt_tp character varying(3),
+    f3z1_rpt_tp_desc character varying(30),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_3');
+
+
+
+
+--
+-- Name: form_3l; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_3l (
+    form_3l_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(28),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_addr_chg_flg character varying(1),
+    cmte_election_st character varying(2),
+    cmte_election_district character varying(2),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_dt date,
+    election_st character varying(2),
+    semi_an_per_5c_5d character varying(1),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    semi_an_jan_jun_6b character varying(1),
+    semi_an_jul_dec_6b character varying(1),
+    qtr_mon_bundled_contb numeric(14,2),
+    semi_an_bundled_contb numeric(14,2),
+    tres_l_nm character varying(30),
+    tres_f_nm character varying(20),
+    tres_m_nm character varying(20),
+    tres_prefix character varying(10),
+    tres_suffix character varying(10),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_31');
+
+
+
+
+--
+-- Name: form_3p; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_3p (
+    form_3p_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    addr_chg_flg character varying(1),
+    activity_primary character varying(1),
+    activity_general character varying(1),
+    term_rpt_flag character varying(1),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_dt date,
+    election_st character varying(2),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    coh_bop numeric(14,2),
+    ttl_receipts_sum_page_per numeric(14,2),
+    subttl_sum_page_per numeric(14,2),
+    ttl_disb_sum_page_per numeric(14,2),
+    coh_cop numeric(14,2),
+    debts_owed_to_cmte numeric(14,2),
+    debts_owed_by_cmte numeric(14,2),
+    exp_subject_limits numeric(14,2),
+    net_contb_sum_page_per numeric(14,2),
+    net_op_exp_sum_page_per numeric(14,2),
+    fed_funds_per numeric(14,2),
+    indv_contb_per numeric(14,2),
+    pol_pty_cmte_contb_per numeric(14,2),
+    other_pol_cmte_contb_per numeric(14,2),
+    cand_contb_per numeric(14,2),
+    ttl_contb_per numeric(14,2),
+    tranf_from_affilated_cmte_per numeric(14,2),
+    loans_received_from_cand_per numeric(14,2),
+    other_loans_received_per numeric(14,2),
+    ttl_loans_received_per numeric(14,2),
+    offsets_to_op_exp_per numeric(14,2),
+    offsets_to_fndrsg_exp_per numeric(14,2),
+    offsets_to_legal_acctg_per numeric(14,2),
+    ttl_offsets_to_op_exp_per numeric(14,2),
+    other_receipts_per numeric(14,2),
+    ttl_receipts_per numeric(14,2),
+    op_exp_per numeric(14,2),
+    tranf_to_other_auth_cmte_per numeric(14,2),
+    fndrsg_disb_per numeric(14,2),
+    exempt_legal_acctg_disb_per numeric(14,2),
+    repymts_loans_made_by_cand_per numeric(14,2),
+    repymts_other_loans_per numeric(14,2),
+    ttl_loan_repymts_made_per numeric(14,2),
+    ref_indv_contb_per numeric(14,2),
+    ref_pol_pty_cmte_contb_per numeric(14,2),
+    ref_other_pol_cmte_contb_per numeric(14,2),
+    ttl_contb_ref_per numeric(14,2),
+    other_disb_per numeric(14,2),
+    ttl_disb_per numeric(14,2),
+    items_on_hand_liquidated numeric(14,2),
+    alabama_per numeric(14,2),
+    alaska_per numeric(14,2),
+    arizona_per numeric(14,2),
+    arkansas_per numeric(14,2),
+    california_per numeric(14,2),
+    colorado_per numeric(14,2),
+    connecticut_per numeric(14,2),
+    delaware_per numeric(14,2),
+    district_columbia_per numeric(14,2),
+    florida_per numeric(14,2),
+    georgia_per numeric(14,2),
+    hawaii_per numeric(14,2),
+    idaho_per numeric(14,2),
+    illinois_per numeric(14,2),
+    indiana_per numeric(14,2),
+    iowa_per numeric(14,2),
+    kansas_per numeric(14,2),
+    kentucky_per numeric(14,2),
+    louisiana_per numeric(14,2),
+    maine_per numeric(14,2),
+    maryland_per numeric(14,2),
+    massachusetts_per numeric(14,2),
+    michigan_per numeric(14,2),
+    minnesota_per numeric(14,2),
+    mississippi_per numeric(14,2),
+    missouri_per numeric(14,2),
+    montana_per numeric(14,2),
+    nebraska_per numeric(14,2),
+    nevada_per numeric(14,2),
+    new_hampshire_per numeric(14,2),
+    new_jersey_per numeric(14,2),
+    new_mexico_per numeric(14,2),
+    new_york_per numeric(14,2),
+    north_carolina_per numeric(14,2),
+    north_dakota_per numeric(14,2),
+    ohio_per numeric(14,2),
+    oklahoma_per numeric(14,2),
+    oregon_per numeric(14,2),
+    pennsylvania_per numeric(14,2),
+    rhode_island_per numeric(14,2),
+    south_carolina_per numeric(14,2),
+    south_dakota_per numeric(14,2),
+    tennessee_per numeric(14,2),
+    texas_per numeric(14,2),
+    utah_per numeric(14,2),
+    vermont_per numeric(14,2),
+    virginia_per numeric(14,2),
+    washington_per numeric(14,2),
+    west_virginia_per numeric(14,2),
+    wisconsin_per numeric(14,2),
+    wyoming_per numeric(14,2),
+    puerto_rico_per numeric(14,2),
+    guam_per numeric(14,2),
+    virgin_islands_per numeric(14,2),
+    ttl_per numeric(14,2),
+    fed_funds_ytd numeric(14,2),
+    indv_contb_ytd numeric(14,2),
+    pol_pty_cmte_contb_ytd numeric(14,2),
+    other_pol_cmte_contb_ytd numeric(14,2),
+    cand_contb_ytd numeric(14,2),
+    ttl_contb_ytd numeric(14,2),
+    tranf_from_affiliated_cmte_ytd numeric(14,2),
+    loans_received_from_cand_ytd numeric(14,2),
+    other_loans_received_ytd numeric(14,2),
+    ttl_loans_received_ytd numeric(14,2),
+    offsets_to_op_exp_ytd numeric(14,2),
+    offsets_to_fndrsg_exp_ytd numeric(14,2),
+    offsets_to_legal_acctg_ytd numeric(14,2),
+    ttl_offsets_to_op_exp_ytd numeric(14,2),
+    other_receipts_ytd numeric(14,2),
+    ttl_receipts_ytd numeric(14,2),
+    op_exp_ytd numeric(14,2),
+    tranf_to_other_auth_cmte_ytd numeric(14,2),
+    fndrsg_disb_ytd numeric(14,2),
+    exempt_legal_acctg_disb_ytd numeric(14,2),
+    repymts_loans_made_cand_ytd numeric(14,2),
+    repymts_other_loans_ytd numeric(14,2),
+    ttl_loan_repymts_made_ytd numeric(14,2),
+    ref_indv_contb_ytd numeric(14,2),
+    ref_pol_pty_cmte_contb_ytd numeric(14,2),
+    ref_other_pol_cmte_contb_ytd numeric(14,2),
+    ttl_contb_ref_ytd numeric(14,2),
+    other_disb_ytd numeric(14,2),
+    ttl_disb_ytd numeric(14,2),
+    alabama_ytd numeric(14,2),
+    alaska_ytd numeric(14,2),
+    arizona_ytd numeric(14,2),
+    arkansas_ytd numeric(14,2),
+    california_ytd numeric(14,2),
+    colorado_ytd numeric(14,2),
+    connecticut_ytd numeric(14,2),
+    delaware_ytd numeric(14,2),
+    district_columbia_ytd numeric(14,2),
+    florida_ytd numeric(14,2),
+    georgia_ytd numeric(14,2),
+    hawaii_ytd numeric(14,2),
+    idaho_ytd numeric(14,2),
+    illinois_ytd numeric(14,2),
+    indiana_ytd numeric(14,2),
+    iowa_ytd numeric(14,2),
+    kansas_ytd numeric(14,2),
+    kentucky_ytd numeric(14,2),
+    louisiana_ytd numeric(14,2),
+    maine_ytd numeric(14,2),
+    maryland_ytd numeric(14,2),
+    massachusetts_ytd numeric(14,2),
+    michigan_ytd numeric(14,2),
+    minnesota_ytd numeric(14,2),
+    mississippi_ytd numeric(14,2),
+    missouri_ytd numeric(14,2),
+    montana_ytd numeric(14,2),
+    nebraska_ytd numeric(14,2),
+    nevada_ytd numeric(14,2),
+    new_hampshire_ytd numeric(14,2),
+    new_jersey_ytd numeric(14,2),
+    new_mexico_ytd numeric(14,2),
+    new_york_ytd numeric(14,2),
+    north_carolina_ytd numeric(14,2),
+    north_dakota_ytd numeric(14,2),
+    ohio_ytd numeric(14,2),
+    oklahoma_ytd numeric(14,2),
+    oregon_ytd numeric(14,2),
+    pennsylvania_ytd numeric(14,2),
+    rhode_island_ytd numeric(14,2),
+    south_carolina_ytd numeric(14,2),
+    south_dakota_ytd numeric(14,2),
+    tennessee_ytd numeric(14,2),
+    texas_ytd numeric(14,2),
+    utah_ytd numeric(14,2),
+    vermont_ytd numeric(14,2),
+    virginia_ytd numeric(14,2),
+    washington_ytd numeric(14,2),
+    west_virginia_ytd numeric(14,2),
+    wisconsin_ytd numeric(14,2),
+    wyoming_ytd numeric(14,2),
+    puerto_rico_ytd numeric(14,2),
+    guam_ytd numeric(14,2),
+    virgin_islands_ytd numeric(14,2),
+    ttl_ytd numeric(14,2),
+    tres_sign_nm character varying(38),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_3p');
+
+
+
+
+--
+-- Name: form_3p_line_31s; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_3p_line_31s (
+    form_3p31s_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    entity_tp character varying(3),
+    contbr_lender_nm character varying(90),
+    contbr_lender_st1 character varying(34),
+    contbr_lender_st2 character varying(34),
+    contbr_lender_city character varying(18),
+    contbr_lender_st character varying(2),
+    contbr_lender_zip character varying(9),
+    rpt_pgi character varying(5),
+    contbr_lender_employer character varying(38),
+    contbr_lender_occupation character varying(38),
+    contb_dt date,
+    fair_mkt_value_of_item numeric(14,2),
+    tran_code character varying(3),
+    tran_desc character varying(100),
+    cand_id character varying(9),
+    cand_nm character varying(38),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    conduit_cmte_id character varying(9),
+    conduit_cmte_nm character varying(90),
+    conduit_cmte_st1 character varying(34),
+    conduit_cmte_st2 character varying(34),
+    conduit_cmte_city character varying(18),
+    conduit_cmte_st character varying(2),
+    conduit_cmte_zip character varying(9),
+    memo_flag character varying(1),
+    memo_text character varying(100),
+    amndt_ind character varying(1),
+    tran_id character varying(32),
+    receipt_dt date,
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_3p_line_31s');
+
+
+
+
+--
+-- Name: form_3ps; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_3ps (
+    form_3ps_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    alabama numeric(14,2),
+    alaska numeric(14,2),
+    arizona numeric(14,2),
+    arkansas numeric(14,2),
+    california numeric(14,2),
+    colorado numeric(14,2),
+    connecticut numeric(14,2),
+    delaware numeric(14,2),
+    district_columbia numeric(14,2),
+    florida numeric(14,2),
+    georgia numeric(14,2),
+    hawaii numeric(14,2),
+    idaho numeric(14,2),
+    illinois numeric(14,2),
+    indiana numeric(14,2),
+    iowa numeric(14,2),
+    kansas numeric(14,2),
+    kentucky numeric(14,2),
+    louisiana numeric(14,2),
+    maine numeric(14,2),
+    maryland numeric(14,2),
+    massachusetts numeric(14,2),
+    michigan numeric(14,2),
+    minnesota numeric(14,2),
+    mississippi numeric(14,2),
+    missouri numeric(14,2),
+    montana numeric(14,2),
+    nebraska numeric(14,2),
+    nevada numeric(14,2),
+    new_hampshire numeric(14,2),
+    new_jersey numeric(14,2),
+    new_mexico numeric(14,2),
+    new_york numeric(14,2),
+    north_carolina numeric(14,2),
+    north_dakota numeric(14,2),
+    ohio numeric(14,2),
+    oklahoma numeric(14,2),
+    oregon numeric(14,2),
+    pennsylvania numeric(14,2),
+    rhode_island numeric(14,2),
+    south_carolina numeric(14,2),
+    south_dakota numeric(14,2),
+    tennessee numeric(14,2),
+    texas numeric(14,2),
+    utah numeric(14,2),
+    vermont numeric(14,2),
+    virginia numeric(14,2),
+    washington numeric(14,2),
+    west_virginia numeric(14,2),
+    wisconsin numeric(14,2),
+    wyoming numeric(14,2),
+    puerto_rico numeric(14,2),
+    guam numeric(14,2),
+    virgin_islands numeric(14,2),
+    ttl numeric(14,2),
+    election_dt date,
+    day_after_election_dt date,
+    net_contb numeric(14,2),
+    net_exp numeric(14,2),
+    fed_funds numeric(14,2),
+    indv_contb_other_loans numeric(14,2),
+    pol_pty_cmte_contb_other_loans numeric(14,2),
+    pac_contb_other_loans numeric(14,2),
+    cand_contb_other_loans numeric(14,2),
+    ttl_contb_other_loans numeric(14,2),
+    tranf_from_affiliated_cmte numeric(14,2),
+    loans_received_from_cand numeric(14,2),
+    other_loans_received numeric(14,2),
+    ttl_loans numeric(14,2),
+    op_exp numeric(14,2),
+    fndrsg_exp numeric(14,2),
+    legal_and_acctg_exp numeric(14,2),
+    ttl_offsets_to_op_exp numeric(14,2),
+    other_receipts numeric(14,2),
+    ttl_receipts numeric(14,2),
+    op_exp2 numeric(14,2),
+    tranf_to_other_auth_cmte numeric(14,2),
+    fndrsg_disb numeric(14,2),
+    exempt_legal_and_acctg_disb numeric(14,2),
+    loan_repymts_made_by_cand numeric(14,2),
+    other_repymts numeric(14,2),
+    ttl_loan_repymts_made numeric(14,2),
+    ref_indv_contb numeric(14,2),
+    ref_pol_pty_contb numeric(14,2),
+    ref_other_pol_cmte_contb numeric(14,2),
+    ttl_contb_ref numeric(14,2),
+    other_disb numeric(14,2),
+    ttl_disb numeric(14,2),
+    receipt_dt date,
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_3ps');
+
+
+
+
+--
+-- Name: form_3s; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_3s (
+    form_3s_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    ttl_contb numeric(14,2),
+    ttl_contb_ref numeric(14,2),
+    net_contb numeric(14,2),
+    ttl_op_exp numeric(14,2),
+    ttl_offsets_to_op_exp numeric(14,2),
+    net_op_exp numeric(14,2),
+    indv_item_contb numeric(14,2),
+    indv_unitem_contb numeric(14,2),
+    ttl_indv_contb numeric(14,2),
+    pol_pty_cmte_contb numeric(14,2),
+    other_pol_cmte_contb numeric(14,2),
+    cand_contb numeric(14,2),
+    ttl_contb_column_ttl numeric(14,2),
+    tranf_from_other_auth_cmte numeric(14,2),
+    loans_made_by_cand numeric(14,2),
+    all_other_loans numeric(14,2),
+    ttl_loans numeric(14,2),
+    offsets_to_op_exp numeric(14,2),
+    other_receipts numeric(14,2),
+    ttl_receipts numeric(14,2),
+    op_exp numeric(14,2),
+    tranf_to_other_auth_cmte numeric(14,2),
+    loan_repymts_cand_loans numeric(14,2),
+    loan_repymts_other_loans numeric(14,2),
+    ttl_loan_repymts numeric(14,2),
+    ref_indv_contb numeric(14,2),
+    ref_pol_pty_cmte_contb numeric(14,2),
+    ref_other_pol_cmte_contb numeric(14,2),
+    ttl_contb_ref_col_ttl numeric(14,2),
+    other_disb numeric(14,2),
+    ttl_disb numeric(14,2),
+    election_dt date,
+    day_after_election_dt date,
+    receipt_dt date,
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_3s');
+
+
+
+
+--
+-- Name: form_3x; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_3x (
+    form_3x_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_addr_chg_flg character varying(1),
+    qual_cmte_flg character varying(1),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_dt date,
+    election_st character varying(2),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    coh_bop numeric(14,2),
+    ttl_receipts_sum_page_per numeric(14,2),
+    subttl_sum_page_per numeric(14,2),
+    ttl_disb_sum_page_per numeric(14,2),
+    coh_cop numeric(14,2),
+    debts_owed_to_cmte numeric(14,2),
+    debts_owed_by_cmte numeric(14,2),
+    indv_item_contb_per numeric(14,2),
+    indv_unitem_contb_per numeric(14,2),
+    ttl_indv_contb numeric(14,2),
+    pol_pty_cmte_contb_per_i numeric(14,2),
+    other_pol_cmte_contb_per_i numeric(14,2),
+    ttl_contb_col_ttl_per numeric(14,2),
+    tranf_from_affiliated_pty_per numeric(14,2),
+    all_loans_received_per numeric(14,2),
+    loan_repymts_received_per numeric(14,2),
+    offsets_to_op_exp_per_i numeric(14,2),
+    fed_cand_contb_ref_per numeric(14,2),
+    other_fed_receipts_per numeric(14,2),
+    tranf_from_nonfed_acct_per numeric(14,2),
+    ttl_receipts_per numeric(14,2),
+    ttl_fed_receipts_per numeric(14,2),
+    shared_fed_op_exp_per numeric(14,2),
+    shared_nonfed_op_exp_per numeric(14,2),
+    other_fed_op_exp_per numeric(14,2),
+    ttl_op_exp_per numeric(14,2),
+    tranf_to_affliliated_cmte_per numeric(14,2),
+    fed_cand_cmte_contb_per numeric(14,2),
+    indt_exp_per numeric(14,2),
+    coord_exp_by_pty_cmte_per numeric(14,2),
+    loan_repymts_made_per numeric(14,2),
+    loans_made_per numeric(14,2),
+    indv_contb_ref_per numeric(14,2),
+    pol_pty_cmte_contb_per_ii numeric(14,2),
+    other_pol_cmte_contb_per_ii numeric(14,2),
+    ttl_contb_ref_per_i numeric(14,2),
+    other_disb_per numeric(14,2),
+    ttl_disb_per numeric(14,2),
+    ttl_fed_disb_per numeric(14,2),
+    ttl_contb_per numeric(14,2),
+    ttl_contb_ref_per_ii numeric(14,2),
+    net_contb_per numeric(14,2),
+    ttl_fed_op_exp_per numeric(14,2),
+    offsets_to_op_exp_per_ii numeric(14,2),
+    net_op_exp_per numeric(14,2),
+    coh_begin_calendar_yr numeric(14,2),
+    calendar_yr numeric(4,0),
+    ttl_receipts_sum_page_ytd numeric(14,2),
+    subttl_sum_ytd numeric(14,2),
+    ttl_disb_sum_page_ytd numeric(14,2),
+    coh_coy numeric(14,2),
+    indv_item_contb_ytd numeric(14,2),
+    indv_unitem_contb_ytd numeric(14,2),
+    ttl_indv_contb_ytd numeric(14,2),
+    pol_pty_cmte_contb_ytd_i numeric(14,2),
+    other_pol_cmte_contb_ytd_i numeric(14,2),
+    ttl_contb_col_ttl_ytd numeric(14,2),
+    tranf_from_affiliated_pty_ytd numeric(14,2),
+    all_loans_received_ytd numeric(14,2),
+    loan_repymts_received_ytd numeric(14,2),
+    offsets_to_op_exp_ytd_i numeric(14,2),
+    fed_cand_cmte_contb_ytd numeric(14,2),
+    other_fed_receipts_ytd numeric(14,2),
+    tranf_from_nonfed_acct_ytd numeric(14,2),
+    ttl_receipts_ytd numeric(14,2),
+    ttl_fed_receipts_ytd numeric(14,2),
+    shared_fed_op_exp_ytd numeric(14,2),
+    shared_nonfed_op_exp_ytd numeric(14,2),
+    other_fed_op_exp_ytd numeric(14,2),
+    ttl_op_exp_ytd numeric(14,2),
+    tranf_to_affilitated_cmte_ytd numeric(14,2),
+    fed_cand_cmte_contb_ref_ytd numeric(14,2),
+    indt_exp_ytd numeric(14,2),
+    coord_exp_by_pty_cmte_ytd numeric(14,2),
+    loan_repymts_made_ytd numeric(14,2),
+    loans_made_ytd numeric(14,2),
+    indv_contb_ref_ytd numeric(14,2),
+    pol_pty_cmte_contb_ytd_ii numeric(14,2),
+    other_pol_cmte_contb_ytd_ii numeric(14,2),
+    ttl_contb_ref_ytd_i numeric(14,2),
+    other_disb_ytd numeric(14,2),
+    ttl_disb_ytd numeric(14,2),
+    ttl_fed_disb_ytd numeric(14,2),
+    ttl_contb_ytd numeric(14,2),
+    ttl_contb_ref_ytd_ii numeric(14,2),
+    net_contb_ytd numeric(14,2),
+    ttl_fed_op_exp_ytd numeric(14,2),
+    offsets_to_op_exp_ytd_ii numeric(14,2),
+    net_op_exp_ytd numeric(14,2),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    multicand_flg character varying(1),
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    tranf_from_nonfed_levin_per numeric(14,2),
+    ttl_nonfed_tranf_per numeric(14,2),
+    shared_fed_actvy_fed_shr_per numeric(14,2),
+    shared_fed_actvy_nonfed_per numeric(14,2),
+    non_alloc_fed_elect_actvy_per numeric(14,2),
+    ttl_fed_elect_actvy_per numeric(14,2),
+    tranf_from_nonfed_levin_ytd numeric(14,2),
+    ttl_nonfed_tranf_ytd numeric(14,2),
+    shared_fed_actvy_fed_shr_ytd numeric(14,2),
+    shared_fed_actvy_nonfed_ytd numeric(14,2),
+    non_alloc_fed_elect_actvy_ytd numeric(14,2),
+    ttl_fed_elect_actvy_ytd numeric(14,2),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_3x');
+
+
+
+
+--
+-- Name: form_3z; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_3z (
+    form_3z_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    pcc_id character varying(9),
+    pcc_nm character varying(90),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    auth_cmte_id character varying(9),
+    auth_cmte_nm character varying(90),
+    indv_contb numeric(14,2),
+    pol_pty_contb numeric(14,2),
+    other_pol_cmte_contb numeric(14,2),
+    cand_contb numeric(14,2),
+    ttl_contb numeric(14,2),
+    tranf_from_other_auth_cmte numeric(14,2),
+    loans_made_by_cand numeric(14,2),
+    all_other_loans numeric(14,2),
+    ttl_loans numeric(14,2),
+    offsets_to_op_exp numeric(14,2),
+    other_receipts numeric(14,2),
+    ttl_receipts numeric(14,2),
+    op_exp numeric(14,2),
+    tranf_to_other_auth_cmte numeric(14,2),
+    repymts_loans_made_cand numeric(14,2),
+    repymts_all_other_loans numeric(14,2),
+    ttl_loan_repymts numeric(14,2),
+    ref_indv_contb numeric(14,2),
+    ref_pol_pty_cmte_contb numeric(14,2),
+    ref_other_pol_cmte_contb numeric(14,2),
+    ttl_contb_ref numeric(14,2),
+    other_disb numeric(14,2),
+    ttl_disb numeric(14,2),
+    coh_bop numeric(14,2),
+    coh_cop numeric(14,2),
+    debts_owed_to_cmte numeric(14,2),
+    debts_owed_by_cmte numeric(14,2),
+    net_contb numeric(14,2),
+    net_op_exp numeric(14,2),
+    receipt_dt date,
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_3z');
+
+
+
+
+--
+-- Name: form_4; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_4 (
+    form_4_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_tp character varying(1),
+    cmte_desc character varying(40),
+    rpt_tp character varying(3),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    coh_bop numeric(14,2),
+    ttl_receipts_sum_page_per numeric(14,2),
+    subttl_sum_page_per numeric(14,2),
+    ttl_disb_sum_page_per numeric(14,2),
+    coh_cop numeric(14,2),
+    debts_owed_to_cmte_per numeric(14,2),
+    debts_owed_by_cmte_per numeric(14,2),
+    convn_exp_per numeric(14,2),
+    ref_reb_ret_convn_exp_per numeric(14,2),
+    exp_subject_limits_per numeric(14,2),
+    exp_prior_yrs_subject_lim_per numeric(14,2),
+    ttl_exp_subject_limits numeric(14,2),
+    fed_funds_per numeric(14,2),
+    item_convn_exp_contb_per numeric(14,2),
+    unitem_convn_exp_contb_per numeric(14,2),
+    subttl_convn_exp_contb_per numeric(14,2),
+    tranf_from_affiliated_cmte_per numeric(14,2),
+    loans_received_per numeric(14,2),
+    loan_repymts_received_per numeric(14,2),
+    subttl_loan_repymts_per numeric(14,2),
+    item_ref_reb_ret_per numeric(14,2),
+    unitem_ref_reb_ret_per numeric(14,2),
+    subttl_ref_reb_ret_per numeric(14,2),
+    item_other_ref_reb_ret_per numeric(14,2),
+    unitem_other_ref_reb_ret_per numeric(14,2),
+    subttl_other_ref_reb_ret_per numeric(14,2),
+    item_other_income_per numeric(14,2),
+    unitem_other_income_per numeric(14,2),
+    subttl_other_income_per numeric(14,2),
+    ttl_receipts_per numeric(14,2),
+    item_convn_exp_disb_per numeric(14,2),
+    unitem_convn_exp_disb_per numeric(14,2),
+    subttl_convn_exp_disb_per numeric(14,2),
+    tranf_to_affiliated_cmte_per numeric(14,2),
+    loans_made_per numeric(14,2),
+    loan_repymts_made_per numeric(14,2),
+    subttl_loan_repymts_disb_per numeric(14,2),
+    item_other_disb_per numeric(14,2),
+    unitem_other_disb_per numeric(14,2),
+    subttl_other_disb_per numeric(14,2),
+    ttl_disb_per numeric(14,2),
+    coh_begin_calendar_yr numeric(14,2),
+    calendar_yr numeric(4,0),
+    ttl_receipts_sum_page_ytd numeric(14,2),
+    subttl_sum_page_ytd numeric(14,2),
+    ttl_disb_sum_page_ytd numeric(14,2),
+    coh_coy numeric(14,2),
+    convn_exp_ytd numeric(14,2),
+    ref_reb_ret_convn_exp_ytd numeric(14,2),
+    exp_subject_limits_ytd numeric(14,2),
+    exp_prior_yrs_subject_lim_ytd numeric(14,2),
+    ttl_exp_subject_limits_ytd numeric(14,2),
+    fed_funds_ytd numeric(14,2),
+    subttl_convn_exp_contb_ytd numeric(14,2),
+    tranf_from_affiliated_cmte_ytd numeric(14,2),
+    subttl_loan_repymts_ytd numeric(14,2),
+    subttl_ref_reb_ret_deposit_ytd numeric(14,2),
+    subttl_other_ref_reb_ret_ytd numeric(14,2),
+    subttl_other_income_ytd numeric(14,2),
+    ttl_receipts_ytd numeric(14,2),
+    subttl_convn_exp_disb_ytd numeric(14,2),
+    tranf_to_affiliated_cmte_ytd numeric(14,2),
+    subttl_loan_repymts_disb_ytd numeric(14,2),
+    subttl_other_disb_ytd numeric(14,2),
+    ttl_disb_ytd numeric(14,2),
+    tres_sign_nm character varying(38),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(11),
+    end_image_num character varying(11),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_4');
+
+
+
+
+--
+-- Name: form_5; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_5 (
+    form_5_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    indv_org_id character varying(9),
+    indv_org_nm character varying(90),
+    indv_org_st1 character varying(34),
+    indv_org_st2 character varying(34),
+    indv_org_city character varying(18),
+    indv_org_st character varying(2),
+    indv_org_zip character varying(9),
+    addr_chg_flg character varying(1),
+    qual_nonprofit_corp_ind character varying(1),
+    indv_org_employer character varying(38),
+    indv_org_occupation character varying(38),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_tp character varying(2),
+    election_dt date,
+    election_st character varying(2),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    ttl_indt_contb numeric(14,2),
+    ttl_indt_exp numeric(14,2),
+    filer_nm character varying(38),
+    filer_sign_nm character varying(38),
+    filer_sign_dt date,
+    notary_sign_dt date,
+    notary_commission_exprtn_dt date,
+    notary_nm character varying(38),
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    entity_tp character varying(3),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_5');
+
+
+
+
+--
+-- Name: form_6; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_6 (
+    form_6_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    filer_cmte_nm character varying(200),
+    filer_cmte_st1 character varying(34),
+    filer_cmte_st2 character varying(34),
+    filer_cmte_city character varying(30),
+    filer_cmte_st character varying(2),
+    filer_cmte_zip character varying(9),
+    cand_id character varying(9),
+    cand_nm character varying(90),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    signer_last_name character varying(30),
+    signer_first_name character varying(20),
+    signer_middle_name character varying(20),
+    signer_prefix character varying(10),
+    signer_suffix character varying(10),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_6');
+
+
+
+
+--
+-- Name: form_7; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_7 (
+    form_7_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    org_id character varying(9),
+    org_nm character varying(90),
+    org_st1 character varying(34),
+    org_st2 character varying(34),
+    org_city character varying(18),
+    org_st character varying(2),
+    org_zip character varying(9),
+    org_tp character varying(1),
+    rpt_tp character varying(3),
+    election_dt date,
+    election_st character varying(2),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    ttl_communication_cost numeric(14,2),
+    filer_sign_nm character varying(38),
+    filer_sign_dt date,
+    filer_title character varying(20),
+    receipt_dt date,
+    rpt_pgi character varying(1),
+    amndt_ind character varying(1),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_7');
+
+
+
+
+--
+-- Name: form_8; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_8 (
+    form_8_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    coh numeric(14,2),
+    calender_yr date,
+    ttl_liquidated_assets numeric(14,2),
+    ttl_assets numeric(14,2),
+    ytd_reciepts numeric(14,2),
+    ytd_disb numeric(14,2),
+    ttl_amt_debts_owed numeric(14,2),
+    ttl_num_cred_owed numeric(8,0),
+    ttl_num_cred_part2 numeric(8,0),
+    ttl_amt_debts_owed_part2 numeric(14,2),
+    ttl_amt_paid_cred numeric(14,2),
+    term_flg character varying(1),
+    term_dt_desc character varying(15),
+    addl_auth_cmte_flg character varying(1),
+    add_auth_cmte_desc character varying(300),
+    sufficient_amt_to_pay_ttl_flg character varying(1),
+    sufficient_amt_to_pay_desc character varying(100),
+    prev_debt_settlement_plan_flg character varying(1),
+    residual_funds_flg character varying(1),
+    residual_funds_desc character varying(100),
+    remaining_amt_flg character varying(1),
+    remaining_amt_desc character varying(100),
+    tres_sign_nm character varying(38),
+    tres_sign_dt date,
+    receipt_dt date,
+    amndt_ind character varying(1),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_8');
+
+
+
+
+--
+-- Name: form_9; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_9 (
+    form_9_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    ind_org_corp_nm character varying(90),
+    ind_org_corp_st1 character varying(34),
+    ind_org_corp_st2 character varying(34),
+    ind_org_corp_city character varying(18),
+    ind_org_corp_st character varying(2),
+    ind_org_corp_zip character varying(9),
+    addr_chg_flg character varying(1),
+    ind_org_corp_emp character varying(38),
+    ind_org_corp_occup character varying(38),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    pub_distrib_dt date,
+    qual_nonprofit_flg character varying(18),
+    segr_bank_acct_flg character varying(1),
+    ind_custod_nm character varying(38),
+    ind_custod_st1 character varying(34),
+    ind_custod_st2 character varying(34),
+    ind_custod_city character varying(18),
+    ind_custod_st character varying(2),
+    ind_custod_zip character varying(9),
+    ind_custod_emp character varying(38),
+    ind_custod_occup character varying(38),
+    ttl_dons_this_stmt numeric(14,2),
+    ttl_disb_this_stmt numeric(14,2),
+    filer_sign_nm character varying(38),
+    filer_sign_dt date,
+    begin_image_num character varying(11),
+    end_image_num character varying(11),
+    last_update_dt date,
+    amndt_ind character varying(1),
+    receipt_dt date,
+    rpt_tp character varying(3),
+    comm_title character varying(40),
+    rpt_yr numeric(4,0),
+    entity_tp character varying(3),
+    filer_cd character varying(3),
+    filer_cd_desc character varying(20),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_9');
+
+
+
+
+--
+-- Name: form_99_misc; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.form_99_misc (
+    form_99_misc_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    text_field character varying(4000),
+    to_from_ind character varying(1),
+    receipt_dt date,
+    text_cd character varying(3),
+    text_cd_desc character varying(40),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'form_99_misc');
+
+
+
+
+--
+-- Name: log_audit_dml; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.log_audit_dml (
+    dml_id numeric(8,0) NOT NULL,
+    run_id numeric(8,0),
+    audit_id numeric(8,0),
+    dml_type character varying(12) NOT NULL,
+    target_table character varying(32) NOT NULL,
+    start_time timestamp without time zone NOT NULL,
+    row_count numeric(10,0),
+    dml_desc character varying(100),
+    cpu_minutes numeric(8,4),
+    elapsed_minutes numeric(8,4),
+    start_cpu_time numeric NOT NULL,
+    start_clock_time numeric NOT NULL
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'log_audit_dml');
+
+
+
+
+--
+-- Name: log_audit_module; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.log_audit_module (
+    audit_id numeric(8,0) NOT NULL,
+    run_id numeric(8,0),
+    module_name character varying(65) NOT NULL,
+    start_time timestamp without time zone NOT NULL,
+    input_parameters character varying(500),
+    error_message character varying(4000),
+    cpu_minutes numeric(8,4),
+    elapsed_minutes numeric(8,4),
+    start_cpu_time numeric NOT NULL,
+    start_clock_time numeric NOT NULL
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'log_audit_module');
+
+
+
+
+--
+-- Name: log_audit_process; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.log_audit_process (
+    run_id numeric(8,0) NOT NULL,
+    session_id numeric(22,0) NOT NULL,
+    process_name character varying(30),
+    interface_name character varying(6) NOT NULL,
+    module_name character varying(65) NOT NULL,
+    start_time timestamp without time zone NOT NULL,
+    input_parameters character varying(500),
+    messages character varying(4000),
+    cpu_minutes numeric(8,4),
+    elapsed_minutes numeric(8,4),
+    start_cpu_time numeric NOT NULL,
+    start_clock_time numeric NOT NULL
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'log_audit_process');
+
+
+
+
+--
+-- Name: log_dml_errors; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.log_dml_errors (
+    "ora_err_number$" numeric,
+    "ora_err_mesg$" character varying(2000),
+    "ora_err_rowid$" character varying,
+    "ora_err_optyp$" character varying(2),
+    "ora_err_tag$" character varying(100),
+    seq_no numeric(10,0),
+    form_tp character varying(100),
+    file_num character varying(100),
+    receipt_dt character varying(100),
+    begin_image_num character varying(100),
+    end_image_num character varying(100),
+    image_num character varying(100),
+    cmte_id character varying(100),
+    auth_cmte_id character varying(100),
+    pcc_cmte_id character varying(100),
+    pcc_id character varying(100),
+    cand_id character varying(100),
+    sub_id character varying(100),
+    load_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'log_dml_errors');
+
+
+
+
+--
+-- Name: ref_cand_ici; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.ref_cand_ici (
+    cand_ici_cd character(1) NOT NULL,
+    cand_ici_desc character varying(100),
+    incumbent_flg character(1),
+    open_flg character(1)
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'ref_cand_ici');
+
+
+
+
+--
+-- Name: ref_cand_status; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.ref_cand_status (
+    cand_status_cd character(1) NOT NULL,
+    cand_status_desc character varying(100)
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'ref_cand_status');
+
+
+
+
+--
+-- Name: ref_cmte_dsgn; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.ref_cmte_dsgn (
+    cmte_dsgn character(1) NOT NULL,
+    cmte_dsgn_desc character varying(90)
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'ref_cmte_dsgn');
+
+
+
+
+--
+-- Name: ref_cmte_type; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.ref_cmte_type (
+    cmte_tp character(1) NOT NULL,
+    cmte_tp_desc character varying(90),
+    explanation character varying(1000)
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'ref_cmte_type');
+
+
+
+
+--
+-- Name: ref_election; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.ref_election (
+    election_tp character(1) NOT NULL,
+    election_tp_desc character varying(100)
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'ref_election');
+
+
+
+
+--
+-- Name: ref_entity_type; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.ref_entity_type (
+    entity_tp character varying(3) NOT NULL,
+    entity_tp_desc character varying(100)
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'ref_entity_type');
+
+
+
+
+--
+-- Name: ref_form_type; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.ref_form_type (
+    form_tp character varying(15) NOT NULL,
+    form_tp_desc character varying(100),
+    form_nm character varying(1000),
+    obsolete_flg character(1) DEFAULT 'N'::bpchar,
+    obsolete_date date
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'ref_form_type');
+
+
+
+
+--
+-- Name: ref_office; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.ref_office (
+    office_tp character(1) NOT NULL,
+    office_tp_desc character varying(100)
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'ref_office');
+
+
+
+
+--
+-- Name: ref_org_type; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.ref_org_type (
+    org_tp character(1) NOT NULL,
+    org_tp_desc character varying(90)
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'ref_org_type');
+
+
+
+
+--
+-- Name: ref_party; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.ref_party (
+    party_cd character varying(3) NOT NULL,
+    party_desc character varying(100)
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'ref_party');
+
+
+
+
+--
+-- Name: ref_report_type; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.ref_report_type (
+    rpt_tp character varying(3) NOT NULL,
+    rpt_tp_desc character varying(100)
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'ref_report_type');
+
+
+
+
+--
+-- Name: ref_state; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.ref_state (
+    state_cd character varying(2) NOT NULL,
+    state_nm character varying(90)
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'ref_state');
+
+
+
+
+--
+-- Name: ref_transaction_code; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed_live.ref_transaction_code (
+    transaction_cd character varying(3) NOT NULL,
+    transaction_desc character varying(100)
+) SERVER rds OPTIONS (schema_name 'processed', table_name 'ref_transaction_code');
+
+
+

--- a/data/ddl/processed_schema.to_rds.sql
+++ b/data/ddl/processed_schema.to_rds.sql
@@ -1,0 +1,2109 @@
+-- run on data access machine to create foreign tables in RDS
+
+CREATE FOREIGN TABLE processed.cand_status_ici (
+    cand_status_ici_sk numeric(10,0) NOT NULL,
+    cand_id character varying(9) NOT NULL,
+    election_yr numeric(4,0) NOT NULL,
+    ici_code character varying(1),
+    cand_status character varying(1),
+    cand_inactive_flg character varying(1),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'cand_status_ici');
+
+
+
+
+--
+-- Name: form_1; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_1 (
+    form_1_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    submit_dt date,
+    cmte_nm_chg_flg character varying(1),
+    cmte_addr_chg_flg character varying(1),
+    cmte_tp character varying(1),
+    cand_id character varying(9),
+    cand_nm character varying(90),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    cand_pty_affiliation character varying(3),
+    cand_pty_tp character varying(3),
+    affiliated_cmte_id character varying(9),
+    affiliated_cmte_nm character varying(200),
+    affiliated_cmte_st1 character varying(34),
+    affiliated_cmte_st2 character varying(34),
+    affiliated_cmte_city character varying(30),
+    affiliated_cmte_st character varying(2),
+    affiliated_cmte_zip character varying(9),
+    cmte_rltshp character varying(38),
+    org_tp character varying(1),
+    cust_rec_nm character varying(90),
+    cust_rec_st1 character varying(34),
+    cust_rec_st2 character varying(34),
+    cust_rec_city character varying(30),
+    cust_rec_st character varying(2),
+    cust_rec_zip character varying(9),
+    cust_rec_title character varying(20),
+    cust_rec_ph_num character varying(10),
+    tres_nm character varying(90),
+    tres_st1 character varying(34),
+    tres_st2 character varying(34),
+    tres_city character varying(30),
+    tres_st character varying(2),
+    tres_zip character varying(9),
+    tres_title character varying(20),
+    tres_ph_num character varying(10),
+    designated_agent_nm character varying(90),
+    designated_agent_st1 character varying(34),
+    designated_agent_st2 character varying(34),
+    designated_agent_city character varying(30),
+    designated_agent_st character varying(2),
+    designated_agent_zip character varying(9),
+    designated_agent_title character varying(20),
+    designated_agent_ph_num character varying(10),
+    bank_depository_nm character varying(200),
+    bank_depository_st1 character varying(34),
+    bank_depository_st2 character varying(34),
+    bank_depository_city character varying(30),
+    bank_depository_st character varying(2),
+    bank_depository_zip character varying(9),
+    sec_bank_depository_nm character varying(200),
+    sec_bank_depository_st1 character varying(34),
+    sec_bank_depository_st2 character varying(34),
+    sec_bank_depository_city character varying(30),
+    sec_bank_depository_st character varying(2),
+    sec_bank_depository_zip character varying(10),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    cmte_email character varying(90),
+    cmte_web_url character varying(90),
+    receipt_dt date,
+    filing_freq character varying(1),
+    cmte_dsgn character varying(1),
+    qual_dt date,
+    cmte_fax character varying(12),
+    efiling_cmte_tp character varying(1),
+    rpt_yr numeric(4,0),
+    leadership_pac character varying(1),
+    affiliated_relationship_cd character varying(3),
+    cmte_email_chg_flg character varying(1),
+    cmte_url_chg_flg character varying(1),
+    lobbyist_registrant_pac character varying(1),
+    affiliated_cand_id character varying(9),
+    affiliated_cand_l_nm character varying(30),
+    affiliated_cand_f_nm character varying(20),
+    affiliated_cand_m_nm character varying(20),
+    affiliated_cand_prefix character varying(10),
+    affiliated_cand_suffix character varying(10),
+    cand_l_nm character varying(30),
+    cand_f_nm character varying(20),
+    cand_m_nm character varying(20),
+    cand_prefix character varying(10),
+    cand_suffix character varying(10),
+    cust_rec_l_nm character varying(30),
+    cust_rec_f_nm character varying(20),
+    cust_rec_m_nm character varying(20),
+    cust_rec_prefix character varying(10),
+    cust_rec_suffix character varying(10),
+    tres_l_nm character varying(30),
+    tres_f_nm character varying(20),
+    tres_m_nm character varying(20),
+    tres_prefix character varying(10),
+    tres_suffix character varying(10),
+    designated_agent_l_nm character varying(30),
+    designated_agent_f_nm character varying(20),
+    designated_agent_m_nm character varying(20),
+    designated_agent_prefix character varying(10),
+    designated_agent_suffix character varying(10),
+    f3l_filing_freq character varying(1),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_1');
+
+
+
+
+--
+-- Name: form_10; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_10 (
+    form_10_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    cand_nm character varying(38),
+    cand_id character varying(9),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    cmte_nm character varying(90),
+    st1 character varying(34),
+    st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    prev_exp_agg numeric(14,2),
+    exp_ttl_this_rpt numeric(14,2),
+    exp_ttl_cycl_to_dt numeric(14,2),
+    cand_sign_nm character varying(38),
+    sign_dt date,
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    form_tp_desc character varying(90),
+    cand_office_desc character varying(20),
+    cand_office_st_desc character varying(20),
+    cmte_st_desc character varying(20),
+    image_tp character varying(10),
+    last_update_dt date,
+    amndt_ind character varying(1),
+    receipt_dt date,
+    form_6_chk character varying(1),
+    contbr_employer character varying(38),
+    contbr_occupation character varying(38),
+    rpt_yr numeric(4,0),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_10');
+
+
+
+
+--
+-- Name: form_11; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_11 (
+    form_11_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    cand_nm character varying(38),
+    cand_id character varying(9),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    oppos_cand_nm character varying(38),
+    oppos_cmte_nm character varying(90),
+    oppos_cmte_id character varying(9),
+    oppos_cmte_st1 character varying(34),
+    oppos_cmte_st2 character varying(34),
+    oppos_cmte_city character varying(18),
+    oppos_cmte_st character varying(2),
+    oppos_cmte_zip character varying(9),
+    form_10_recpt_dt date,
+    oppos_pers_fund_amt numeric(14,2),
+    election_tp character varying(5),
+    fec_election_tp_desc character varying(20),
+    reg_special_elect_tp character varying(1),
+    cand_tres_sign_nm character varying(38),
+    cand_tres_sign_dt date,
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    amndt_ind character varying(1),
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    cand_last_name character varying(30),
+    cand_first_name character varying(20),
+    cand_middle_name character varying(20),
+    cand_prefix character varying(10),
+    cand_suffix character varying(10),
+    oppos_cand_last_name character varying(30),
+    oppos_cand_first_name character varying(20),
+    oppos_cand_middle_name character varying(20),
+    oppos_cand_prefix character varying(10),
+    oppos_cand_suffix character varying(10),
+    cand_tres_last_name character varying(30),
+    cand_tres_first_name character varying(20),
+    cand_tres_middle_name character varying(20),
+    cand_tres_prefix character varying(10),
+    cand_tres_suffix character varying(10),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_11');
+
+
+
+
+--
+-- Name: form_12; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_12 (
+    form_12_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    cand_nm character varying(38),
+    cand_id character varying(9),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    cmte_nm character varying(90),
+    st1 character varying(34),
+    st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    election_tp character varying(5),
+    reg_special_elect_tp character varying(1),
+    fec_election_tp_desc character varying(20),
+    hse_date_reached_100 date,
+    hse_pers_funds_amt numeric(14,2),
+    hse_form_11_prev_dt date,
+    sen_date_reached_110 date,
+    sen_pers_funds_amt numeric(14,2),
+    sen_form_11_prev_dt date,
+    cand_tres_sign_nm character varying(38),
+    cand_tres_sign_dt date,
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    amndt_ind character varying(1),
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    cand_last_name character varying(30),
+    cand_first_name character varying(20),
+    cand_middle_name character varying(20),
+    cand_prefix character varying(10),
+    cand_suffix character varying(10),
+    cand_tres_last_name character varying(30),
+    cand_tres_first_name character varying(20),
+    cand_tres_middle_name character varying(20),
+    cand_tres_prefix character varying(10),
+    cand_tres_suffix character varying(10),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_12');
+
+
+
+
+--
+-- Name: form_13; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_13 (
+    form_13_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_addr_chg_flg character varying(1),
+    cmte_tp character varying(1),
+    rpt_tp character varying(3),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    ttl_dons_accepted numeric(14,2),
+    ttl_dons_refunded numeric(14,2),
+    net_dons numeric(14,2),
+    desig_officer_last_nm character varying(30),
+    desig_officer_first_nm character varying(20),
+    desig_officer_middle_nm character varying(20),
+    desig_officer_prefix character varying(10),
+    desig_officer_suffix character varying(10),
+    desig_officer_nm character varying(38),
+    receipt_dt date,
+    signature_dt date,
+    rpt_yr numeric(4,0),
+    original_report_dt date,
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_13');
+
+
+
+
+--
+-- Name: form_1m; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_1m (
+    form_1m_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_tp character varying(1),
+    affiliation_dt date,
+    affiliated_cmte_id character varying(9),
+    affiliated_cmte_nm character varying(200),
+    fst_cand_id character varying(9),
+    fst_cand_nm character varying(90),
+    fst_cand_office character varying(1),
+    fst_cand_office_st character varying(2),
+    fst_cand_office_district character varying(2),
+    fst_cand_contb_dt date,
+    sec_cand_id character varying(9),
+    sec_cand_nm character varying(90),
+    sec_cand_office character varying(1),
+    sec_cand_office_st character varying(2),
+    sec_cand_office_district character varying(2),
+    sec_cand_contb_dt date,
+    trd_cand_id character varying(9),
+    trd_cand_nm character varying(90),
+    trd_cand_office character varying(1),
+    trd_cand_office_st character varying(2),
+    trd_cand_office_district character varying(2),
+    trd_cand_contb_dt date,
+    frth_cand_id character varying(9),
+    frth_cand_nm character varying(90),
+    frth_cand_office character varying(1),
+    frth_cand_office_st character varying(2),
+    frth_cand_office_district character varying(2),
+    frth_cand_contb_dt date,
+    fith_cand_id character varying(9),
+    fith_cand_nm character varying(90),
+    fith_cand_office character varying(1),
+    fith_cand_office_st character varying(2),
+    fith_cand_office_district character varying(2),
+    fith_cand_contb_dt date,
+    fiftyfirst_cand_contbr_dt date,
+    orig_registration_dt date,
+    qual_dt date,
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_1m');
+
+
+
+
+--
+-- Name: form_1s; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_1s (
+    form_1s_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    affiliated_cmte_id character varying(9),
+    affiliated_cmte_nm character varying(200),
+    affiliated_cmte_st1 character varying(34),
+    affiliated_cmte_st2 character varying(34),
+    affiliated_cmte_city character varying(30),
+    affiliated_cmte_st character varying(2),
+    affiliated_cmte_zip character varying(9),
+    cmte_rltshp character varying(38),
+    org_tp character varying(1),
+    designated_agent_nm character varying(200),
+    designated_agent_st1 character varying(34),
+    designated_agent_st2 character varying(34),
+    designated_agent_city character varying(30),
+    designated_agent_st character varying(2),
+    designated_agent_zip character varying(9),
+    designated_agent_title character varying(20),
+    designated_agent_ph_num character varying(10),
+    bank_depository_nm character varying(200),
+    bank_depository_st1 character varying(34),
+    bank_depository_st2 character varying(34),
+    bank_depository_city character varying(30),
+    bank_depository_st character varying(2),
+    bank_depository_zip character varying(9),
+    receipt_dt date,
+    joint_cmte_nm character varying(90),
+    joint_cmte_id character varying(9),
+    affiliated_relationship_cd character varying(3),
+    affiliated_cand_id character varying(9),
+    affiliated_cand_l_nm character varying(30),
+    affiliated_cand_f_nm character varying(20),
+    affiliated_cand_m_nm character varying(20),
+    affiliated_cand_prefix character varying(10),
+    affiliated_cand_suffix character varying(10),
+    designated_agent_l_nm character varying(30),
+    designated_agent_f_nm character varying(20),
+    designated_agent_m_nm character varying(20),
+    designated_agent_prefix character varying(10),
+    designated_agent_suffix character varying(10),
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_1s');
+
+
+
+
+--
+-- Name: form_2; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_2 (
+    form_2_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cand_id character varying(9),
+    cand_nm character varying(90),
+    cand_st1 character varying(34),
+    cand_st2 character varying(34),
+    cand_city character varying(30),
+    cand_st character varying(2),
+    cand_zip character varying(9),
+    addr_chg_flg character varying(1),
+    cand_pty_affiliation character varying(3),
+    cand_pty_affiliation_2 character varying(3),
+    cand_pty_affiliation_3 character varying(3),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    election_yr numeric(4,0),
+    pcc_cmte_id character varying(9),
+    pcc_cmte_nm character varying(200),
+    pcc_cmte_st1 character varying(34),
+    pcc_cmte_st2 character varying(34),
+    pcc_cmte_city character varying(30),
+    pcc_cmte_st character varying(2),
+    pcc_cmte_zip character varying(9),
+    addl_auth_cmte_id character varying(9),
+    addl_auth_cmte_nm character varying(200),
+    addl_auth_cmte_st1 character varying(34),
+    addl_auth_cmte_st2 character varying(34),
+    addl_auth_cmte_city character varying(18),
+    addl_auth_cmte_st character varying(2),
+    addl_auth_cmte_zip character varying(9),
+    cand_sign_nm character varying(90),
+    cand_sign_dt date,
+    receipt_dt date,
+    party_cd character varying(1),
+    cand_ici character varying(1),
+    cand_status character varying(1),
+    prim_pers_funds_decl numeric(14,2),
+    gen_pers_funds_decl numeric(14,2),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_2');
+
+
+
+
+--
+-- Name: form_24; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_24 (
+    form_24_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_tp character varying(3),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_24');
+
+
+
+
+--
+-- Name: form_2s; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_2s (
+    form_2s_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cand_id character varying(9),
+    auth_cmte_id character varying(9),
+    auth_cmte_nm character varying(90),
+    auth_cmte_st1 character varying(34),
+    auth_cmte_st2 character varying(34),
+    auth_cmte_city character varying(18),
+    auth_cmte_st character varying(2),
+    auth_cmte_zip character varying(9),
+    receipt_dt date,
+    amndt_ind character varying(1),
+    begin_image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_2s');
+
+
+
+
+--
+-- Name: form_3; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_3 (
+    form_3_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_addr_chg_flg character varying(1),
+    cmte_election_st character varying(2),
+    cmte_election_district character varying(2),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_dt date,
+    election_st character varying(2),
+    primary_election character varying(1),
+    general_election character varying(1),
+    special_election character varying(1),
+    runoff_election character varying(1),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    ttl_contb_per numeric(14,2),
+    ttl_contb_ref_per numeric(14,2),
+    net_contb_per numeric(14,2),
+    ttl_op_exp_per numeric(14,2),
+    ttl_offsets_to_op_exp_per numeric(14,2),
+    net_op_exp_per numeric(14,2),
+    coh_cop_i numeric(14,2),
+    debts_owed_to_cmte numeric(14,2),
+    debts_owed_by_cmte numeric(14,2),
+    indv_item_contb_per numeric(14,2),
+    indv_unitem_contb_per numeric(14,2),
+    ttl_indv_contb_per numeric(14,2),
+    pol_pty_cmte_contb_per numeric(14,2),
+    other_pol_cmte_contb_per numeric(14,2),
+    cand_contb_per numeric(14,2),
+    ttl_contb_column_ttl_per numeric(14,2),
+    tranf_from_other_auth_cmte_per numeric(14,2),
+    loans_made_by_cand_per numeric(14,2),
+    all_other_loans_per numeric(14,2),
+    ttl_loans_per numeric(14,2),
+    offsets_to_op_exp_per numeric(14,2),
+    other_receipts_per numeric(14,2),
+    ttl_receipts_per_i numeric(14,2),
+    op_exp_per numeric(14,2),
+    tranf_to_other_auth_cmte_per numeric(14,2),
+    loan_repymts_cand_loans_per numeric(14,2),
+    loan_repymts_other_loans_per numeric(14,2),
+    ttl_loan_repymts_per numeric(14,2),
+    ref_indv_contb_per numeric(14,2),
+    ref_pol_pty_cmte_contb_per numeric(14,2),
+    ref_other_pol_cmte_contb_per numeric(14,2),
+    ttl_contb_ref_col_ttl_per numeric(14,2),
+    other_disb_per numeric(14,2),
+    ttl_disb_per_i numeric(14,2),
+    coh_bop numeric(14,2),
+    ttl_receipts_ii numeric(14,2),
+    subttl_per numeric(14,2),
+    ttl_disb_per_ii numeric(14,2),
+    coh_cop_ii numeric(14,2),
+    ttl_contb_ytd numeric(14,2),
+    ttl_contb_ref_ytd numeric(14,2),
+    net_contb_ytd numeric(14,2),
+    ttl_op_exp_ytd numeric(14,2),
+    ttl_offsets_to_op_exp_ytd numeric(14,2),
+    net_op_exp_ytd numeric(14,2),
+    ttl_indv_item_contb_ytd numeric(14,2),
+    ttl_indv_unitem_contb_ytd numeric(14,2),
+    ttl_indv_contb_ytd numeric(14,2),
+    pol_pty_cmte_contb_ytd numeric(14,2),
+    other_pol_cmte_contb_ytd numeric(14,2),
+    cand_contb_ytd numeric(14,2),
+    ttl_contb_col_ttl_ytd numeric(14,2),
+    tranf_from_other_auth_cmte_ytd numeric(14,2),
+    loans_made_by_cand_ytd numeric(14,2),
+    all_other_loans_ytd numeric(14,2),
+    ttl_loans_ytd numeric(14,2),
+    offsets_to_op_exp_ytd numeric(14,2),
+    other_receipts_ytd numeric(14,2),
+    ttl_receipts_ytd numeric(14,2),
+    op_exp_ytd numeric(14,2),
+    tranf_to_other_auth_cmte_ytd numeric(14,2),
+    loan_repymts_cand_loans_ytd numeric(14,2),
+    loan_repymts_other_loans_ytd numeric(14,2),
+    ttl_loan_repymts_ytd numeric(14,2),
+    ref_indv_contb_ytd numeric(14,2),
+    ref_pol_pty_cmte_contb_ytd numeric(14,2),
+    ref_other_pol_cmte_contb_ytd numeric(14,2),
+    ref_ttl_contb_col_ttl_ytd numeric(14,2),
+    other_disb_ytd numeric(14,2),
+    ttl_disb_ytd numeric(14,2),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    grs_rcpt_auth_cmte_prim numeric(14,2),
+    agr_amt_contrib_pers_fund_prim numeric(14,2),
+    grs_rcpt_min_pers_contrib_prim numeric(14,2),
+    grs_rcpt_auth_cmte_gen numeric(14,2),
+    agr_amt_pers_contrib_gen numeric(14,2),
+    grs_rcpt_min_pers_contrib_gen numeric(14,2),
+    cand_id character varying(9),
+    cand_nm character varying(38),
+    f3z1_rpt_tp character varying(3),
+    f3z1_rpt_tp_desc character varying(30),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_3');
+
+
+
+
+--
+-- Name: form_3l; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_3l (
+    form_3l_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(28),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_addr_chg_flg character varying(1),
+    cmte_election_st character varying(2),
+    cmte_election_district character varying(2),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_dt date,
+    election_st character varying(2),
+    semi_an_per_5c_5d character varying(1),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    semi_an_jan_jun_6b character varying(1),
+    semi_an_jul_dec_6b character varying(1),
+    qtr_mon_bundled_contb numeric(14,2),
+    semi_an_bundled_contb numeric(14,2),
+    tres_l_nm character varying(30),
+    tres_f_nm character varying(20),
+    tres_m_nm character varying(20),
+    tres_prefix character varying(10),
+    tres_suffix character varying(10),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_31');
+
+
+
+
+--
+-- Name: form_3p; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_3p (
+    form_3p_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    addr_chg_flg character varying(1),
+    activity_primary character varying(1),
+    activity_general character varying(1),
+    term_rpt_flag character varying(1),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_dt date,
+    election_st character varying(2),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    coh_bop numeric(14,2),
+    ttl_receipts_sum_page_per numeric(14,2),
+    subttl_sum_page_per numeric(14,2),
+    ttl_disb_sum_page_per numeric(14,2),
+    coh_cop numeric(14,2),
+    debts_owed_to_cmte numeric(14,2),
+    debts_owed_by_cmte numeric(14,2),
+    exp_subject_limits numeric(14,2),
+    net_contb_sum_page_per numeric(14,2),
+    net_op_exp_sum_page_per numeric(14,2),
+    fed_funds_per numeric(14,2),
+    indv_contb_per numeric(14,2),
+    pol_pty_cmte_contb_per numeric(14,2),
+    other_pol_cmte_contb_per numeric(14,2),
+    cand_contb_per numeric(14,2),
+    ttl_contb_per numeric(14,2),
+    tranf_from_affilated_cmte_per numeric(14,2),
+    loans_received_from_cand_per numeric(14,2),
+    other_loans_received_per numeric(14,2),
+    ttl_loans_received_per numeric(14,2),
+    offsets_to_op_exp_per numeric(14,2),
+    offsets_to_fndrsg_exp_per numeric(14,2),
+    offsets_to_legal_acctg_per numeric(14,2),
+    ttl_offsets_to_op_exp_per numeric(14,2),
+    other_receipts_per numeric(14,2),
+    ttl_receipts_per numeric(14,2),
+    op_exp_per numeric(14,2),
+    tranf_to_other_auth_cmte_per numeric(14,2),
+    fndrsg_disb_per numeric(14,2),
+    exempt_legal_acctg_disb_per numeric(14,2),
+    repymts_loans_made_by_cand_per numeric(14,2),
+    repymts_other_loans_per numeric(14,2),
+    ttl_loan_repymts_made_per numeric(14,2),
+    ref_indv_contb_per numeric(14,2),
+    ref_pol_pty_cmte_contb_per numeric(14,2),
+    ref_other_pol_cmte_contb_per numeric(14,2),
+    ttl_contb_ref_per numeric(14,2),
+    other_disb_per numeric(14,2),
+    ttl_disb_per numeric(14,2),
+    items_on_hand_liquidated numeric(14,2),
+    alabama_per numeric(14,2),
+    alaska_per numeric(14,2),
+    arizona_per numeric(14,2),
+    arkansas_per numeric(14,2),
+    california_per numeric(14,2),
+    colorado_per numeric(14,2),
+    connecticut_per numeric(14,2),
+    delaware_per numeric(14,2),
+    district_columbia_per numeric(14,2),
+    florida_per numeric(14,2),
+    georgia_per numeric(14,2),
+    hawaii_per numeric(14,2),
+    idaho_per numeric(14,2),
+    illinois_per numeric(14,2),
+    indiana_per numeric(14,2),
+    iowa_per numeric(14,2),
+    kansas_per numeric(14,2),
+    kentucky_per numeric(14,2),
+    louisiana_per numeric(14,2),
+    maine_per numeric(14,2),
+    maryland_per numeric(14,2),
+    massachusetts_per numeric(14,2),
+    michigan_per numeric(14,2),
+    minnesota_per numeric(14,2),
+    mississippi_per numeric(14,2),
+    missouri_per numeric(14,2),
+    montana_per numeric(14,2),
+    nebraska_per numeric(14,2),
+    nevada_per numeric(14,2),
+    new_hampshire_per numeric(14,2),
+    new_jersey_per numeric(14,2),
+    new_mexico_per numeric(14,2),
+    new_york_per numeric(14,2),
+    north_carolina_per numeric(14,2),
+    north_dakota_per numeric(14,2),
+    ohio_per numeric(14,2),
+    oklahoma_per numeric(14,2),
+    oregon_per numeric(14,2),
+    pennsylvania_per numeric(14,2),
+    rhode_island_per numeric(14,2),
+    south_carolina_per numeric(14,2),
+    south_dakota_per numeric(14,2),
+    tennessee_per numeric(14,2),
+    texas_per numeric(14,2),
+    utah_per numeric(14,2),
+    vermont_per numeric(14,2),
+    virginia_per numeric(14,2),
+    washington_per numeric(14,2),
+    west_virginia_per numeric(14,2),
+    wisconsin_per numeric(14,2),
+    wyoming_per numeric(14,2),
+    puerto_rico_per numeric(14,2),
+    guam_per numeric(14,2),
+    virgin_islands_per numeric(14,2),
+    ttl_per numeric(14,2),
+    fed_funds_ytd numeric(14,2),
+    indv_contb_ytd numeric(14,2),
+    pol_pty_cmte_contb_ytd numeric(14,2),
+    other_pol_cmte_contb_ytd numeric(14,2),
+    cand_contb_ytd numeric(14,2),
+    ttl_contb_ytd numeric(14,2),
+    tranf_from_affiliated_cmte_ytd numeric(14,2),
+    loans_received_from_cand_ytd numeric(14,2),
+    other_loans_received_ytd numeric(14,2),
+    ttl_loans_received_ytd numeric(14,2),
+    offsets_to_op_exp_ytd numeric(14,2),
+    offsets_to_fndrsg_exp_ytd numeric(14,2),
+    offsets_to_legal_acctg_ytd numeric(14,2),
+    ttl_offsets_to_op_exp_ytd numeric(14,2),
+    other_receipts_ytd numeric(14,2),
+    ttl_receipts_ytd numeric(14,2),
+    op_exp_ytd numeric(14,2),
+    tranf_to_other_auth_cmte_ytd numeric(14,2),
+    fndrsg_disb_ytd numeric(14,2),
+    exempt_legal_acctg_disb_ytd numeric(14,2),
+    repymts_loans_made_cand_ytd numeric(14,2),
+    repymts_other_loans_ytd numeric(14,2),
+    ttl_loan_repymts_made_ytd numeric(14,2),
+    ref_indv_contb_ytd numeric(14,2),
+    ref_pol_pty_cmte_contb_ytd numeric(14,2),
+    ref_other_pol_cmte_contb_ytd numeric(14,2),
+    ttl_contb_ref_ytd numeric(14,2),
+    other_disb_ytd numeric(14,2),
+    ttl_disb_ytd numeric(14,2),
+    alabama_ytd numeric(14,2),
+    alaska_ytd numeric(14,2),
+    arizona_ytd numeric(14,2),
+    arkansas_ytd numeric(14,2),
+    california_ytd numeric(14,2),
+    colorado_ytd numeric(14,2),
+    connecticut_ytd numeric(14,2),
+    delaware_ytd numeric(14,2),
+    district_columbia_ytd numeric(14,2),
+    florida_ytd numeric(14,2),
+    georgia_ytd numeric(14,2),
+    hawaii_ytd numeric(14,2),
+    idaho_ytd numeric(14,2),
+    illinois_ytd numeric(14,2),
+    indiana_ytd numeric(14,2),
+    iowa_ytd numeric(14,2),
+    kansas_ytd numeric(14,2),
+    kentucky_ytd numeric(14,2),
+    louisiana_ytd numeric(14,2),
+    maine_ytd numeric(14,2),
+    maryland_ytd numeric(14,2),
+    massachusetts_ytd numeric(14,2),
+    michigan_ytd numeric(14,2),
+    minnesota_ytd numeric(14,2),
+    mississippi_ytd numeric(14,2),
+    missouri_ytd numeric(14,2),
+    montana_ytd numeric(14,2),
+    nebraska_ytd numeric(14,2),
+    nevada_ytd numeric(14,2),
+    new_hampshire_ytd numeric(14,2),
+    new_jersey_ytd numeric(14,2),
+    new_mexico_ytd numeric(14,2),
+    new_york_ytd numeric(14,2),
+    north_carolina_ytd numeric(14,2),
+    north_dakota_ytd numeric(14,2),
+    ohio_ytd numeric(14,2),
+    oklahoma_ytd numeric(14,2),
+    oregon_ytd numeric(14,2),
+    pennsylvania_ytd numeric(14,2),
+    rhode_island_ytd numeric(14,2),
+    south_carolina_ytd numeric(14,2),
+    south_dakota_ytd numeric(14,2),
+    tennessee_ytd numeric(14,2),
+    texas_ytd numeric(14,2),
+    utah_ytd numeric(14,2),
+    vermont_ytd numeric(14,2),
+    virginia_ytd numeric(14,2),
+    washington_ytd numeric(14,2),
+    west_virginia_ytd numeric(14,2),
+    wisconsin_ytd numeric(14,2),
+    wyoming_ytd numeric(14,2),
+    puerto_rico_ytd numeric(14,2),
+    guam_ytd numeric(14,2),
+    virgin_islands_ytd numeric(14,2),
+    ttl_ytd numeric(14,2),
+    tres_sign_nm character varying(38),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_3p');
+
+
+
+
+--
+-- Name: form_3p_line_31s; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_3p_line_31s (
+    form_3p31s_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    entity_tp character varying(3),
+    contbr_lender_nm character varying(90),
+    contbr_lender_st1 character varying(34),
+    contbr_lender_st2 character varying(34),
+    contbr_lender_city character varying(18),
+    contbr_lender_st character varying(2),
+    contbr_lender_zip character varying(9),
+    rpt_pgi character varying(5),
+    contbr_lender_employer character varying(38),
+    contbr_lender_occupation character varying(38),
+    contb_dt date,
+    fair_mkt_value_of_item numeric(14,2),
+    tran_code character varying(3),
+    tran_desc character varying(100),
+    cand_id character varying(9),
+    cand_nm character varying(38),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    conduit_cmte_id character varying(9),
+    conduit_cmte_nm character varying(90),
+    conduit_cmte_st1 character varying(34),
+    conduit_cmte_st2 character varying(34),
+    conduit_cmte_city character varying(18),
+    conduit_cmte_st character varying(2),
+    conduit_cmte_zip character varying(9),
+    memo_flag character varying(1),
+    memo_text character varying(100),
+    amndt_ind character varying(1),
+    tran_id character varying(32),
+    receipt_dt date,
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_3p_line_31s');
+
+
+
+
+--
+-- Name: form_3ps; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_3ps (
+    form_3ps_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    alabama numeric(14,2),
+    alaska numeric(14,2),
+    arizona numeric(14,2),
+    arkansas numeric(14,2),
+    california numeric(14,2),
+    colorado numeric(14,2),
+    connecticut numeric(14,2),
+    delaware numeric(14,2),
+    district_columbia numeric(14,2),
+    florida numeric(14,2),
+    georgia numeric(14,2),
+    hawaii numeric(14,2),
+    idaho numeric(14,2),
+    illinois numeric(14,2),
+    indiana numeric(14,2),
+    iowa numeric(14,2),
+    kansas numeric(14,2),
+    kentucky numeric(14,2),
+    louisiana numeric(14,2),
+    maine numeric(14,2),
+    maryland numeric(14,2),
+    massachusetts numeric(14,2),
+    michigan numeric(14,2),
+    minnesota numeric(14,2),
+    mississippi numeric(14,2),
+    missouri numeric(14,2),
+    montana numeric(14,2),
+    nebraska numeric(14,2),
+    nevada numeric(14,2),
+    new_hampshire numeric(14,2),
+    new_jersey numeric(14,2),
+    new_mexico numeric(14,2),
+    new_york numeric(14,2),
+    north_carolina numeric(14,2),
+    north_dakota numeric(14,2),
+    ohio numeric(14,2),
+    oklahoma numeric(14,2),
+    oregon numeric(14,2),
+    pennsylvania numeric(14,2),
+    rhode_island numeric(14,2),
+    south_carolina numeric(14,2),
+    south_dakota numeric(14,2),
+    tennessee numeric(14,2),
+    texas numeric(14,2),
+    utah numeric(14,2),
+    vermont numeric(14,2),
+    virginia numeric(14,2),
+    washington numeric(14,2),
+    west_virginia numeric(14,2),
+    wisconsin numeric(14,2),
+    wyoming numeric(14,2),
+    puerto_rico numeric(14,2),
+    guam numeric(14,2),
+    virgin_islands numeric(14,2),
+    ttl numeric(14,2),
+    election_dt date,
+    day_after_election_dt date,
+    net_contb numeric(14,2),
+    net_exp numeric(14,2),
+    fed_funds numeric(14,2),
+    indv_contb_other_loans numeric(14,2),
+    pol_pty_cmte_contb_other_loans numeric(14,2),
+    pac_contb_other_loans numeric(14,2),
+    cand_contb_other_loans numeric(14,2),
+    ttl_contb_other_loans numeric(14,2),
+    tranf_from_affiliated_cmte numeric(14,2),
+    loans_received_from_cand numeric(14,2),
+    other_loans_received numeric(14,2),
+    ttl_loans numeric(14,2),
+    op_exp numeric(14,2),
+    fndrsg_exp numeric(14,2),
+    legal_and_acctg_exp numeric(14,2),
+    ttl_offsets_to_op_exp numeric(14,2),
+    other_receipts numeric(14,2),
+    ttl_receipts numeric(14,2),
+    op_exp2 numeric(14,2),
+    tranf_to_other_auth_cmte numeric(14,2),
+    fndrsg_disb numeric(14,2),
+    exempt_legal_and_acctg_disb numeric(14,2),
+    loan_repymts_made_by_cand numeric(14,2),
+    other_repymts numeric(14,2),
+    ttl_loan_repymts_made numeric(14,2),
+    ref_indv_contb numeric(14,2),
+    ref_pol_pty_contb numeric(14,2),
+    ref_other_pol_cmte_contb numeric(14,2),
+    ttl_contb_ref numeric(14,2),
+    other_disb numeric(14,2),
+    ttl_disb numeric(14,2),
+    receipt_dt date,
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_3ps');
+
+
+
+
+--
+-- Name: form_3s; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_3s (
+    form_3s_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    ttl_contb numeric(14,2),
+    ttl_contb_ref numeric(14,2),
+    net_contb numeric(14,2),
+    ttl_op_exp numeric(14,2),
+    ttl_offsets_to_op_exp numeric(14,2),
+    net_op_exp numeric(14,2),
+    indv_item_contb numeric(14,2),
+    indv_unitem_contb numeric(14,2),
+    ttl_indv_contb numeric(14,2),
+    pol_pty_cmte_contb numeric(14,2),
+    other_pol_cmte_contb numeric(14,2),
+    cand_contb numeric(14,2),
+    ttl_contb_column_ttl numeric(14,2),
+    tranf_from_other_auth_cmte numeric(14,2),
+    loans_made_by_cand numeric(14,2),
+    all_other_loans numeric(14,2),
+    ttl_loans numeric(14,2),
+    offsets_to_op_exp numeric(14,2),
+    other_receipts numeric(14,2),
+    ttl_receipts numeric(14,2),
+    op_exp numeric(14,2),
+    tranf_to_other_auth_cmte numeric(14,2),
+    loan_repymts_cand_loans numeric(14,2),
+    loan_repymts_other_loans numeric(14,2),
+    ttl_loan_repymts numeric(14,2),
+    ref_indv_contb numeric(14,2),
+    ref_pol_pty_cmte_contb numeric(14,2),
+    ref_other_pol_cmte_contb numeric(14,2),
+    ttl_contb_ref_col_ttl numeric(14,2),
+    other_disb numeric(14,2),
+    ttl_disb numeric(14,2),
+    election_dt date,
+    day_after_election_dt date,
+    receipt_dt date,
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_3s');
+
+
+
+
+--
+-- Name: form_3x; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_3x (
+    form_3x_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_addr_chg_flg character varying(1),
+    qual_cmte_flg character varying(1),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_dt date,
+    election_st character varying(2),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    coh_bop numeric(14,2),
+    ttl_receipts_sum_page_per numeric(14,2),
+    subttl_sum_page_per numeric(14,2),
+    ttl_disb_sum_page_per numeric(14,2),
+    coh_cop numeric(14,2),
+    debts_owed_to_cmte numeric(14,2),
+    debts_owed_by_cmte numeric(14,2),
+    indv_item_contb_per numeric(14,2),
+    indv_unitem_contb_per numeric(14,2),
+    ttl_indv_contb numeric(14,2),
+    pol_pty_cmte_contb_per_i numeric(14,2),
+    other_pol_cmte_contb_per_i numeric(14,2),
+    ttl_contb_col_ttl_per numeric(14,2),
+    tranf_from_affiliated_pty_per numeric(14,2),
+    all_loans_received_per numeric(14,2),
+    loan_repymts_received_per numeric(14,2),
+    offsets_to_op_exp_per_i numeric(14,2),
+    fed_cand_contb_ref_per numeric(14,2),
+    other_fed_receipts_per numeric(14,2),
+    tranf_from_nonfed_acct_per numeric(14,2),
+    ttl_receipts_per numeric(14,2),
+    ttl_fed_receipts_per numeric(14,2),
+    shared_fed_op_exp_per numeric(14,2),
+    shared_nonfed_op_exp_per numeric(14,2),
+    other_fed_op_exp_per numeric(14,2),
+    ttl_op_exp_per numeric(14,2),
+    tranf_to_affliliated_cmte_per numeric(14,2),
+    fed_cand_cmte_contb_per numeric(14,2),
+    indt_exp_per numeric(14,2),
+    coord_exp_by_pty_cmte_per numeric(14,2),
+    loan_repymts_made_per numeric(14,2),
+    loans_made_per numeric(14,2),
+    indv_contb_ref_per numeric(14,2),
+    pol_pty_cmte_contb_per_ii numeric(14,2),
+    other_pol_cmte_contb_per_ii numeric(14,2),
+    ttl_contb_ref_per_i numeric(14,2),
+    other_disb_per numeric(14,2),
+    ttl_disb_per numeric(14,2),
+    ttl_fed_disb_per numeric(14,2),
+    ttl_contb_per numeric(14,2),
+    ttl_contb_ref_per_ii numeric(14,2),
+    net_contb_per numeric(14,2),
+    ttl_fed_op_exp_per numeric(14,2),
+    offsets_to_op_exp_per_ii numeric(14,2),
+    net_op_exp_per numeric(14,2),
+    coh_begin_calendar_yr numeric(14,2),
+    calendar_yr numeric(4,0),
+    ttl_receipts_sum_page_ytd numeric(14,2),
+    subttl_sum_ytd numeric(14,2),
+    ttl_disb_sum_page_ytd numeric(14,2),
+    coh_coy numeric(14,2),
+    indv_item_contb_ytd numeric(14,2),
+    indv_unitem_contb_ytd numeric(14,2),
+    ttl_indv_contb_ytd numeric(14,2),
+    pol_pty_cmte_contb_ytd_i numeric(14,2),
+    other_pol_cmte_contb_ytd_i numeric(14,2),
+    ttl_contb_col_ttl_ytd numeric(14,2),
+    tranf_from_affiliated_pty_ytd numeric(14,2),
+    all_loans_received_ytd numeric(14,2),
+    loan_repymts_received_ytd numeric(14,2),
+    offsets_to_op_exp_ytd_i numeric(14,2),
+    fed_cand_cmte_contb_ytd numeric(14,2),
+    other_fed_receipts_ytd numeric(14,2),
+    tranf_from_nonfed_acct_ytd numeric(14,2),
+    ttl_receipts_ytd numeric(14,2),
+    ttl_fed_receipts_ytd numeric(14,2),
+    shared_fed_op_exp_ytd numeric(14,2),
+    shared_nonfed_op_exp_ytd numeric(14,2),
+    other_fed_op_exp_ytd numeric(14,2),
+    ttl_op_exp_ytd numeric(14,2),
+    tranf_to_affilitated_cmte_ytd numeric(14,2),
+    fed_cand_cmte_contb_ref_ytd numeric(14,2),
+    indt_exp_ytd numeric(14,2),
+    coord_exp_by_pty_cmte_ytd numeric(14,2),
+    loan_repymts_made_ytd numeric(14,2),
+    loans_made_ytd numeric(14,2),
+    indv_contb_ref_ytd numeric(14,2),
+    pol_pty_cmte_contb_ytd_ii numeric(14,2),
+    other_pol_cmte_contb_ytd_ii numeric(14,2),
+    ttl_contb_ref_ytd_i numeric(14,2),
+    other_disb_ytd numeric(14,2),
+    ttl_disb_ytd numeric(14,2),
+    ttl_fed_disb_ytd numeric(14,2),
+    ttl_contb_ytd numeric(14,2),
+    ttl_contb_ref_ytd_ii numeric(14,2),
+    net_contb_ytd numeric(14,2),
+    ttl_fed_op_exp_ytd numeric(14,2),
+    offsets_to_op_exp_ytd_ii numeric(14,2),
+    net_op_exp_ytd numeric(14,2),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    multicand_flg character varying(1),
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    tranf_from_nonfed_levin_per numeric(14,2),
+    ttl_nonfed_tranf_per numeric(14,2),
+    shared_fed_actvy_fed_shr_per numeric(14,2),
+    shared_fed_actvy_nonfed_per numeric(14,2),
+    non_alloc_fed_elect_actvy_per numeric(14,2),
+    ttl_fed_elect_actvy_per numeric(14,2),
+    tranf_from_nonfed_levin_ytd numeric(14,2),
+    ttl_nonfed_tranf_ytd numeric(14,2),
+    shared_fed_actvy_fed_shr_ytd numeric(14,2),
+    shared_fed_actvy_nonfed_ytd numeric(14,2),
+    non_alloc_fed_elect_actvy_ytd numeric(14,2),
+    ttl_fed_elect_actvy_ytd numeric(14,2),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_3x');
+
+
+
+
+--
+-- Name: form_3z; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_3z (
+    form_3z_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    pcc_id character varying(9),
+    pcc_nm character varying(90),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    auth_cmte_id character varying(9),
+    auth_cmte_nm character varying(90),
+    indv_contb numeric(14,2),
+    pol_pty_contb numeric(14,2),
+    other_pol_cmte_contb numeric(14,2),
+    cand_contb numeric(14,2),
+    ttl_contb numeric(14,2),
+    tranf_from_other_auth_cmte numeric(14,2),
+    loans_made_by_cand numeric(14,2),
+    all_other_loans numeric(14,2),
+    ttl_loans numeric(14,2),
+    offsets_to_op_exp numeric(14,2),
+    other_receipts numeric(14,2),
+    ttl_receipts numeric(14,2),
+    op_exp numeric(14,2),
+    tranf_to_other_auth_cmte numeric(14,2),
+    repymts_loans_made_cand numeric(14,2),
+    repymts_all_other_loans numeric(14,2),
+    ttl_loan_repymts numeric(14,2),
+    ref_indv_contb numeric(14,2),
+    ref_pol_pty_cmte_contb numeric(14,2),
+    ref_other_pol_cmte_contb numeric(14,2),
+    ttl_contb_ref numeric(14,2),
+    other_disb numeric(14,2),
+    ttl_disb numeric(14,2),
+    coh_bop numeric(14,2),
+    coh_cop numeric(14,2),
+    debts_owed_to_cmte numeric(14,2),
+    debts_owed_by_cmte numeric(14,2),
+    net_contb numeric(14,2),
+    net_op_exp numeric(14,2),
+    receipt_dt date,
+    image_num character varying(13),
+    sub_id numeric(19,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_3z');
+
+
+
+
+--
+-- Name: form_4; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_4 (
+    form_4_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    cmte_tp character varying(1),
+    cmte_desc character varying(40),
+    rpt_tp character varying(3),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    coh_bop numeric(14,2),
+    ttl_receipts_sum_page_per numeric(14,2),
+    subttl_sum_page_per numeric(14,2),
+    ttl_disb_sum_page_per numeric(14,2),
+    coh_cop numeric(14,2),
+    debts_owed_to_cmte_per numeric(14,2),
+    debts_owed_by_cmte_per numeric(14,2),
+    convn_exp_per numeric(14,2),
+    ref_reb_ret_convn_exp_per numeric(14,2),
+    exp_subject_limits_per numeric(14,2),
+    exp_prior_yrs_subject_lim_per numeric(14,2),
+    ttl_exp_subject_limits numeric(14,2),
+    fed_funds_per numeric(14,2),
+    item_convn_exp_contb_per numeric(14,2),
+    unitem_convn_exp_contb_per numeric(14,2),
+    subttl_convn_exp_contb_per numeric(14,2),
+    tranf_from_affiliated_cmte_per numeric(14,2),
+    loans_received_per numeric(14,2),
+    loan_repymts_received_per numeric(14,2),
+    subttl_loan_repymts_per numeric(14,2),
+    item_ref_reb_ret_per numeric(14,2),
+    unitem_ref_reb_ret_per numeric(14,2),
+    subttl_ref_reb_ret_per numeric(14,2),
+    item_other_ref_reb_ret_per numeric(14,2),
+    unitem_other_ref_reb_ret_per numeric(14,2),
+    subttl_other_ref_reb_ret_per numeric(14,2),
+    item_other_income_per numeric(14,2),
+    unitem_other_income_per numeric(14,2),
+    subttl_other_income_per numeric(14,2),
+    ttl_receipts_per numeric(14,2),
+    item_convn_exp_disb_per numeric(14,2),
+    unitem_convn_exp_disb_per numeric(14,2),
+    subttl_convn_exp_disb_per numeric(14,2),
+    tranf_to_affiliated_cmte_per numeric(14,2),
+    loans_made_per numeric(14,2),
+    loan_repymts_made_per numeric(14,2),
+    subttl_loan_repymts_disb_per numeric(14,2),
+    item_other_disb_per numeric(14,2),
+    unitem_other_disb_per numeric(14,2),
+    subttl_other_disb_per numeric(14,2),
+    ttl_disb_per numeric(14,2),
+    coh_begin_calendar_yr numeric(14,2),
+    calendar_yr numeric(4,0),
+    ttl_receipts_sum_page_ytd numeric(14,2),
+    subttl_sum_page_ytd numeric(14,2),
+    ttl_disb_sum_page_ytd numeric(14,2),
+    coh_coy numeric(14,2),
+    convn_exp_ytd numeric(14,2),
+    ref_reb_ret_convn_exp_ytd numeric(14,2),
+    exp_subject_limits_ytd numeric(14,2),
+    exp_prior_yrs_subject_lim_ytd numeric(14,2),
+    ttl_exp_subject_limits_ytd numeric(14,2),
+    fed_funds_ytd numeric(14,2),
+    subttl_convn_exp_contb_ytd numeric(14,2),
+    tranf_from_affiliated_cmte_ytd numeric(14,2),
+    subttl_loan_repymts_ytd numeric(14,2),
+    subttl_ref_reb_ret_deposit_ytd numeric(14,2),
+    subttl_other_ref_reb_ret_ytd numeric(14,2),
+    subttl_other_income_ytd numeric(14,2),
+    ttl_receipts_ytd numeric(14,2),
+    subttl_convn_exp_disb_ytd numeric(14,2),
+    tranf_to_affiliated_cmte_ytd numeric(14,2),
+    subttl_loan_repymts_disb_ytd numeric(14,2),
+    subttl_other_disb_ytd numeric(14,2),
+    ttl_disb_ytd numeric(14,2),
+    tres_sign_nm character varying(38),
+    tres_sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(11),
+    end_image_num character varying(11),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_4');
+
+
+
+
+--
+-- Name: form_5; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_5 (
+    form_5_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    amndt_ind character varying(1),
+    indv_org_id character varying(9),
+    indv_org_nm character varying(90),
+    indv_org_st1 character varying(34),
+    indv_org_st2 character varying(34),
+    indv_org_city character varying(18),
+    indv_org_st character varying(2),
+    indv_org_zip character varying(9),
+    addr_chg_flg character varying(1),
+    qual_nonprofit_corp_ind character varying(1),
+    indv_org_employer character varying(38),
+    indv_org_occupation character varying(38),
+    rpt_tp character varying(3),
+    rpt_pgi character varying(5),
+    election_tp character varying(2),
+    election_dt date,
+    election_st character varying(2),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    ttl_indt_contb numeric(14,2),
+    ttl_indt_exp numeric(14,2),
+    filer_nm character varying(38),
+    filer_sign_nm character varying(38),
+    filer_sign_dt date,
+    notary_sign_dt date,
+    notary_commission_exprtn_dt date,
+    notary_nm character varying(38),
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    entity_tp character varying(3),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_5');
+
+
+
+
+--
+-- Name: form_6; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_6 (
+    form_6_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    filer_cmte_id character varying(9),
+    filer_cmte_nm character varying(200),
+    filer_cmte_st1 character varying(34),
+    filer_cmte_st2 character varying(34),
+    filer_cmte_city character varying(30),
+    filer_cmte_st character varying(2),
+    filer_cmte_zip character varying(9),
+    cand_id character varying(9),
+    cand_nm character varying(90),
+    cand_office character varying(1),
+    cand_office_st character varying(2),
+    cand_office_district character varying(2),
+    sign_dt date,
+    receipt_dt date,
+    rpt_yr numeric(4,0),
+    signer_last_name character varying(30),
+    signer_first_name character varying(20),
+    signer_middle_name character varying(20),
+    signer_prefix character varying(10),
+    signer_suffix character varying(10),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_6');
+
+
+
+
+--
+-- Name: form_7; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_7 (
+    form_7_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    org_id character varying(9),
+    org_nm character varying(90),
+    org_st1 character varying(34),
+    org_st2 character varying(34),
+    org_city character varying(18),
+    org_st character varying(2),
+    org_zip character varying(9),
+    org_tp character varying(1),
+    rpt_tp character varying(3),
+    election_dt date,
+    election_st character varying(2),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    ttl_communication_cost numeric(14,2),
+    filer_sign_nm character varying(38),
+    filer_sign_dt date,
+    filer_title character varying(20),
+    receipt_dt date,
+    rpt_pgi character varying(1),
+    amndt_ind character varying(1),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_7');
+
+
+
+
+--
+-- Name: form_8; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_8 (
+    form_8_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(90),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(18),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    coh numeric(14,2),
+    calender_yr date,
+    ttl_liquidated_assets numeric(14,2),
+    ttl_assets numeric(14,2),
+    ytd_reciepts numeric(14,2),
+    ytd_disb numeric(14,2),
+    ttl_amt_debts_owed numeric(14,2),
+    ttl_num_cred_owed numeric(8,0),
+    ttl_num_cred_part2 numeric(8,0),
+    ttl_amt_debts_owed_part2 numeric(14,2),
+    ttl_amt_paid_cred numeric(14,2),
+    term_flg character varying(1),
+    term_dt_desc character varying(15),
+    addl_auth_cmte_flg character varying(1),
+    add_auth_cmte_desc character varying(300),
+    sufficient_amt_to_pay_ttl_flg character varying(1),
+    sufficient_amt_to_pay_desc character varying(100),
+    prev_debt_settlement_plan_flg character varying(1),
+    residual_funds_flg character varying(1),
+    residual_funds_desc character varying(100),
+    remaining_amt_flg character varying(1),
+    remaining_amt_desc character varying(100),
+    tres_sign_nm character varying(38),
+    tres_sign_dt date,
+    receipt_dt date,
+    amndt_ind character varying(1),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_8');
+
+
+
+
+--
+-- Name: form_9; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_9 (
+    form_9_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    ind_org_corp_nm character varying(90),
+    ind_org_corp_st1 character varying(34),
+    ind_org_corp_st2 character varying(34),
+    ind_org_corp_city character varying(18),
+    ind_org_corp_st character varying(2),
+    ind_org_corp_zip character varying(9),
+    addr_chg_flg character varying(1),
+    ind_org_corp_emp character varying(38),
+    ind_org_corp_occup character varying(38),
+    cvg_start_dt date,
+    cvg_end_dt date,
+    pub_distrib_dt date,
+    qual_nonprofit_flg character varying(18),
+    segr_bank_acct_flg character varying(1),
+    ind_custod_nm character varying(38),
+    ind_custod_st1 character varying(34),
+    ind_custod_st2 character varying(34),
+    ind_custod_city character varying(18),
+    ind_custod_st character varying(2),
+    ind_custod_zip character varying(9),
+    ind_custod_emp character varying(38),
+    ind_custod_occup character varying(38),
+    ttl_dons_this_stmt numeric(14,2),
+    ttl_disb_this_stmt numeric(14,2),
+    filer_sign_nm character varying(38),
+    filer_sign_dt date,
+    begin_image_num character varying(11),
+    end_image_num character varying(11),
+    last_update_dt date,
+    amndt_ind character varying(1),
+    receipt_dt date,
+    rpt_tp character varying(3),
+    comm_title character varying(40),
+    rpt_yr numeric(4,0),
+    entity_tp character varying(3),
+    filer_cd character varying(3),
+    filer_cd_desc character varying(20),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_9');
+
+
+
+
+--
+-- Name: form_99_misc; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.form_99_misc (
+    form_99_misc_sk numeric(10,0) NOT NULL,
+    form_tp character varying(8),
+    cmte_id character varying(9),
+    cmte_nm character varying(200),
+    cmte_st1 character varying(34),
+    cmte_st2 character varying(34),
+    cmte_city character varying(30),
+    cmte_st character varying(2),
+    cmte_zip character varying(9),
+    tres_sign_nm character varying(90),
+    tres_sign_dt date,
+    text_field character varying(4000),
+    to_from_ind character varying(1),
+    receipt_dt date,
+    text_cd character varying(3),
+    text_cd_desc character varying(40),
+    rpt_yr numeric(4,0),
+    begin_image_num character varying(13),
+    end_image_num character varying(13),
+    sub_id numeric(19,0),
+    two_yr_period numeric(4,0),
+    transaction_id numeric(10,0),
+    etl_invalid_flg character(1),
+    etl_complete_date date,
+    filing_type character(1),
+    record_ind character(1),
+    mrf_rec character(1),
+    load_date date NOT NULL,
+    update_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'form_99_misc');
+
+
+
+
+--
+-- Name: log_audit_dml; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.log_audit_dml (
+    dml_id numeric(8,0) NOT NULL,
+    run_id numeric(8,0),
+    audit_id numeric(8,0),
+    dml_type character varying(12) NOT NULL,
+    target_table character varying(32) NOT NULL,
+    start_time timestamp without time zone NOT NULL,
+    row_count numeric(10,0),
+    dml_desc character varying(100),
+    cpu_minutes numeric(8,4),
+    elapsed_minutes numeric(8,4),
+    start_cpu_time numeric NOT NULL,
+    start_clock_time numeric NOT NULL
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'log_audit_dml');
+
+
+
+
+--
+-- Name: log_audit_module; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.log_audit_module (
+    audit_id numeric(8,0) NOT NULL,
+    run_id numeric(8,0),
+    module_name character varying(65) NOT NULL,
+    start_time timestamp without time zone NOT NULL,
+    input_parameters character varying(500),
+    error_message character varying(4000),
+    cpu_minutes numeric(8,4),
+    elapsed_minutes numeric(8,4),
+    start_cpu_time numeric NOT NULL,
+    start_clock_time numeric NOT NULL
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'log_audit_module');
+
+
+
+
+--
+-- Name: log_audit_process; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.log_audit_process (
+    run_id numeric(8,0) NOT NULL,
+    session_id numeric(22,0) NOT NULL,
+    process_name character varying(30),
+    interface_name character varying(6) NOT NULL,
+    module_name character varying(65) NOT NULL,
+    start_time timestamp without time zone NOT NULL,
+    input_parameters character varying(500),
+    messages character varying(4000),
+    cpu_minutes numeric(8,4),
+    elapsed_minutes numeric(8,4),
+    start_cpu_time numeric NOT NULL,
+    start_clock_time numeric NOT NULL
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'log_audit_process');
+
+
+
+
+--
+-- Name: log_dml_errors; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.log_dml_errors (
+    "ora_err_number$" numeric,
+    "ora_err_mesg$" character varying(2000),
+    "ora_err_rowid$" character varying,
+    "ora_err_optyp$" character varying(2),
+    "ora_err_tag$" character varying(100),
+    seq_no numeric(10,0),
+    form_tp character varying(100),
+    file_num character varying(100),
+    receipt_dt character varying(100),
+    begin_image_num character varying(100),
+    end_image_num character varying(100),
+    image_num character varying(100),
+    cmte_id character varying(100),
+    auth_cmte_id character varying(100),
+    pcc_cmte_id character varying(100),
+    pcc_id character varying(100),
+    cand_id character varying(100),
+    sub_id character varying(100),
+    load_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'log_dml_errors');
+
+
+
+
+--
+-- Name: ref_cand_ici; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.ref_cand_ici (
+    cand_ici_cd character(1) NOT NULL,
+    cand_ici_desc character varying(100),
+    incumbent_flg character(1),
+    open_flg character(1)
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'ref_cand_ici');
+
+
+
+
+--
+-- Name: ref_cand_status; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.ref_cand_status (
+    cand_status_cd character(1) NOT NULL,
+    cand_status_desc character varying(100)
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'ref_cand_status');
+
+
+
+
+--
+-- Name: ref_cmte_dsgn; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.ref_cmte_dsgn (
+    cmte_dsgn character(1) NOT NULL,
+    cmte_dsgn_desc character varying(90)
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'ref_cmte_dsgn');
+
+
+
+
+--
+-- Name: ref_cmte_type; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.ref_cmte_type (
+    cmte_tp character(1) NOT NULL,
+    cmte_tp_desc character varying(90),
+    explanation character varying(1000)
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'ref_cmte_type');
+
+
+
+
+--
+-- Name: ref_election; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.ref_election (
+    election_tp character(1) NOT NULL,
+    election_tp_desc character varying(100)
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'ref_election');
+
+
+
+
+--
+-- Name: ref_entity_type; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.ref_entity_type (
+    entity_tp character varying(3) NOT NULL,
+    entity_tp_desc character varying(100)
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'ref_entity_type');
+
+
+
+
+--
+-- Name: ref_form_type; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.ref_form_type (
+    form_tp character varying(15) NOT NULL,
+    form_tp_desc character varying(100),
+    form_nm character varying(1000),
+    obsolete_flg character(1) DEFAULT 'N'::bpchar,
+    obsolete_date date
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'ref_form_type');
+
+
+
+
+--
+-- Name: ref_office; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.ref_office (
+    office_tp character(1) NOT NULL,
+    office_tp_desc character varying(100)
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'ref_office');
+
+
+
+
+--
+-- Name: ref_org_type; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.ref_org_type (
+    org_tp character(1) NOT NULL,
+    org_tp_desc character varying(90)
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'ref_org_type');
+
+
+
+
+--
+-- Name: ref_party; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.ref_party (
+    party_cd character varying(3) NOT NULL,
+    party_desc character varying(100)
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'ref_party');
+
+
+
+
+--
+-- Name: ref_report_type; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.ref_report_type (
+    rpt_tp character varying(3) NOT NULL,
+    rpt_tp_desc character varying(100)
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'ref_report_type');
+
+
+
+
+--
+-- Name: ref_state; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.ref_state (
+    state_cd character varying(2) NOT NULL,
+    state_nm character varying(90)
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'ref_state');
+
+
+
+
+--
+-- Name: ref_transaction_code; Type: TABLE; Schema: processed; Owner: ec2-user; Tablespace:
+--
+
+CREATE FOREIGN TABLE processed.ref_transaction_code (
+    transaction_cd character varying(3) NOT NULL,
+    transaction_desc character varying(100)
+) SERVER rds OPTIONS (schema_name 'processed_newdownload', table_name 'ref_transaction_code');
+
+
+

--- a/data/ddl/psql_w_vars.sh
+++ b/data/ddl/psql_w_vars.sh
@@ -1,0 +1,1 @@
+psql -v rds_password="'$RDS_PASSWORD'" -v rds_host_loc="'$RDS_HOST'" -v oracle_server_loc="'$ORACLE_SERVER_LOC'" -v oracle_password="'$ORACLE_PASSWORD'" $@

--- a/data/ddl/to_rds_ddl.live.sql
+++ b/data/ddl/to_rds_ddl.live.sql
@@ -1,32 +1,41 @@
-SET search_path=newdownload;
 
-create table pinglog (at timestamp primary key, up boolean);
+-- TODO: file Blaze bug - Columns that are NUMBER(14,2) in Oracle come across as INTEGER!
+-- ex: DESC SCHED_D - SEE OUTSTG_BAL_BOP
+-- had to change _id and _sk integers to bigint, all others to numeric
 
-CREATE TABLE dimcand (
+-- run it via ``psql_w_vars.sh`` to set variables like :rds_host_loc
+
+DROP SCHEMA live CASCADE;
+CREATE SCHEMA live;
+
+DROP FOREIGN TABLE live.pinglog;
+CREATE FOREIGN TABLE live.pinglog
+( at timestamp, up boolean
+) SERVER rds OPTIONS (schema_name 'public', table_name 'pinglog');
+
+CREATE FOREIGN TABLE live.dimcand (
     cand_sk bigint NOT NULL,
     cand_id text,
     form_sk bigint,
     form_tp text,
     load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'dimcand');
 
-CREATE TABLE dimcandoffice (
+CREATE FOREIGN TABLE live.dimcandoffice (
     candoffice_sk bigint NOT NULL,
     cand_sk bigint,
     office_sk bigint,
     party_sk bigint,
     form_sk bigint,
     form_tp text,
-    cand_election_yr int,
-    load_date timestamp without time zone,
+    cand_election_yr integer,
+    load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) ;
-
-ALTER TABLE dimcandoffice ALTER COLUMN cand_election_yr TYPE integer;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'dimcandoffice');
 
 
-CREATE TABLE dimcandproperties (
+CREATE FOREIGN TABLE live.dimcandproperties (
     candproperties_sk bigint NOT NULL,
     cand_sk bigint NOT NULL,
     form_sk bigint,
@@ -50,29 +59,29 @@ CREATE TABLE dimcandproperties (
     gen_pers_funds_decl numeric,
     load_date timestamp without time zone,
     expire_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'dimcandproperties');
 
-CREATE TABLE dimcandstatusici (
+CREATE FOREIGN TABLE live.dimcandstatusici (
     candstatusici_sk bigint NOT NULL,
     cand_sk bigint,
     election_yr numeric NOT NULL,
     ici_code text,
     cand_status text,
     cand_inactive_flg text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'dimcandstatusici');
 
-CREATE TABLE dimcmte (
+CREATE FOREIGN TABLE live.dimcmte (
     cmte_sk bigint NOT NULL,
     cmte_id text,
     form_sk bigint,
     form_tp text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'dimcmte');
 
-CREATE TABLE dimcmteproperties (
+CREATE FOREIGN TABLE live.dimcmteproperties (
     cmteproperties_sk bigint NOT NULL,
     cmte_sk bigint,
     form_sk bigint,
@@ -161,34 +170,34 @@ CREATE TABLE dimcmteproperties (
     fith_cand_contb_dt timestamp without time zone,
     load_date timestamp without time zone,
     expire_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'dimcmteproperties');
 
 
-CREATE TABLE dimcmtetpdsgn (
+CREATE FOREIGN TABLE live.dimcmtetpdsgn (
     cmte_tpdgn_sk bigint NOT NULL,
     cmte_sk bigint NOT NULL,
     cmte_tp text,
     cmte_dsgn text,
     receipt_date timestamp without time zone,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'dimcmtetpdsgn');
 
-CREATE TABLE dimdates (
+CREATE FOREIGN TABLE live.dimdates (
     date_sk bigint NOT NULL,
     dw_date timestamp without time zone,
     load_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'dimdates');
 
-CREATE TABLE dimelectiontp (
+CREATE FOREIGN TABLE live.dimelectiontp (
     electiontp_sk bigint NOT NULL,
     election_type_id text NOT NULL,
     election_type_desc text,
     load_date timestamp without time zone,
     expire_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'dimelectiontp');
 
-CREATE TABLE dimlinkages (
+CREATE FOREIGN TABLE live.dimlinkages (
     linkages_sk bigint NOT NULL,
     cand_sk bigint NOT NULL,
     cmte_sk bigint NOT NULL,
@@ -200,9 +209,9 @@ CREATE TABLE dimlinkages (
     link_date timestamp without time zone,
     load_date timestamp without time zone,
     expire_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'dimlinkages');
 
-CREATE TABLE dimoffice (
+CREATE FOREIGN TABLE live.dimoffice (
     office_sk bigint NOT NULL,
     office_tp text,
     office_tp_desc text,
@@ -210,31 +219,31 @@ CREATE TABLE dimoffice (
     office_district text,
     load_date timestamp without time zone,
     expire_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'dimoffice');
 
-CREATE TABLE dimparty (
+CREATE FOREIGN TABLE live.dimparty (
     party_sk bigint NOT NULL,
     party_affiliation text,
     party_affiliation_desc text,
     load_date timestamp without time zone,
     expire_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'dimparty');
 
-CREATE TABLE dimreporttype (
+CREATE FOREIGN TABLE live.dimreporttype (
     reporttype_sk bigint NOT NULL,
     rpt_tp text,
     rpt_tp_desc text,
     load_date timestamp without time zone,
     expire_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'dimreporttype');
 
-CREATE TABLE dimyears (
+CREATE FOREIGN TABLE live.dimyears (
     year_sk bigint NOT NULL,
     year numeric,
     load_date timestamp without time zone NOT NULL
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'dimyears');
 
-CREATE TABLE facthousesenate_f3 (
+CREATE FOREIGN TABLE live.facthousesenate_f3 (
     facthousesenate_f3_sk bigint NOT NULL,
     form_3_sk bigint,
     cmte_sk bigint,
@@ -323,11 +332,11 @@ CREATE TABLE facthousesenate_f3 (
     grs_rcpt_min_pers_contrib_gen numeric,
     begin_image_num numeric,
     end_image_num numeric,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'facthousesenate_f3');
 
-CREATE TABLE factpacsandparties_f3x (
+CREATE FOREIGN TABLE live.factpacsandparties_f3x (
     factpacsandparties_f3x_sk bigint NOT NULL,
     form_3x_sk bigint,
     cmte_sk bigint,
@@ -441,12 +450,12 @@ CREATE TABLE factpacsandparties_f3x (
     ttl_fed_elect_actvy_ytd numeric,
     begin_image_num numeric,
     end_image_num numeric,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'factpacsandparties_f3x');
 
 
-CREATE TABLE factpresidential_f3p (
+CREATE FOREIGN TABLE live.factpresidential_f3p (
     factpresidential_f3p_sk bigint NOT NULL,
     form_3p_sk bigint,
     cmte_sk bigint,
@@ -638,12 +647,12 @@ CREATE TABLE factpresidential_f3p (
     ttl_ytd numeric,
     begin_image_num numeric,
     end_image_num numeric,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'factpresidential_f3p');
 
 
-CREATE TABLE form_105 (
+CREATE FOREIGN TABLE live.form_105 (
     form_105_sk bigint NOT NULL,
     form_tp text,
     filer_cmte_id text,
@@ -662,12 +671,12 @@ CREATE TABLE form_105 (
     link_id bigint,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'form_105');
 
 
-CREATE TABLE form_56 (
+CREATE FOREIGN TABLE live.form_56 (
     form_56_sk bigint NOT NULL,
     form_tp text,
     filer_cmte_id text,
@@ -703,12 +712,12 @@ CREATE TABLE form_56 (
     link_id bigint,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'form_56');
 
 
-CREATE TABLE form_57 (
+CREATE FOREIGN TABLE live.form_57 (
     form_57_sk bigint NOT NULL,
     form_tp text,
     filer_cmte_id text,
@@ -751,12 +760,12 @@ CREATE TABLE form_57 (
     link_id bigint,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'form_57');
 
 
-CREATE TABLE form_65 (
+CREATE FOREIGN TABLE live.form_65 (
     form_65_sk bigint NOT NULL,
     form_tp text,
     filer_cmte_id text,
@@ -792,12 +801,12 @@ CREATE TABLE form_65 (
     link_id bigint,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'form_65');
 
 
-CREATE TABLE form_76 (
+CREATE FOREIGN TABLE live.form_76 (
     form_76_sk bigint NOT NULL,
     form_tp text,
     org_id text,
@@ -824,12 +833,12 @@ CREATE TABLE form_76 (
     link_id bigint,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'form_76');
 
 
-CREATE TABLE form_82 (
+CREATE FOREIGN TABLE live.form_82 (
     form_82_sk bigint NOT NULL,
     form_tp text,
     cmte_id text,
@@ -868,12 +877,12 @@ CREATE TABLE form_82 (
     link_id bigint,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'form_82');
 
 
-CREATE TABLE form_83 (
+CREATE FOREIGN TABLE live.form_83 (
     form_83_sk bigint NOT NULL,
     form_tp text,
     cmte_id text,
@@ -904,12 +913,12 @@ CREATE TABLE form_83 (
     link_id bigint,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'form_83');
 
 
-CREATE TABLE form_91 (
+CREATE FOREIGN TABLE live.form_91 (
     form_91_sk bigint NOT NULL,
     form_tp text,
     filer_cmte_id text,
@@ -931,12 +940,11 @@ CREATE TABLE form_91 (
     link_id bigint,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'form_91');
 
-
-CREATE TABLE form_94 (
+CREATE FOREIGN TABLE live.form_94 (
     form_94_sk bigint NOT NULL,
     form_tp text,
     filer_cmte_id text,
@@ -960,12 +968,12 @@ CREATE TABLE form_94 (
     link_id bigint,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'form_94');
 
 
-CREATE TABLE log_audit_dml (
+CREATE FOREIGN TABLE live.log_audit_dml (
     dml_id bigint NOT NULL,
     run_id bigint,
     audit_id bigint,
@@ -978,10 +986,10 @@ CREATE TABLE log_audit_dml (
     elapsed_minutes numeric,
     start_cpu_time numeric NOT NULL,
     start_clock_time numeric NOT NULL
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'log_audit_dml');
 
 
-CREATE TABLE log_audit_module (
+CREATE FOREIGN TABLE live.log_audit_module (
     audit_id bigint NOT NULL,
     run_id bigint,
     module_name text NOT NULL,
@@ -992,10 +1000,10 @@ CREATE TABLE log_audit_module (
     elapsed_minutes numeric,
     start_cpu_time numeric NOT NULL,
     start_clock_time numeric NOT NULL
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'log_audit_module');
 
 
-CREATE TABLE log_audit_process (
+CREATE FOREIGN TABLE live.log_audit_process (
     run_id bigint NOT NULL,
     session_id bigint NOT NULL,
     process_name text,
@@ -1008,10 +1016,10 @@ CREATE TABLE log_audit_process (
     elapsed_minutes numeric,
     start_cpu_time numeric NOT NULL,
     start_clock_time numeric NOT NULL
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'log_audit_process');
 
 
-CREATE TABLE sched_a (
+CREATE FOREIGN TABLE live.sched_a (
     sched_a_sk bigint NOT NULL,
     form_tp text,
     cmte_id text,
@@ -1070,12 +1078,12 @@ CREATE TABLE sched_a (
     transaction_id bigint,
     filing_type text,
     filing_form text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_a');
 
 
-CREATE TABLE sched_b (
+CREATE FOREIGN TABLE live.sched_b (
     sched_b_sk bigint NOT NULL,
     form_tp text,
     cmte_id text,
@@ -1136,12 +1144,12 @@ CREATE TABLE sched_b (
     transaction_id bigint,
     filing_type text,
     filing_form text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_b');
 
 
-CREATE TABLE sched_c (
+CREATE FOREIGN TABLE live.sched_c (
     sched_c_sk bigint NOT NULL,
     form_tp text,
     cmte_id text,
@@ -1189,12 +1197,12 @@ CREATE TABLE sched_c (
     transaction_id bigint,
     filing_type text,
     filing_form text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_c');
 
 
-CREATE TABLE sched_c1 (
+CREATE FOREIGN TABLE live.sched_c1 (
     sched_c1_sk bigint NOT NULL,
     form_tp text,
     cmte_id text,
@@ -1253,12 +1261,11 @@ CREATE TABLE sched_c1 (
     transaction_id bigint,
     filing_type text,
     filing_form text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_c1');
 
-
-CREATE TABLE sched_c2 (
+CREATE FOREIGN TABLE live.sched_c2 (
     sched_c2_sk bigint NOT NULL,
     form_tp text,
     cmte_id text,
@@ -1288,12 +1295,12 @@ CREATE TABLE sched_c2 (
     transaction_id bigint,
     filing_type text,
     filing_form text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_c2');
 
 
-CREATE TABLE sched_d (
+CREATE FOREIGN TABLE live.sched_d (
     sched_d_sk bigint NOT NULL,
     form_tp text,
     cmte_id text,
@@ -1340,12 +1347,12 @@ CREATE TABLE sched_d (
     transaction_id bigint,
     filing_type text,
     filing_form text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_d');
 
 
-CREATE TABLE sched_e (
+CREATE FOREIGN TABLE live.sched_e (
     sched_e_sk bigint NOT NULL,
     form_tp text,
     cmte_id text,
@@ -1405,12 +1412,12 @@ CREATE TABLE sched_e (
     rpt_yr numeric,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_e');
 
 
-CREATE TABLE sched_f (
+CREATE FOREIGN TABLE live.sched_f (
     sched_f_sk bigint NOT NULL,
     form_tp text,
     cmte_id text,
@@ -1474,12 +1481,12 @@ CREATE TABLE sched_f (
     rpt_yr numeric,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_f');
 
 
-CREATE TABLE sched_h1 (
+CREATE FOREIGN TABLE live.sched_h1 (
     sched_h1_sk bigint NOT NULL,
     form_tp text,
     filer_cmte_id text,
@@ -1535,12 +1542,12 @@ CREATE TABLE sched_h1 (
     rpt_yr numeric,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_h1');
 
 
-CREATE TABLE sched_h2 (
+CREATE FOREIGN TABLE live.sched_h2 (
     sched_h2_sk bigint NOT NULL,
     form_tp text,
     filer_cmte_id text,
@@ -1568,12 +1575,12 @@ CREATE TABLE sched_h2 (
     rpt_yr numeric,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_h2');
 
 
-CREATE TABLE sched_h3 (
+CREATE FOREIGN TABLE live.sched_h3 (
     sched_h3_sk bigint NOT NULL,
     form_tp text,
     filer_cmte_id text,
@@ -1601,12 +1608,12 @@ CREATE TABLE sched_h3 (
     rpt_yr numeric,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_h3');
 
 
-CREATE TABLE sched_h4 (
+CREATE FOREIGN TABLE live.sched_h4 (
     sched_h4_sk bigint NOT NULL,
     form_tp text,
     filer_cmte_id text,
@@ -1670,19 +1677,18 @@ CREATE TABLE sched_h4 (
     rpt_yr numeric,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_h4');
 
-
-CREATE TABLE sched_h5 (
+CREATE FOREIGN TABLE live.sched_h5 (
     sched_h5_sk bigint NOT NULL,
     form_tp text,
     filer_cmte_id text,
     acct_nm text,
     tranf_dt timestamp without time zone,
     ttl_tranf_amt_voter_reg numeric,
-    ttl_tranf_voter_id bigint,
+    ttl_tranf_voter_id numeric,
     ttl_tranf_gotv numeric,
     ttl_tranf_gen_campgn_actvy numeric,
     ttl_tranf_amt numeric,
@@ -1702,12 +1708,12 @@ CREATE TABLE sched_h5 (
     rpt_yr numeric,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_h5');
 
 
-CREATE TABLE sched_h6 (
+CREATE FOREIGN TABLE live.sched_h6 (
     sched_h6_sk bigint NOT NULL,
     form_tp text,
     filer_cmte_id text,
@@ -1765,12 +1771,12 @@ CREATE TABLE sched_h6 (
     rpt_yr numeric,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_h6');
 
 
-CREATE TABLE sched_i (
+CREATE FOREIGN TABLE live.sched_i (
     sched_i_sk bigint NOT NULL,
     form_tp text,
     filer_cmte_id text,
@@ -1819,12 +1825,12 @@ CREATE TABLE sched_i (
     end_image_num text,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_i');
 
 
-CREATE TABLE sched_l (
+CREATE FOREIGN TABLE live.sched_l (
     sched_l_sk bigint NOT NULL,
     form_tp text,
     filer_cmte_id text,
@@ -1883,12 +1889,129 @@ CREATE TABLE sched_l (
     orig_sub_id bigint,
     transaction_id bigint,
     filing_type text,
-    load_date timestamp without time zone,
+    load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) ;
+) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_l');
 
-GRANT USAGE ON SCHEMA newdownload TO webro;
-GRANT USAGE ON SCHEMA newdownload TO openfec;
-GRANT ALL PRIVILEGES ON SCHEMA newdownload TO openfec;
-GRANT SELECT ON ALL TABLES IN SCHEMA newdownload TO webro;
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA newdownload TO openfec;
+CREATE FOREIGN TABLE live.form_1 (
+   form_1_sk				   bigint,
+   form_tp					    text,
+   cmte_id					    text,
+   cmte_nm					    text,
+   cmte_st1					    text,
+   cmte_st2					    text,
+   cmte_city					    text,
+   cmte_st					    text,
+   cmte_zip					    text,
+   submit_dt					    timestamp without time zone,
+   cmte_nm_chg_flg				    text,
+   cmte_addr_chg_flg				    text,
+   cmte_tp					    text,
+   cand_id					    text,
+   cand_nm					    text,
+   cand_office					    text,
+   cand_office_st 				    text,
+   cand_office_district				    text,
+   cand_pty_affiliation				    text,
+   cand_pty_tp					    text,
+   affiliated_cmte_id				    text,
+   affiliated_cmte_nm				    text,
+   affiliated_cmte_st1				    text,
+   affiliated_cmte_st2				    text,
+   affiliated_cmte_city				    text,
+   affiliated_cmte_st				    text,
+   affiliated_cmte_zip				    text,
+   cmte_rltshp					    text,
+   org_tp 					    text,
+   cust_rec_nm					    text,
+   cust_rec_st1					    text,
+   cust_rec_st2					    text,
+   cust_rec_city					    text,
+   cust_rec_st					    text,
+   cust_rec_zip					    text,
+   cust_rec_title 				    text,
+   cust_rec_ph_num				    text,
+   tres_nm					    text,
+   tres_st1					    text,
+   tres_st2					    text,
+   tres_city					    text,
+   tres_st					    text,
+   tres_zip					    text,
+   tres_title					    text,
+   tres_ph_num					    text,
+   designated_agent_nm				    text,
+   designated_agent_st1				    text,
+   designated_agent_st2				    text,
+   designated_agent_city				    text,
+   designated_agent_st				    text,
+   designated_agent_zip				    text,
+   designated_agent_title 			    text,
+   designated_agent_ph_num			    text,
+   bank_depository_nm				    text,
+   bank_depository_st1				    text,
+   bank_depository_st2				    text,
+   bank_depository_city				    text,
+   bank_depository_st				    text,
+   bank_depository_zip				    text,
+   sec_bank_depository_nm 			    text,
+   sec_bank_depository_st1			    text,
+   sec_bank_depository_st2			    text,
+   sec_bank_depository_city			    text,
+   sec_bank_depository_st 			    text,
+   sec_bank_depository_zip			    text,
+   tres_sign_nm					    text,
+   tres_sign_dt					    timestamp without time zone,
+   cmte_email					    text,
+   cmte_web_url					    text,
+   receipt_dt					    timestamp without time zone,
+   filing_freq					    text,
+   cmte_dsgn					    text,
+   qual_dt					    timestamp without time zone,
+   cmte_fax					    text,
+   efiling_cmte_tp				    text,
+   rpt_yr 					    integer,
+   leadership_pac 				    text,
+   affiliated_relationship_cd			    text,
+   cmte_email_chg_flg				    text,
+   cmte_url_chg_flg				    text,
+   lobbyist_registrant_pac			    text,
+   affiliated_cand_id				    text,
+   affiliated_cand_l_nm				    text,
+   affiliated_cand_f_nm				    text,
+   affiliated_cand_m_nm				    text,
+   affiliated_cand_prefix 			    text,
+   affiliated_cand_suffix 			    text,
+   cand_l_nm					    text,
+   cand_f_nm					    text,
+   cand_m_nm					    text,
+   cand_prefix					    text,
+   cand_suffix					    text,
+   cust_rec_l_nm					    text,
+   cust_rec_f_nm					    text,
+   cust_rec_m_nm					    text,
+   cust_rec_prefix				    text,
+   cust_rec_suffix				    text,
+   tres_l_nm					    text,
+   tres_f_nm					    text,
+   tres_m_nm					    text,
+   tres_prefix					    text,
+   tres_suffix					    text,
+   designated_agent_l_nm				    text,
+   designated_agent_f_nm				    text,
+   designated_agent_m_nm				    text,
+   designated_agent_prefix			    text,
+   designated_agent_suffix			    text,
+   f3l_filing_freq				    text,
+   begin_image_num				    text,
+   end_image_num					    text,
+   sub_id 					          bigint,
+   etl_invalid_flg				    text,
+   etl_complete_date				    timestamp without time zone,
+   filing_type					    text,
+   record_ind					    text,
+   load_date				   timestamp without time zone not null,
+   update_date					    timestamp without time zone
+) SERVER rds OPTIONS (schema_name 'public', table_name 'form_1');
+
+GRANT ALL PRIVILEGES ON SCHEMA live TO openfec;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA live TO openfec;

--- a/data/ddl/to_rds_ddl.sql
+++ b/data/ddl/to_rds_ddl.sql
@@ -3,6 +3,11 @@
 -- ex: DESC SCHED_D - SEE OUTSTG_BAL_BOP
 -- had to change _id and _sk integers to bigint, all others to numeric
 
+-- run it via ``psql_w_vars.sh`` to set variables like :rds_host_loc
+
+DROP SCHEMA public CASCADE;
+CREATE SCHEMA public;
+
 CREATE EXTENSION postgres_fdw;
 DROP SERVER rds CASCADE;
 CREATE SERVER rds FOREIGN DATA WRAPPER postgres_fdw
@@ -19,14 +24,10 @@ CREATE USER MAPPING FOR "ec2-user" SERVER rds
           OPTIONS (user 'openfec',
                    password :rds_password);
 
-
-DROP SCHEMA public;
-CREATE SCHEMA public;
-
 DROP FOREIGN TABLE public.pinglog;
 CREATE FOREIGN TABLE public.pinglog
 ( at timestamp, up boolean
-) SERVER rds OPTIONS (schema_name 'public', table_name 'pinglog');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'pinglog');
 
 CREATE FOREIGN TABLE public.dimcand (
     cand_sk bigint NOT NULL,
@@ -35,7 +36,7 @@ CREATE FOREIGN TABLE public.dimcand (
     form_tp text,
     load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'dimcand');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'dimcand');
 
 CREATE FOREIGN TABLE public.dimcandoffice (
     candoffice_sk bigint NOT NULL,
@@ -47,7 +48,7 @@ CREATE FOREIGN TABLE public.dimcandoffice (
     cand_election_yr integer,
     load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'dimcandoffice');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'dimcandoffice');
 
 
 CREATE FOREIGN TABLE public.dimcandproperties (
@@ -74,7 +75,7 @@ CREATE FOREIGN TABLE public.dimcandproperties (
     gen_pers_funds_decl numeric,
     load_date timestamp without time zone,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'dimcandproperties');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'dimcandproperties');
 
 CREATE FOREIGN TABLE public.dimcandstatusici (
     candstatusici_sk bigint NOT NULL,
@@ -85,7 +86,7 @@ CREATE FOREIGN TABLE public.dimcandstatusici (
     cand_inactive_flg text,
     load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'dimcandstatusici');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'dimcandstatusici');
 
 CREATE FOREIGN TABLE public.dimcmte (
     cmte_sk bigint NOT NULL,
@@ -94,7 +95,7 @@ CREATE FOREIGN TABLE public.dimcmte (
     form_tp text,
     load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'dimcmte');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'dimcmte');
 
 CREATE FOREIGN TABLE public.dimcmteproperties (
     cmteproperties_sk bigint NOT NULL,
@@ -185,7 +186,7 @@ CREATE FOREIGN TABLE public.dimcmteproperties (
     fith_cand_contb_dt timestamp without time zone,
     load_date timestamp without time zone,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'dimcmteproperties');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'dimcmteproperties');
 
 
 CREATE FOREIGN TABLE public.dimcmtetpdsgn (
@@ -196,13 +197,13 @@ CREATE FOREIGN TABLE public.dimcmtetpdsgn (
     receipt_date timestamp without time zone,
     load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'dimcmtetpdsgn');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'dimcmtetpdsgn');
 
 CREATE FOREIGN TABLE public.dimdates (
     date_sk bigint NOT NULL,
     dw_date timestamp without time zone,
     load_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'dimdates');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'dimdates');
 
 CREATE FOREIGN TABLE public.dimelectiontp (
     electiontp_sk bigint NOT NULL,
@@ -210,7 +211,7 @@ CREATE FOREIGN TABLE public.dimelectiontp (
     election_type_desc text,
     load_date timestamp without time zone,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'dimelectiontp');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'dimelectiontp');
 
 CREATE FOREIGN TABLE public.dimlinkages (
     linkages_sk bigint NOT NULL,
@@ -224,7 +225,7 @@ CREATE FOREIGN TABLE public.dimlinkages (
     link_date timestamp without time zone,
     load_date timestamp without time zone,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'dimlinkages');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'dimlinkages');
 
 CREATE FOREIGN TABLE public.dimoffice (
     office_sk bigint NOT NULL,
@@ -234,7 +235,7 @@ CREATE FOREIGN TABLE public.dimoffice (
     office_district text,
     load_date timestamp without time zone,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'dimoffice');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'dimoffice');
 
 CREATE FOREIGN TABLE public.dimparty (
     party_sk bigint NOT NULL,
@@ -242,7 +243,7 @@ CREATE FOREIGN TABLE public.dimparty (
     party_affiliation_desc text,
     load_date timestamp without time zone,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'dimparty');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'dimparty');
 
 CREATE FOREIGN TABLE public.dimreporttype (
     reporttype_sk bigint NOT NULL,
@@ -250,13 +251,13 @@ CREATE FOREIGN TABLE public.dimreporttype (
     rpt_tp_desc text,
     load_date timestamp without time zone,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'dimreporttype');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'dimreporttype');
 
 CREATE FOREIGN TABLE public.dimyears (
     year_sk bigint NOT NULL,
     year numeric,
     load_date timestamp without time zone NOT NULL
-) SERVER rds OPTIONS (schema_name 'public', table_name 'dimyears');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'dimyears');
 
 CREATE FOREIGN TABLE public.facthousesenate_f3 (
     facthousesenate_f3_sk bigint NOT NULL,
@@ -349,7 +350,7 @@ CREATE FOREIGN TABLE public.facthousesenate_f3 (
     end_image_num numeric,
     load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'facthousesenate_f3');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'facthousesenate_f3');
 
 CREATE FOREIGN TABLE public.factpacsandparties_f3x (
     factpacsandparties_f3x_sk bigint NOT NULL,
@@ -467,7 +468,7 @@ CREATE FOREIGN TABLE public.factpacsandparties_f3x (
     end_image_num numeric,
     load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'factpacsandparties_f3x');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'factpacsandparties_f3x');
 
 
 CREATE FOREIGN TABLE public.factpresidential_f3p (
@@ -664,7 +665,7 @@ CREATE FOREIGN TABLE public.factpresidential_f3p (
     end_image_num numeric,
     load_date timestamp without time zone NOT NULL,
     expire_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'factpresidential_f3p');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'factpresidential_f3p');
 
 
 CREATE FOREIGN TABLE public.form_105 (
@@ -688,7 +689,7 @@ CREATE FOREIGN TABLE public.form_105 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'form_105');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'form_105');
 
 
 CREATE FOREIGN TABLE public.form_56 (
@@ -729,7 +730,7 @@ CREATE FOREIGN TABLE public.form_56 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'form_56');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'form_56');
 
 
 CREATE FOREIGN TABLE public.form_57 (
@@ -777,7 +778,7 @@ CREATE FOREIGN TABLE public.form_57 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'form_57');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'form_57');
 
 
 CREATE FOREIGN TABLE public.form_65 (
@@ -818,7 +819,7 @@ CREATE FOREIGN TABLE public.form_65 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'form_65');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'form_65');
 
 
 CREATE FOREIGN TABLE public.form_76 (
@@ -850,7 +851,7 @@ CREATE FOREIGN TABLE public.form_76 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'form_76');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'form_76');
 
 
 CREATE FOREIGN TABLE public.form_82 (
@@ -894,7 +895,7 @@ CREATE FOREIGN TABLE public.form_82 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'form_82');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'form_82');
 
 
 CREATE FOREIGN TABLE public.form_83 (
@@ -930,7 +931,7 @@ CREATE FOREIGN TABLE public.form_83 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'form_83');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'form_83');
 
 
 CREATE FOREIGN TABLE public.form_91 (
@@ -957,7 +958,7 @@ CREATE FOREIGN TABLE public.form_91 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'form_91');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'form_91');
 
 CREATE FOREIGN TABLE public.form_94 (
     form_94_sk bigint NOT NULL,
@@ -985,7 +986,7 @@ CREATE FOREIGN TABLE public.form_94 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'form_94');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'form_94');
 
 
 CREATE FOREIGN TABLE public.log_audit_dml (
@@ -1001,7 +1002,7 @@ CREATE FOREIGN TABLE public.log_audit_dml (
     elapsed_minutes numeric,
     start_cpu_time numeric NOT NULL,
     start_clock_time numeric NOT NULL
-) SERVER rds OPTIONS (schema_name 'public', table_name 'log_audit_dml');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'log_audit_dml');
 
 
 CREATE FOREIGN TABLE public.log_audit_module (
@@ -1015,7 +1016,7 @@ CREATE FOREIGN TABLE public.log_audit_module (
     elapsed_minutes numeric,
     start_cpu_time numeric NOT NULL,
     start_clock_time numeric NOT NULL
-) SERVER rds OPTIONS (schema_name 'public', table_name 'log_audit_module');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'log_audit_module');
 
 
 CREATE FOREIGN TABLE public.log_audit_process (
@@ -1031,7 +1032,7 @@ CREATE FOREIGN TABLE public.log_audit_process (
     elapsed_minutes numeric,
     start_cpu_time numeric NOT NULL,
     start_clock_time numeric NOT NULL
-) SERVER rds OPTIONS (schema_name 'public', table_name 'log_audit_process');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'log_audit_process');
 
 
 CREATE FOREIGN TABLE public.sched_a (
@@ -1095,7 +1096,7 @@ CREATE FOREIGN TABLE public.sched_a (
     filing_form text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_a');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_a');
 
 
 CREATE FOREIGN TABLE public.sched_b (
@@ -1161,7 +1162,7 @@ CREATE FOREIGN TABLE public.sched_b (
     filing_form text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_b');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_b');
 
 
 CREATE FOREIGN TABLE public.sched_c (
@@ -1214,7 +1215,7 @@ CREATE FOREIGN TABLE public.sched_c (
     filing_form text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_c');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_c');
 
 
 CREATE FOREIGN TABLE public.sched_c1 (
@@ -1278,7 +1279,7 @@ CREATE FOREIGN TABLE public.sched_c1 (
     filing_form text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_c1');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_c1');
 
 CREATE FOREIGN TABLE public.sched_c2 (
     sched_c2_sk bigint NOT NULL,
@@ -1312,7 +1313,7 @@ CREATE FOREIGN TABLE public.sched_c2 (
     filing_form text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_c2');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_c2');
 
 
 CREATE FOREIGN TABLE public.sched_d (
@@ -1364,7 +1365,7 @@ CREATE FOREIGN TABLE public.sched_d (
     filing_form text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_d');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_d');
 
 
 CREATE FOREIGN TABLE public.sched_e (
@@ -1429,7 +1430,7 @@ CREATE FOREIGN TABLE public.sched_e (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_e');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_e');
 
 
 CREATE FOREIGN TABLE public.sched_f (
@@ -1498,7 +1499,7 @@ CREATE FOREIGN TABLE public.sched_f (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_f');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_f');
 
 
 CREATE FOREIGN TABLE public.sched_h1 (
@@ -1559,7 +1560,7 @@ CREATE FOREIGN TABLE public.sched_h1 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_h1');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_h1');
 
 
 CREATE FOREIGN TABLE public.sched_h2 (
@@ -1592,7 +1593,7 @@ CREATE FOREIGN TABLE public.sched_h2 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_h2');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_h2');
 
 
 CREATE FOREIGN TABLE public.sched_h3 (
@@ -1625,7 +1626,7 @@ CREATE FOREIGN TABLE public.sched_h3 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_h3');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_h3');
 
 
 CREATE FOREIGN TABLE public.sched_h4 (
@@ -1694,7 +1695,7 @@ CREATE FOREIGN TABLE public.sched_h4 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_h4');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_h4');
 
 CREATE FOREIGN TABLE public.sched_h5 (
     sched_h5_sk bigint NOT NULL,
@@ -1725,7 +1726,7 @@ CREATE FOREIGN TABLE public.sched_h5 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_h5');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_h5');
 
 
 CREATE FOREIGN TABLE public.sched_h6 (
@@ -1788,7 +1789,7 @@ CREATE FOREIGN TABLE public.sched_h6 (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_h6');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_h6');
 
 
 CREATE FOREIGN TABLE public.sched_i (
@@ -1842,7 +1843,7 @@ CREATE FOREIGN TABLE public.sched_i (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_i');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_i');
 
 
 CREATE FOREIGN TABLE public.sched_l (
@@ -1906,7 +1907,7 @@ CREATE FOREIGN TABLE public.sched_l (
     filing_type text,
     load_date timestamp without time zone NOT NULL,
     update_date timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'sched_l');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'sched_l');
 
 CREATE FOREIGN TABLE public.form_1 (
    form_1_sk				   bigint,
@@ -2026,7 +2027,7 @@ CREATE FOREIGN TABLE public.form_1 (
    record_ind					    text,
    load_date				   timestamp without time zone not null,
    update_date					    timestamp without time zone
-) SERVER rds OPTIONS (schema_name 'public', table_name 'form_1');
+) SERVER rds OPTIONS (schema_name 'newdownload', table_name 'form_1');
 
 GRANT ALL PRIVILEGES ON SCHEMA public TO openfec;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO openfec;

--- a/documentation/notebooks/processes.ipynb
+++ b/documentation/notebooks/processes.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:d7afbdb07b839e31a9185144f085550360a8809256018c0fd82aa15d2aa17b26"
+  "signature": "sha256:33a52d384101914bb97e4a9512e6f721608766832e249a938f765f0f3c899689"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -80,6 +80,47 @@
       "4. On the data gateway machine, run openFEC/data/synch/push_in_chunks.py to transfer rows from the largest tables, `sched_a` and `sched_b` (one day or more)\n",
       "\n",
       "5. Against the AWS instance, run openFEC/data/ddl/fulltext.sql to update the full-text indexes\n"
+     ]
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Complete data repopulation"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "From the bridge machine, populating a fresh schema with all-new data can be done with the `public` and `processed` schemas in `cfdm`.  To access existing production data, use `live` and `processed_live`.\n",
+      "\n",
+      "In RDS\n",
+      "\n",
+      "    drop schema newdownload cascade;\n",
+      "    create schema newdownload;\n",
+      "    set search_path=newdownload;\n",
+      "    \\f in_rds_ddl.sql\n",
+      "    drop schema processed_newdownload cascade;\n",
+      "    create schema processed_newdownload;\n",
+      "    set search_path=processed_newdownload;\n",
+      "    \\f processed_schema.in_rds.sql\n",
+      "    \n",
+      "on bridge machine\n",
+      "\n",
+      "    bin/set_env_vars.real.sh\n",
+      "    cd ddl\n",
+      "    ./psql_w_vars.sh cfdm\n",
+      "    \\i to_rds_ddl.sql\n",
+      "    \\i to_rds_ddl.live.sql\n",
+      "    \\i processed_schema.to_rds.sql\n",
+      "    \\i processed_schema.to_rds.live.sql    \n",
+      "    cd ../synch\n",
+      "    psql -f bulk_push_from_oracle.sql cfdm\n",
+      "    psql -f bulk_push_from_oracle.sql cfdm\n",
+      "    \n",
+      "    \n"
      ]
     },
     {


### PR DESCRIPTION
either current live data or a copy in process

Many and kind of cryptic changes (sorry, reviewer!) but the point is that, from PostgreSQL on the bridge machine, it's now possible to push a full copy of the data from FEC to a separate schema on RDS, while the current data remains in place.  When that copy is done we can rapidly swap it to become the new production data.