### PR TITLE
Add 'list_routes' management command

### DIFF
--- a/webservices/manage.py
+++ b/webservices/manage.py
@@ -1,0 +1,28 @@
+from flask.ext.script import Manager
+from flask import url_for
+
+from rest import app
+
+manager = Manager(app)
+
+@manager.command
+def list_routes():
+    import urllib
+    output = []
+    for rule in app.url_map.iter_rules():
+
+        options = {}
+        for arg in rule.arguments:
+            options[arg] = "[{0}]".format(arg)
+
+        methods = ','.join(rule.methods)
+        url = url_for(rule.endpoint, **options)
+        line = urllib.unquote("{:50s} {:20s} {}".format(rule.endpoint, methods, url))
+        output.append(line)
+
+    for line in sorted(output):
+        print line
+
+
+if __name__ == "__main__":
+    manager.run()


### PR DESCRIPTION
Just a little something I've found helpful while learning my way around this app. Might be helpful for others, too.

- Shows all routes in the app, with their Python methods and HTTP methods

- To invoke: `python manage.py list_routes`