### PR TITLE
Name standardization to match the previous _full pattern.

### DIFF
--- a/data/sql_updates/create_candidates_vw.sql
+++ b/data/sql_updates/create_candidates_vw.sql
@@ -3,26 +3,26 @@ create view ofec_candidates_vw as
 select
     dimcand.cand_sk as candidate_key,
     dimcand.cand_id as candidate_id,
-    max(csi_recent.cand_status) as candidate_status_short,
+    max(csi_recent.cand_status) as candidate_status,
     case max(csi_recent.cand_status)
-        when 'C' then 'candidate'
-        when 'F' then 'future candidate'
-        when 'N' then 'not yet a candidate'
-        when 'P' then 'prior candidate'
-        else 'unknown' end as candidate_status,
+        when 'C' then 'Candidate'
+        when 'F' then 'Future candidate'
+        when 'N' then 'Not yet a candidate'
+        when 'P' then 'Prior candidate'
+        else 'Unknown' end as candidate_status_full,
     max(dimoffice.office_district) as district,
     csi_recent.election_yr as active_through,
     (select array_agg(distinct election_yr)::int[] from dimcandstatusici csi where csi.cand_sk = dimcand.cand_sk) as election_years,
-    max(csi_recent.ici_code) as incumbent_challenge_short,
+    max(csi_recent.ici_code) as incumbent_challenge,
     case max(csi_recent.ici_code)
-        when 'I' then 'incumbent'
-        when 'C' then 'challenger'
-        when 'O' then 'open seat'
-        else 'unknown' end as incumbent_challenge,
-    max(dimoffice.office_tp) as office_short,
-    max(dimoffice.office_tp_desc) as office,
-    max(dimparty.party_affiliation) as party_short,
-    max(dimparty.party_affiliation_desc) as party,
+        when 'I' then 'Incumbent'
+        when 'C' then 'Challenger'
+        when 'O' then 'Open seat'
+        else 'Unknown' end as incumbent_challenge_full,
+    max(dimoffice.office_tp) as office,
+    max(dimoffice.office_tp_desc) as office_full,
+    max(dimparty.party_affiliation) as party,
+    max(dimparty.party_affiliation_desc) as party_full,
     max(dimoffice.office_state) as state,
     (select cand_nm from dimcandproperties cp where cp.cand_sk = dimcand.cand_sk order by candproperties_sk desc limit 1) as name
 from dimcand

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -8,16 +8,16 @@ from sqlalchemy.sql import text
 # output format for flask-restful marshaling
 candidate_fields = {
     'candidate_id': fields.String,
-    'candidate_status_short': fields.String,
+    'candidate_status_full': fields.String,
     'candidate_status': fields.String,
     'district': fields.String,
     'active_through': fields.Integer,
     'election_years': fields.List(fields.Integer),
-    'incumbent_challenge_short': fields.String,
+    'incumbent_challenge_full': fields.String,
     'incumbent_challenge': fields.String,
-    'office_short': fields.String,
+    'office_full': fields.String,
     'office': fields.String,
-    'party_short': fields.String,
+    'party_full': fields.String,
     'party': fields.String,
     'state': fields.String,
     'name': fields.String,
@@ -45,15 +45,13 @@ class CandidateList(Resource):
     parser.add_argument('name', type=str, help="Candidate's name (full or partial)")
     parser.add_argument('office', type=str, help='Governmental office candidate runs for')
     parser.add_argument('state', type=str, help='U. S. State candidate is registered in')
-    parser.add_argument('party', type=str, help="Party under which a candidate ran for office")
-    parser.add_argument('party_short', type=str, help="Three letter code of the party under which a candidate ran for office")
+    parser.add_argument('party', type=str, help="Three letter code for the party under which a candidate ran for office")
     parser.add_argument('year', type=str, default=default_year(), dest='election_year', help="Year in which a candidate runs for office")
     parser.add_argument('fields', type=str, help='Choose the fields that are displayed')
     parser.add_argument('district', type=str, help='Two digit district number')
-    parser.add_argument('candidate_status', type=str, help='Test explaining if the candidate is a present, future or past candidate')
-    parser.add_argument('candidate_status_short', type=str, help='Code explaining if the candidate is a present, future or past candidate')
-    parser.add_argument('incumbent_challenge', type=str, help='Text explaining if the candidate is an incumbent, a challenger, or if the seat is open.')
-    parser.add_argument('incumbent_challenge_short', type=str, help='Code explaining if the candidate is an incumbent, a challenger, or if the seat is open.')
+    parser.add_argument('candidate_status', type=str, help='One letter code explaining if the candidate is a present, future or past candidate')
+    parser.add_argument('incumbent_challenge', type=str, help='One letter code explaining if the candidate is an incumbent, a challenger, or if the seat is open.')
+
 
     @marshal_with(candidate_list_fields)
     def get(self, **kwargs):
@@ -92,12 +90,10 @@ class CandidateList(Resource):
             candidates = candidates.filter(Candidate.candidate_key.in_(
                 db.session.query("cand_sk").from_statement(text(fulltext_qry)).params(findme=findme)))
 
-        for argname in ['office', 'district', 'state', 'party', 'candidate_id']:
+        for argname in ['candidate_id', 'candidate_status', 'district', 'incumbent_challenge', 'office', 'party', 'state']:
             if args.get(argname):
                 if ',' in args[argname]:
                     candidates = candidates.filter(getattr(Candidate, argname).in_(args[argname].split(',')))
-                elif argname in ['office', 'party', 'incumbent_challenge', 'candidate_status']:
-                    candidates = candidates.filter_by(**{argname + '_short': args[argname]})
                 else:
                     candidates = candidates.filter_by(**{argname: args[argname]})
 
@@ -116,17 +112,17 @@ class CandidateList(Resource):
 class Candidate(db.Model):
     candidate_key = db.Column(db.Integer, primary_key=True)
     candidate_id = db.Column(db.String(10))
-    candidate_status_short = db.Column(db.String(1))
-    candidate_status = db.Column(db.String(11))
+    candidate_status = db.Column(db.String(1))
+    candidate_status_full = db.Column(db.String(11))
     district = db.Column(db.String(2))
     active_through = db.Column(db.Integer)
     election_years = db.Column(ARRAY(db.Integer))
-    incumbent_challenge_short = db.Column(db.String(1))
-    incumbent_challenge = db.Column(db.String(10))
-    office_short = db.Column(db.String(1))
-    office = db.Column(db.String(9))
-    party_short = db.Column(db.String(3))
-    party = db.Column(db.String(255))
+    incumbent_challenge = db.Column(db.String(1))
+    incumbent_challenge_full = db.Column(db.String(10))
+    office = db.Column(db.String(1))
+    office_full = db.Column(db.String(9))
+    party = db.Column(db.String(3))
+    party_full = db.Column(db.String(255))
     state = db.Column(db.String(2))
     name = db.Column(db.String(100))
 

--- a/webservices/test_api.py
+++ b/webservices/test_api.py
@@ -114,7 +114,7 @@ class OverallTest(ApiBaseTest):
         self.assertEquals(len(elections), 2)
 
 
-    @unittest.skip("Year aggregation needs to be implemented.")
+    @unittest.skip("We are just showing one year at a time, this would be a good feature for /candidate/<id> but it is not a priority right now")
     def test_multi_year(self):
         # testing search
         response = self._results('/candidate?candidate_id=P80003338&year=2012,2008')


### PR DESCRIPTION
This standardizes the names so that we are not using _short anymore. I hope this makes the refactor easier on the front end and the name in the calls will reflect the output. I also added sentence case for the full names, since that was what Noah said he preferred. 

I will use the same patterns in /committees to keep things consistent. 