### PR TITLE
Added a 'refresh_db' command to manage.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_script:
   - psql -f data/cfdm_test.pgdump.sql -U postgres cfdm_test
   - psql -c "SELECT count(*) FROM dimcand" -U postgres cfdm_test
   - pip install -r requirements.txt
-  - python webservices/manage.py refresh_db
+  - python manage.py refresh_db
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ before_script:
   - md5sum data/cfdm_test.pgdump.sql
   - psql -f data/cfdm_test.pgdump.sql -U postgres cfdm_test
   - psql -c "SELECT count(*) FROM dimcand" -U postgres cfdm_test
-  - python webservices/manage.py refresh_db
   - pip install -r requirements.txt
+  - python webservices/manage.py refresh_db
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,6 @@ before_script:
   - md5sum data/cfdm_test.pgdump.sql
   - psql -f data/cfdm_test.pgdump.sql -U postgres cfdm_test
   - psql -c "SELECT count(*) FROM dimcand" -U postgres cfdm_test
-  - psql -f data/sql_updates/create_candidates_vw.sql -U postgres cfdm_test
-  - psql -f data/sql_updates/create_candidate_detail_vw.sql -U postgres cfdm_test
-  - psql -f data/sql_updates/create_committees_vw.sql -U postgres cfdm_test
-  - psql -f data/sql_updates/create_totals_pacs_parties_view.sql -U postgres cfdm_test
-  - psql -f data/sql_updates/create_totals_presidential_view.sql -U postgres cfdm_test
-  - psql -f data/sql_updates/create_totals_house_senate_view.sql -U postgres cfdm_test
-  - psql -f data/sql_updates/create_committee_detail_vw.sql -U postgres cfdm_test
-  - psql -f data/sql_updates/create_linkage_names_vw.sql -U postgres cfdm_test
+  - python webservices/manage.py refresh_db
   - pip install -r requirements.txt
 script: nosetests

--- a/data/sql_updates/README.md
+++ b/data/sql_updates/README.md
@@ -1,0 +1,3 @@
+Every file in this directory will be called by the Flask app's manage.py refresh_views command, so make sure it is up to date, and anything that must be run in order must go in order in the same file.
+
+This is an extremely simple "migrations" system, but we don't need anything more at this time, as all OpenFEC tables are only views and can be dropped and recreated at any time, in a matter of minutes. There is no data to be "migrated."

--- a/data/sql_updates/alter_read_only_web_role.sql
+++ b/data/sql_updates/alter_read_only_web_role.sql
@@ -1,2 +1,16 @@
+DO
+$body$
+BEGIN
+   IF NOT EXISTS (
+      SELECT *
+      FROM   pg_catalog.pg_user
+      WHERE  usename = 'webro') THEN
+
+      CREATE ROLE webro;
+   END IF;
+END
+$body$
+;
+
 alter default privileges in schema public
     grant select on tables to webro;

--- a/data/sql_updates/create_candidate_detail_vw.sql
+++ b/data/sql_updates/create_candidate_detail_vw.sql
@@ -1,4 +1,3 @@
-drop view if exists ofec_candidate_detail_vw;
 drop materialized view if exists ofec_candidate_detail_vw;
 create materialized view ofec_candidate_detail_vw as
 select

--- a/data/sql_updates/run_all.sql
+++ b/data/sql_updates/run_all.sql
@@ -1,8 +1,0 @@
-\i create_candidates_vw.sql
-\i create_candidate_detail_vw.sql
-\i create_committees_vw.sql
-\i create_totals_pacs_parties_view.sql
-\i create_totals_presidential_view.sql
-\i create_totals_house_senate_view.sql
-\i create_committee_detail_vw.sql
-\i create_linkage_names_vw.sql

--- a/manage.py
+++ b/manage.py
@@ -1,8 +1,8 @@
-from common.util import get_full_path
+from webservices.common.util import get_full_path
 from flask.ext.script import Manager
 from flask import url_for
 
-from rest import app, db
+from webservices.rest import app, db
 import glob
 
 manager = Manager(app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+.
 psycopg2 
 htsql-pgsql 
 sqlalchemy 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-.
 psycopg2 
 htsql-pgsql 
 sqlalchemy 
 git+git://github.com/flask-restful/flask-restful.git
 nose
 flask-sqlalchemy
-flask-script
+Flask-Script

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sqlalchemy
 git+git://github.com/flask-restful/flask-restful.git
 nose
 flask-sqlalchemy
+flask-script

--- a/webservices/common/util.py
+++ b/webservices/common/util.py
@@ -1,5 +1,13 @@
 from datetime import datetime
 from flask.ext.restful import reqparse
+from os.path import dirname
+from os.path import join as join_path
+
+MAIN_DIRECTORY = dirname(dirname(dirname(__file__)))
+
+
+def get_full_path(*path):
+    return join_path(MAIN_DIRECTORY, *path)
 
 
 def merge_dicts(x, y):
@@ -7,10 +15,12 @@ def merge_dicts(x, y):
     z.update(y)
     return z
 
+
 def default_year():
     year = datetime.now().year
     years = [str(y) for y in range(year, year-4, -1)]
     return ','.join(years)
+
 
 def natural_number(n):
     result = int(n)

--- a/webservices/manage.py
+++ b/webservices/manage.py
@@ -2,7 +2,7 @@ from common.util import get_full_path
 from flask.ext.script import Manager
 from flask import url_for
 
-from rest import app
+from rest import app, db
 import glob
 
 manager = Manager(app)
@@ -28,13 +28,17 @@ def list_routes():
 
 @manager.command
 def refresh_db():
+    print "Starting DB refresh..."
     sql_dir = get_full_path('data/sql_updates/')
     files = glob.glob(sql_dir + '*.sql')
 
     for sql_file in files:
+        print "Running {}".format(sql_file)
         with open(sql_file, 'r') as sql_fh:
             sql = '\n'.join(sql_fh.readlines())
             db.engine.execute(sql)
+
+    print "Finished DB refresh."
 
 
 if __name__ == "__main__":

--- a/webservices/manage.py
+++ b/webservices/manage.py
@@ -1,7 +1,9 @@
+from common.util import get_full_path
 from flask.ext.script import Manager
 from flask import url_for
 
 from rest import app
+import glob
 
 manager = Manager(app)
 
@@ -22,6 +24,17 @@ def list_routes():
 
     for line in sorted(output):
         print line
+
+
+@manager.command
+def refresh_db():
+    sql_dir = get_full_path('data/sql_updates/')
+    files = glob.glob(sql_dir + '*.sql')
+
+    for sql_file in files:
+        with open(sql_file, 'r') as sql_fh:
+            sql = '\n'.join(sql_fh.readlines())
+            db.engine.execute(sql)
 
 
 if __name__ == "__main__":

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -49,8 +49,7 @@ import flask.ext.restful.representations.json
 from json_encoding import TolerantJSONEncoder
 import sqlalchemy as sa
 
-from db import db_conn, as_dicts
-from resources import Searchable
+from db import db_conn
 from totals.resources import TotalResource, TotalSearch
 from webservices.common.models import db
 from webservices.resources.candidates import CandidateList, CandidateView
@@ -68,8 +67,7 @@ flask.ext.restful.representations.json.settings["cls"] = TolerantJSONEncoder
 def sqla_conn_string():
     sqla_conn_string = os.getenv('SQLA_CONN')
     if not sqla_conn_string:
-        print("Environment variable SQLA_CONN is empty; running against "
-              + "local `cfdm_test`")
+        print("Environment variable SQLA_CONN is empty; running against " + "local `cfdm_test`")
         sqla_conn_string = 'postgresql://:@/cfdm_test'
     print sqla_conn_string
     return sqla_conn_string
@@ -120,7 +118,7 @@ class Help(restful.Resource):
     def get(self):
         result = {'doc': sys.modules[__name__].__doc__,
                   'endpoints': {}}
-        for cls in (CandidateList, CommitteeSearch):
+        for cls in (CandidateList):
             name = cls.__name__[:-6].lower()
             result['endpoints'][name] = {
                 'arguments supported': {a.name: a.help

--- a/webservices/totals/resources.py
+++ b/webservices/totals/resources.py
@@ -4,7 +4,7 @@ from flask.ext.restful import reqparse
 
 from webservices.common.util import natural_number
 from webservices.resources import Searchable, SingleResource
-from .models import Total
+from webservices.totals.models import Total
 
 
 class BaseTotalsResource(Total):


### PR DESCRIPTION
This is a simpler system than "migrations", but we don't need real migrations when all of our tables are (materialized) views, and updating them simply means dropping and recreating them, no matter the change. We also don't have views that rely on one another, at least at this point, so ordering is not a problem.

What this provides is a one-step command that runs all the SQL scripts, and can be easily called by either a dev or another process, to keep the database up to date.

```
python webservices/manage.py refresh_db
```