### PR TITLE
Query candidate ids

### DIFF
--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -58,6 +58,7 @@ class CandidateDetail(db.Model):
 class Committee(db.Model):
     committee_key = db.Column(db.Integer, primary_key=True)
     committee_id = db.Column(db.String(9))
+    candidate_ids = db.Column(ARRAY(db.String))
     designation = db.Column(db.String(1))
     designation_full = db.Column(db.String(25))
     treasurer_name = db.Column(db.String(100))

--- a/webservices/tests/committee_tests.py
+++ b/webservices/tests/committee_tests.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 
+from webservices.common import models
 from .common import ApiBaseTest
 
 ## old, re-factored Committee tests ##
@@ -39,6 +40,24 @@ class CommitteeFormatTest(ApiBaseTest):
         results = response['results'][0]
         self.assertEqual(results['organization_type_full'], 'Corporation')
         self.assertEqual(results['organization_type'], 'C')
+
+    def test_filter_by_candidate_id(self):
+        response = self._response('/committees?candidate_id=H2CA37213')
+        self.assertEqual(
+            len(response['results']),
+            models.Committee.query.filter(
+                models.Committee.candidate_ids.overlap(['H2CA37213'])
+            ).count(),
+        )
+
+    def test_filter_by_candidate_ids(self):
+        response = self._response('/committees?candidate_id=H2CA37213,H2CA38088')
+        self.assertEqual(
+            len(response['results']),
+            models.Committee.query.filter(
+                models.Committee.candidate_ids.overlap(['H2CA37213', 'H2CA38088'])
+            ).count(),
+        )
 
     def test_committee_detail_fields(self):
         response = self._response('/committee/C00048587')

--- a/webservices/tests/common.py
+++ b/webservices/tests/common.py
@@ -14,8 +14,13 @@ class ApiBaseTest(unittest.TestCase):
     def setUp(self):
         rest.app.config['TESTING'] = True
         self.app = rest.app.test_client()
+        self.ctx = rest.app.app_context()
+        self.ctx.push()
         self.longMessage = True
         self.maxDiff = None
+
+    def tearDown(self):
+        self.ctx.pop()
 
     def _response(self, qry):
         response = self.app.get(qry)


### PR DESCRIPTION
The `CommitteeList` resource may attempt to query on `candidate_ids`, but that field isn't mapped in the `Committee` model. This patch adds the missing column and tests on querying by candidate ID.