### PR TITLE
Add some simple scrapers for FEC election results

### DIFF
--- a/requirements-scrapers.txt
+++ b/requirements-scrapers.txt
@@ -1,0 +1,3 @@
+lxml
+requests
+xlrd

--- a/requirements-scrapers.txt
+++ b/requirements-scrapers.txt
@@ -1,3 +1,4 @@
 lxml
 requests
 xlrd
+uuid

--- a/scripts/scrapers/pubrec.py
+++ b/scripts/scrapers/pubrec.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+import sys
+
+import xlrd
+import lxml.html
+import requests
+
+
+LIBRARY = "http://www.fec.gov/general/library.shtml"
+
+
+def lxmlize(url):
+    req = requests.get(url)
+    page = lxml.html.fromstring(req.content)
+    page.make_links_absolute(url)
+    return page
+
+
+def scrape_xls(xls):
+    book = xlrd.open_workbook(xls)
+    print(book)
+
+
+def scrape_html(page):
+    for spreadsheet in page.xpath(
+        "//a[contains(@href, 'federalelections') "
+            "and contains(@href, '.xls')]/@href"
+    ):
+        print(spreadsheet)
+
+    if False:
+        yield
+
+
+def save(data):
+    for el in data:
+        print(el)
+
+
+def scrape():
+    return scrape_xls("federalelections2012.xls")
+
+    lib = lxmlize(LIBRARY)
+    for page in set(lib.xpath("//a[contains(@href, 'federalelections')]/@href")):
+        if page.endswith(".pdf"):
+            continue  # XXX: Write a PDF parser
+        save(scrape_html(lxmlize(page)))
+
+
+if __name__ == "__main__":
+    scrape(*sys.argv[1:])


### PR DESCRIPTION
This was a quick Open Data Day hack; nothing groundbreaking here

This will do a really simple translation from XLS data sources to records on disk. This is likely *not* the best way to import the data, but I figured I'd at least have the scraper do *something* before I left ODD.

Reamining issues:

 - [ ] inconsistant field names over years
 - [ ] more recent (90's -> 00's) data is in HTML form, scraping that is low hanging
 - [ ] import to the database
 - [ ] don't write bajillions of files to disk
 - [ ] Grab presidental race data too
 - [ ] scrape data in other sheets
 - [x] OPEN ALL THE DATA

:+1: 


```json
{"LAST NAME, FIRST": "Dornan, Robert K. \"Bob\"", "#": 503.0, "RUNOFF %": "", "GENERAL %": "", "Notes (See Endnotes Tab)": "", "DISTRICT": "46", "GE RUNOFF": "", "LAST NAME": "Dornan", "TOTAL VOTES": "", "PRIMARY": 13630.0, "GENERAL": "", "GE RUNOFF %": "", "FIRST NAME": "Robert K. \"Bob\"", "STATE": "California", "STATE ABBREVIATION": "CA", "PRIMARY %": 0.16468910852806845, "RUNOFF": "", "PARTY": "R", "FEC ID": "H6CA27124", "INCUMBENT INDICATOR": ""}
```