### PR TITLE
[WIP]Adds bootstrap script and vagrant setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ We are taking data from the Federal Election Commission and creating an API arou
 
 ## Outside Contributors
 
-Hello! If you're interested in learning more about this project, check out some related repos and don't be afraid to ask us questions (general questions usually go here: [fec](https://github.com/18F/fec)). 
+Hello! If you're interested in learning more about this project, check out some related repos and don't be afraid to ask us questions (general questions usually go here: [fec](https://github.com/18F/fec)).
 
-If you'd like to contribute to our project, please check out our [openfec] (https://github.com/18F/openfec) repo. We try to tag things that are easy to pick up without being entrenched in our project with a "help wanted" tag. Things in our [backlog] (https://github.com/18F/openfec/milestones/Backlog) are usually also up for grabs, so let us know if you'd like to pick something up from there. 
+If you'd like to contribute to our project, please check out our [openfec](https://github.com/18F/openfec) repo. We try to tag things that are easy to pick up without being entrenched in our project with a "help wanted" tag. Things in our [backlog](https://github.com/18F/openfec/milestones/Backlog) are usually also up for grabs, so let us know if you'd like to pick something up from there.
 
-For those interested in contributing, please check out our [contributing guidelies] (https://github.com/18F/openfec/blob/master/CONTRIBUTING.md) we use to guide our development processes internally. You don't have to adhere to them to participate, but following them may help keep things from getting messy. 
+For those interested in contributing, please check out our [contributing guidelies](https://github.com/18F/openfec/blob/master/CONTRIBUTING.md) we use to guide our development processes internally. You don't have to adhere to them to participate, but following them may help keep things from getting messy.
 
 ## Our Repos
 
-* [fec](https://github.com/18F/fec) - A discussion forum where we can discuss the project. 
-* [openfec] (https://github.com/18F/openfec) - Where the API work happens. We also use this as the central repo to create issues related to each sprint and our backlog here. If you're interested in contribution, please look for "help wanted" tags or ask!
+* [fec](https://github.com/18F/fec) - A discussion forum where we can discuss the project.
+* [openfec](https://github.com/18F/openfec) - Where the API work happens. We also use this as the central repo to create issues related to each sprint and our backlog here. If you're interested in contribution, please look for "help wanted" tags or ask!
 * [openfec-web-app](https://github.com/18f/openfec-web-app) - Where the web app work happens. Note that issues and discussion tend to happen in the other repos.
 
 ## Installation
@@ -24,7 +24,7 @@ For those interested in contributing, please check out our [contributing guideli
 The easiest way to get started with working on openFEC is to run the [bootstrap script](https://raw.githubusercontent.com/18F/openFEC/master/scripts/bootstrap/fec_bootstrap.sh).
 
 Prior to running, ensure you have the following requirements installed:
-<!---requirements--->
+<!--requirements-->
 * virtualenv
 * virtualenvwrapper
 * python3.4
@@ -33,12 +33,12 @@ Prior to running, ensure you have the following requirements installed:
 * npm
 * PostgreSQL
 * tmuxinator
-<!---endrequirements--->
+<!--endrequirements-->
 
 Then, simply run:
-    
+
     $ curl https://raw.githubusercontent.com/18F/openFEC/master/scripts/bootstrap/fec_bootstrap.sh | bash
-    
+
 This will clone both openFEC repos, set up virtual environments, and set some environment variables (that you supply) in ~/.fec_vars. It might be a good idea to source that file in your ~/.bashrc or ~/.zshrc.
 
 NOTE: This will also sync _*this*_ repo. For bootstrapping, we recommend running the script prior to cloning the repo and letting the script handle that.
@@ -56,5 +56,5 @@ From scripts/bootstrap, simply:
 Assuming you ran the bootstrap script, you can launch the API and the Web App with a single command:
 
     $ tmuxinator fec-local
-    
+
 The site can be found at [http://localhost:3000](http://localhost:3000) (or [http://localhost:3001](http://localhost:3001) if using Vagrant). Remember the username and password you created when running the script.

--- a/README.md
+++ b/README.md
@@ -15,14 +15,46 @@ For those interested in contributing, please check out our [contributing guideli
 ## Our Repos
 
 * [fec](https://github.com/18F/fec) - A discussion forum where we can discuss the project. 
-* [openfec] (https://github.com/18F/openfec) - Where our work happens. We create issues related to each sprint and our backlog here. If you're interested in contribution, please look for "help wanted" tags or ask!
+* [openfec] (https://github.com/18F/openfec) - Where the API work happens. We also use this as the central repo to create issues related to each sprint and our backlog here. If you're interested in contribution, please look for "help wanted" tags or ask!
+* [openfec-web-app](https://github.com/18f/openfec-web-app) - Where the web app work happens. Note that issues and discussion tend to happen in the other repos.
 
 ## Installation
-This will work best when installed in to its own [Virtual Environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/)
 
-- `$ python setup.py develop`
-- `$ python openfec/entities/pipeline.py CleanData --local-scheduler`
+### Bootstrap
+The easiest way to get started with working on openFEC is to run the [bootstrap script](https://raw.githubusercontent.com/18F/openFEC/master/scripts/bootstrap/fec_bootstrap.sh).
 
-This will showcase work so far, which includes combining data from a number of different raw exports from FEC's Data Warehouse (sample files are downloaded) in to a single local database powered by LevelDB for analysis, then beginning the steps of cleaning this data to be a little more sane.
+Prior to running, ensure you have the following requirements installed:
+<!---requirements--->
+* virtualenv
+* virtualenvwrapper
+* python3.4
+* pip
+* nodejs
+* npm
+* PostgreSQL
+* tmuxinator
+<!---endrequirements--->
 
-More to come!
+Then, simply run:
+    
+    $ curl https://raw.githubusercontent.com/18F/openFEC/master/scripts/bootstrap/fec_bootstrap.sh | bash
+    
+This will clone both openFEC repos, set up virtual environments, and set some environment variables (that you supply) in ~/.fec_vars. It might be a good idea to source that file in your ~/.bashrc or ~/.zshrc.
+
+NOTE: This will also sync _*this*_ repo. For bootstrapping, we recommend running the script prior to cloning the repo and letting the script handle that.
+
+### Vagrant
+There is also a Vagrantfile and provisioning shell script available. This will create an Ubuntu 14.04 virtual machine, provisioned with all the requirements to run the bootstrap script.
+
+From scripts/bootstrap, simply:
+
+    $ vagrant up
+    $ vagrant ssh
+    $ cp /vagrant/fec_bootstrap.sh fec_bootstrap.sh && ./fec_bootstrap.sh
+
+### Running the apps using tmuxinator
+Assuming you ran the bootstrap script, you can launch the API and the Web App with a single command:
+
+    $ tmuxinator fec-local
+    
+The site can be found at [http://localhost:3000](http://localhost:3000) (or [http://localhost:3001](http://localhost:3001) if using Vagrant). Remember the username and password you created when running the script.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Prior to running, ensure you have the following requirements installed:
 * npm
 * PostgreSQL
 * tmuxinator
+
 <!--endrequirements-->
 
 Then, simply run:

--- a/scripts/bootstrap/Vagrantfile
+++ b/scripts/bootstrap/Vagrantfile
@@ -1,0 +1,6 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision :shell, path: "provision.sh"
+  config.vm.network "forwarded_port", guest: 3000, host: 3001
+  config.vm.network "forwarded_port", guest: 5000, host: 5001
+end

--- a/scripts/bootstrap/fec_bootstrap.sh
+++ b/scripts/bootstrap/fec_bootstrap.sh
@@ -1,25 +1,5 @@
 #!/usr/bin/env bash
 
-
-
-## Install tmux and tmuxinator if necessary
-#if [ ! $(which tmux) ] 2>/dev/null; then
-#    echo "Installing tmux"
-#fi
-#
-#if [ ! $(which tmuxinator) ] 2>/dev/null; then
-#    echo "Installing tmuxinator"
-#fi
-#
-## Install virtualenv if necessary
-#if [ ! $(which virtualenv) ] 2>/dev/null; then
-#    echo "Installing virtualenv"
-#fi
-#
-## Install virtualenvwrapper if necessary
-#if [ ! $(which virtualenvwrapper.sh) ] 2>/dev/null; then
-#    echo "Installing virtualenvwrapper"
-#fi
 source `which virtualenvwrapper.sh`
 
 # Set up openFEC API
@@ -40,6 +20,10 @@ echo "Refreshing DB"
 python manage.py refresh_db
 deactivate
 cd ..
+
+echo "Creating tmuxinator profile"
+cp scripts/bootstrap/tmux/fec-local.yml ~./tmuxinator/fec-local.yml
+sed -i '' 's|<CHANGE>|'`pwd`'|' ~./tmuxinator/fec-local.yml
 
 # Set up openFEC Web App
 echo "Done with API, setting up web app"
@@ -69,14 +53,10 @@ echo "Installation complete."
 echo ""
 echo "Remember to add 'source ~/.fec_vars' to your bashrc or zshrc."
 echo ""
-echo "From the openFEC directory, run:"
+echo "To launch both apps, simply run:"
 echo ""
-echo "    $ python run_api.py"
+echo "     $ tmuxinator fec-local"
 echo ""
-echo "to start the API server at http://localhost:3000."
-echo "From the openFEC-web-app directory, run:"
-echo ""
-echo "    $ python __init__.py"
-echo ""
-echo "to start the web app at http://localhost:5000"
+echo "The API will be running at localhost:5000 and the webapp will"
+echo "be running at localhost:3000"
 echo "------------------------------------------------------------------"

--- a/scripts/bootstrap/fec_bootstrap.sh
+++ b/scripts/bootstrap/fec_bootstrap.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+
+
+## Install tmux and tmuxinator if necessary
+#if [ ! $(which tmux) ] 2>/dev/null; then
+#    echo "Installing tmux"
+#fi
+#
+#if [ ! $(which tmuxinator) ] 2>/dev/null; then
+#    echo "Installing tmuxinator"
+#fi
+#
+## Install virtualenv if necessary
+#if [ ! $(which virtualenv) ] 2>/dev/null; then
+#    echo "Installing virtualenv"
+#fi
+#
+## Install virtualenvwrapper if necessary
+#if [ ! $(which virtualenvwrapper.sh) ] 2>/dev/null; then
+#    echo "Installing virtualenvwrapper"
+#fi
+source `which virtualenvwrapper.sh`
+
+# Set up openFEC API
+echo "Setting up API"
+echo "Cloning repo"
+git clone https://github.com/18F/openFEC.git
+echo "Creating virtualenv"
+cd openFEC
+mkvirtualenv openFEC -p `which python3.4`
+workon openFEC
+echo "Installing requirements"
+pip install -r requirements.txt
+echo "Creating sample DB"
+dropdb cfdm_test 2>/dev/null
+createdb cfdm_test
+psql -f data/cfdm_test.pgdump.sql cfdm_test >/dev/null
+echo "Refreshing DB"
+python manage.py refresh_db
+deactivate
+cd ..
+
+# Set up openFEC Web App
+echo "Done with API, setting up web app"
+echo "Cloning repo"
+git clone https://github.com/18F/openFEC-web-app.git
+echo "Creating virtualenv"
+cd openFEC-web-app
+mkvirtualenv openFEC-web-app -p `which python3.4`
+workon openFEC-web-app
+echo "Installing requirements"
+pip install -r requirements.txt
+npm config set python `which python2.7`
+npm install -g browserify
+npm install
+npm run build
+echo "Web app uses basic auth. Create username and password:"
+read -p "Name: " name
+read -p "Pass: " pass
+echo "export FEC_WEB_USERNAME=$name" > ~/.fec_vars
+echo "export FEC_WEB_PASSWORD=$pass" >> ~/.fec_vars
+source ~/.fec_vars
+echo "Web app installed."
+echo ""
+echo ""
+echo "------------------------------------------------------------------"
+echo "Installation complete."
+echo ""
+echo "Remember to add 'source ~/.fec_vars' to your bashrc or zshrc."
+echo ""
+echo "From the openFEC directory, run:"
+echo ""
+echo "    $ python run_api.py"
+echo ""
+echo "to start the API server at http://localhost:3000."
+echo "From the openFEC-web-app directory, run:"
+echo ""
+echo "    $ python __init__.py"
+echo ""
+echo "to start the web app at http://localhost:5000"
+echo "------------------------------------------------------------------"

--- a/scripts/bootstrap/provision.sh
+++ b/scripts/bootstrap/provision.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+sudo apt-get install git python3-dev python-pip postgresql libpq-dev -y
+
+pip install virtualenv
+pip install virtualenvwrapper
+
+sudo su vagrant <<'EOF'
+curl https://raw.githubusercontent.com/creationix/nvm/v0.24.1/install.sh | bash
+export NVM_DIR="/home/vagrant/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+source ~/.bashrc
+nvm install v0.11.16
+nvm alias default 0.11.16
+mkdir ~/.virtualenvs
+echo "export WORKON_HOME=~/.virtualenvs" >> ~/.bashrc
+echo "export VIRTUALENVWRAPPER_VIRTUALENV=/usr/local/bin/virtualenv" >> ~/.bashrc
+echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bashrc
+sudo -u postgres createuser -s vagrant
+gem install tmuxinator
+EOF

--- a/scripts/bootstrap/tmux/fec-local.yml
+++ b/scripts/bootstrap/tmux/fec-local.yml
@@ -1,0 +1,34 @@
+# ~/.tmuxinator/fec.yml
+
+name: fec-local
+root: <CHANGE>
+
+# Optional tmux socket
+# socket_name: foo
+
+# Runs before everything. Use it to start daemons etc.
+# pre: sudo /etc/rc.d/mysqld start
+
+# Runs in each window and pane before window/pane specific commands. Useful for setting up interpreter versions.
+pre_window: source ~/.fec_vars
+
+# Pass command line options to tmux. Useful for specifying a different tmux.conf.
+# tmux_options: -f ~/.tmux.mac.conf
+
+# Change the command to call tmux.  This can be used by derivatives/wrappers like byobu.
+# tmux_command: byobu
+
+windows:
+  - servers:
+      layout: tiled
+      panes:
+        - api:
+            - workon openFEC
+            - cd <CHANGE>/openFEC
+            - python run_api.py
+        - site:
+            - workon openFEC-web-app
+            - cd <CHANGE>/openFEC-web-app
+            - python __init__.py
+        - d:
+            - tmux detach


### PR DESCRIPTION
Getting started with development on the two repos is non obvious. This PR adds the ability to quickly bootstrap the environment for working on openFEC and openFEC-web-app.

Next steps could be to add provisioning scripts to add all requirements for Linux or OSX automatically (python3, virutalenv, postgres, etc).