### PR TITLE
Candidate tests

### DIFF
--- a/webservices/candidates/resources.py
+++ b/webservices/candidates/resources.py
@@ -151,7 +151,7 @@ class BaseCandidateResource(Candidate):
 
                 # Names (picking up name variations)
                 if ('cand_nm' in prop
-                        and other_names in fields
+                        and ('other_names' in fields or '*' in fields)
                         and cand_data['name']['full_name'] != prop['cand_nm']
                         and prop['cand_nm'] not in other_names):
                     name = cleantext(prop['cand_nm'])
@@ -271,7 +271,8 @@ class CandidateSearch(BaseCandidateResource, Searchable):
         "candidate_id": string.Template("cand_id={'$arg'}"),
         "fec_id": string.Template("cand_id={'$arg'}"),
         "office": string.Template(
-            "top(dimcandoffice.sort(expire_date-)).dimoffice.office_tp={'$arg'}"
+            "top(dimcandoffice.sort(expire_date-)).dimoffice."
+            "office_tp={'$arg'}"
         ),
         "district": string.Template(
             "top(dimcandoffice.sort(expire_date-)).dimoffice."

--- a/webservices/test_api.py
+++ b/webservices/test_api.py
@@ -1,22 +1,10 @@
 import json
-import unittest
-import rest
 
-class OverallTest(unittest.TestCase):
+from .tests.common import ApiBaseTest
+
+
+class OverallTest(ApiBaseTest):
     # Candidate
-
-    def setUp(self):
-        rest.app.config['TESTING'] = True
-        self.app = rest.app.test_client()
-
-    def tearDown(self):
-        pass
-
-    def _response(self, qry):
-        response = self.app.get(qry)
-        self.assertEquals(response.status_code, 200)
-        return json.loads(response.data)
-
     def test_header_info(self):
         response = self._response('/candidate')
         self.assertIn('api_version', response)

--- a/webservices/tests/candidate.py
+++ b/webservices/tests/candidate.py
@@ -1,0 +1,95 @@
+from .common import ApiBaseTest
+
+
+class CandidateFormatTest(ApiBaseTest):
+    """Test/Document expected formats"""
+    def test_for_regressions(self):
+        """Compare results to expected fields."""
+        # @todo - use a factory rather than the test data
+        response = self._response('/candidate/H0VA08040?fields=*')
+        self.assertResultsEqual(
+            response['pagination'],
+            {'count': 1, 'page': 1, 'pages': 1, 'per_page': 20})
+        self.assertEqual(len(response['results']), 1)
+
+        result = response['results'][0]
+        self.assertEqual(result['candidate_id'], 'H0VA08040')
+        self.assertEqual(result['form_type'], 'F2')
+        # @todo - check for a value for expire_data
+        self.assertEqual(result['expire_date'], None)
+        self.assertEqual(result['load_date'], '1990-02-05 00:00:00')
+        self.assertResultsEqual(
+            result['name'],
+            {
+                "full_name": "MORAN, JAMES P. JR.",
+                "name_1": "JAMES P JR",
+                "name_2": "MORAN",
+                "other_names": [
+                    "MORAN, JAMES P JR", "MORAN, JAMES P",
+                    "MORAN, JAMES PATRICK", "MORAN, JAMES P JR."]
+            })
+        address = {
+            "city": "ALEXANDRIA",
+            "expire_date": "2009-01-01",
+            "state": "VA",
+            "street_1": "311 NORTH WASHINGTON STREET",
+            "street_2": "SUITE 200L",
+            "zip": "22314"
+        }
+        self.assertTrue(address in result['mailing_addresses'])
+
+        self.assertEqual(2, len(result['elections']))
+        election = result['elections'][0]
+        primary_committee = election['primary_committee']  # tested separately
+        del election['primary_committee']
+        self.assertResultsEqual(
+            election,
+            {
+                # From office_mapping
+                "office": "H",
+                "district": "08",
+                "state": "VA",
+                "office_sought": "H",
+                "office_sought_full": "House",
+                # From party_mapping
+                "party": "DEM",
+                "party_affiliation": "Democratic Party",
+                # From status_mapping
+                "election_year": 2014,
+                "candidate_inactive": "Y",
+                "candidate_status": "C",
+                "incumbent_challenge": None,
+                # Expanded from candidate_status
+                "candidate_status_full": "candidate",
+            })
+
+        self.assertResultsEqual(
+            primary_committee,
+            {
+                # From cand_committee_format_mapping
+                "committee_id": "C00241349",
+                "designation": "P",
+                "type": "H",
+                "election_year": 2014,
+                # Calculated separately
+                "committee_name": "MORAN FOR CONGRESS",
+                "designation_full": "Principal campaign committee",
+                "type_full": "House"
+            })
+
+        # The above candidate is missing a few fields
+        response = self._response('/candidate/P20003984?fields=*')
+        election = response['results'][0]['elections'][0]
+        self.assertEqual(election["incumbent_challenge"], "C")
+        self.assertEqual(election["incumbent_challenge_full"], "challenger")
+        self.assertResultsEqual(
+            election['affiliated_committees'],
+            [{
+                "committee_id": "C00527648",
+                "committee_name": "CONNECTICUT GREEN PRESIDENTIAL COMMITTEE",
+                "designation": "U",
+                "designation_full": "Unauthorized",
+                "election_year": 2012.0,
+                "type": "I",
+                "type_full": "Independent Expenditor (Person or Group)"
+            }])

--- a/webservices/tests/candidate_tests.py
+++ b/webservices/tests/candidate_tests.py
@@ -9,7 +9,7 @@ class CandidateFormatTest(ApiBaseTest):
         response = self._response('/candidate/H0VA08040?fields=*')
         self.assertResultsEqual(
             response['pagination'],
-            {'count': 1, 'page': 1, 'pages': 1, 'per_page': 20})
+            {'count': 1, 'page': 1, 'pages': 1, 'per_page': 1})
         self.assertEqual(len(response['results']), 1)
 
         result = response['results'][0]
@@ -26,7 +26,7 @@ class CandidateFormatTest(ApiBaseTest):
                 "name_2": "MORAN",
                 "other_names": [
                     "MORAN, JAMES P JR", "MORAN, JAMES P",
-                    "MORAN, JAMES PATRICK", "MORAN, JAMES P JR."]
+                    "MORAN, JAMES PATRICK", "MORAN, JAMES P  JR."]
             })
         address = {
             "city": "ALEXANDRIA",

--- a/webservices/tests/common.py
+++ b/webservices/tests/common.py
@@ -26,9 +26,9 @@ class ApiBaseTest(unittest.TestCase):
         cryptic "this 500 attribute dict is different than that one"). prefix
         is an identifier to see where we are in the tree
         Inspiration from 18f/hourglass's assertResultsEqual()"""
-        if isinstance(expected, dict):
+        if isinstance(expected, dict) and isinstance(actual, dict):
             self.assertDictsEqual(actual, expected, prefix)
-        elif isinstance(expected, list):
+        elif isinstance(expected, list) and isinstance(actual, list):
             self.assertListsEqual(actual, expected, prefix)
         else:
             self.assertEqual(actual, expected)
@@ -39,8 +39,8 @@ class ApiBaseTest(unittest.TestCase):
         self.assertEqual(
             actual_keys, expected_keys,
             prefix + ": Different keys:\n"
-            ("Unique to actual: %s\n" % actual_keys - expected_keys)
-            ("Unique to expected: %s" % expected_keys - actual_keys))
+            + ("Unique to actual: %s\n" % (actual_keys - expected_keys))
+            + ("Unique to expected: %s" % (expected_keys - actual_keys)))
         for key in expected_keys:
             self.assertResultsEqual(actual[key], expected[key],
                                     prefix + '.' + key)
@@ -51,7 +51,9 @@ class ApiBaseTest(unittest.TestCase):
             len(actual), len(expected),
             prefix + ": Different number of elements "
             "(actual: %d, expected: %d)" % (len(actual), len(expected)))
-        if set(actual) == set(expected):
+        # Check for out of order. Note we can't use set as we might have an
+        # unhashable type
+        if len(actual) == len(expected) and all(a in expected for a in actual):
             self.assertEqual(actual, expected,
                              prefix + ": Sort order is wrong")
         for i in range(len(expected)):

--- a/webservices/tests/common.py
+++ b/webservices/tests/common.py
@@ -1,0 +1,59 @@
+import json
+import unittest
+
+from webservices import rest
+
+
+class ApiBaseTest(unittest.TestCase):
+    @property
+    def __test__(self):
+        """Don't test the base class"""
+        return self.__class__ != ApiBaseTest
+
+    def setUp(self):
+        rest.app.config['TESTING'] = True
+        self.app = rest.app.test_client()
+
+    def _response(self, qry):
+        response = self.app.get(qry)
+        self.assertEquals(response.status_code, 200)
+        result = json.loads(response.data)
+        self.assertEqual(result['api_version'], '0.2')
+        return result
+
+    def assertResultsEqual(self, actual, expected, prefix=""):
+        """This method provides some quick debugging info (rather than the
+        cryptic "this 500 attribute dict is different than that one"). prefix
+        is an identifier to see where we are in the tree
+        Inspiration from 18f/hourglass's assertResultsEqual()"""
+        if isinstance(expected, dict):
+            self.assertDictsEqual(actual, expected, prefix)
+        elif isinstance(expected, list):
+            self.assertListsEqual(actual, expected, prefix)
+        else:
+            self.assertEqual(actual, expected)
+
+    def assertDictsEqual(self, actual, expected, prefix):
+        """Match keys and values. Recurse"""
+        actual_keys, expected_keys = set(actual.keys()), set(expected.keys())
+        self.assertEqual(
+            actual_keys, expected_keys,
+            prefix + ": Different keys:\n"
+            ("Unique to actual: %s\n" % actual_keys - expected_keys)
+            ("Unique to expected: %s" % expected_keys - actual_keys))
+        for key in expected_keys:
+            self.assertResultsEqual(actual[key], expected[key],
+                                    prefix + '.' + key)
+
+    def assertListsEqual(self, actual, expected, prefix):
+        """Check length, order, and recurse"""
+        self.assertEqual(
+            len(actual), len(expected),
+            prefix + ": Different number of elements "
+            "(actual: %d, expected: %d)" % (len(actual), len(expected)))
+        if set(actual) == set(expected):
+            self.assertEqual(actual, expected,
+                             prefix + ": Sort order is wrong")
+        for i in range(len(expected)):
+            self.assertResultsEqual(actual[i], expected[i],
+                                    prefix + '[%d]' % i)


### PR DESCRIPTION
Adds a regression test for querying all fields on a single candidate + comments on where these fields are coming from. This will need to be rewritten for #360, but may help debug that, too.

Also fixed a bug with "other_names".