### PR TITLE
Changed candidate list view election years behavior

### DIFF
--- a/data/sql_updates/create_candidates_vw.sql
+++ b/data/sql_updates/create_candidates_vw.sql
@@ -1,33 +1,38 @@
 drop view if exists ofec_candidates_vw;
 create view ofec_candidates_vw as
-select distinct
+select
     dimcand.cand_sk as candidate_key,
     dimcand.cand_id as candidate_id,
-    csi.cand_status as candidate_status_short,
-    case csi.cand_status
+    max(csi_recent.cand_status) as candidate_status_short,
+    case max(csi_recent.cand_status)
         when 'C' then 'candidate'
         when 'F' then 'future candidate'
         when 'N' then 'not yet a candidate'
         when 'P' then 'prior candidate'
         else 'unknown' end as candidate_status,
-    dimoffice.office_district as district,
-    co.cand_election_yr as election_year,
-    csi.ici_code as incumbent_challenge_short,
-    case csi.ici_code 
+    max(dimoffice.office_district) as district,
+    csi_recent.election_yr as active_through,
+    (select array_agg(distinct election_yr)::int[] from dimcandstatusici csi where csi.cand_sk = dimcand.cand_sk) as election_years,
+    max(csi_recent.ici_code) as incumbent_challenge_short,
+    case max(csi_recent.ici_code)
         when 'I' then 'incumbent'
         when 'C' then 'challenger'
         when 'O' then 'open seat'
         else 'unknown' end as incumbent_challenge,
-    dimoffice.office_tp as office_short,
-    dimoffice.office_tp_desc as office,
-    dimparty.party_affiliation as party_short,
-    dimparty.party_affiliation_desc as party,
-    dimoffice.office_state as state,
+    max(dimoffice.office_tp) as office_short,
+    max(dimoffice.office_tp_desc) as office,
+    max(dimparty.party_affiliation) as party_short,
+    max(dimparty.party_affiliation_desc) as party,
+    max(dimoffice.office_state) as state,
     (select cand_nm from dimcandproperties cp where cp.cand_sk = dimcand.cand_sk order by candproperties_sk desc limit 1) as name
 from dimcand
-    inner join dimcandstatusici csi using (cand_sk)
-    inner join dimcandoffice co on co.cand_sk = csi.cand_sk and co.cand_election_yr = csi.election_yr
+    inner join (select distinct on (cand_sk) cand_sk, election_yr, cand_status, ici_code from dimcandstatusici order by cand_sk, election_yr desc) csi_recent using (cand_sk)
+    inner join dimcandoffice co on co.cand_sk = dimcand.cand_sk and co.cand_election_yr = csi_recent.election_yr  -- only joined to get to dimoffice
     inner join dimoffice using (office_sk)
     inner join dimparty using (party_sk)
+group by
+    dimcand.cand_sk,
+    dimcand.cand_id,
+    csi_recent.election_yr
 ;
 grant select on table ofec_candidates_vw to webro;

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -1,6 +1,7 @@
 from flask.ext.restful import Resource, reqparse, fields, marshal_with, inputs
 from webservices.common.models import db
 from webservices.common.util import default_year
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.sql import text
 
 
@@ -10,7 +11,8 @@ candidate_fields = {
     'candidate_status_short': fields.String,
     'candidate_status': fields.String,
     'district': fields.String,
-    'election_year': fields.Integer,
+    'active_through': fields.Integer,
+    'election_years': fields.List(fields.Integer),
     'incumbent_challenge_short': fields.String,
     'incumbent_challenge': fields.String,
     'office_short': fields.String,
@@ -104,7 +106,7 @@ class CandidateList(Resource):
             candidates = candidates.filter(Candidate.name.ilike('%{}%'.format(args['name'])))
 
         if args.get('election_year') and args['election_year'] != '*':
-            candidates = candidates.filter(Candidate.election_year.in_(args['election_year'].split(',')))
+            candidates = candidates.filter(Candidate.election_years.overlap([int(x) for x in args['election_year'].split(',')]))
 
         count = candidates.count()
 
@@ -117,7 +119,8 @@ class Candidate(db.Model):
     candidate_status_short = db.Column(db.String(1))
     candidate_status = db.Column(db.String(11))
     district = db.Column(db.String(2))
-    election_year = db.Column(db.Integer)
+    active_through = db.Column(db.Integer)
+    election_years = db.Column(ARRAY(db.Integer))
     incumbent_challenge_short = db.Column(db.String(1))
     incumbent_challenge = db.Column(db.String(10))
     office_short = db.Column(db.String(1))

--- a/webservices/test_api.py
+++ b/webservices/test_api.py
@@ -36,7 +36,7 @@ class OverallTest(ApiBaseTest):
     def test_year_filter(self):
         results = self._results('/candidate?year=1988&fields=*')
         for r in results:
-            self.assertEqual(r.get('election_year'), 1988)
+            self.assertEqual(r.get('active_through'), 1988)
 
     def test_per_page_defaults_to_20(self):
         results = self._results('/candidate')
@@ -61,7 +61,7 @@ class OverallTest(ApiBaseTest):
         for itm in page_two:
             self.assertIn(itm, page_one_and_two)
 
-# Candidates
+    ### Candidates ###
     def test_fields(self):
         # testing key defaults
         response = self._results('/candidate/P80003338?year=2008')


### PR DESCRIPTION
- `active_through` now shows most recent year
- `election_years` will show all election years candidate participated
  regardless of filters
- ofec_candidates_vw will now only return one line per candidate
- all status details will be according to the most recent record