### PR TITLE
White listing the api.data.gov ip when PRODUCTION=true

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -46,12 +46,11 @@ db.init_app(app)
 # api.data.gov
 trusted_proxies = ('192.168.114.100',)
 PRODUCTION = os.getenv('PRODUCTION', False)
-print(PRODUCTION)
+
 
 @app.before_request
 def limit_remote_addr():
-    if PRODUCTION == 'true':
-        print('running')
+    if PRODUCTION != False:
         remote = request.remote_addr
         route = list(request.access_route)
         while remote in trusted_proxies:

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -45,13 +45,13 @@ db.init_app(app)
 
 # api.data.gov
 trusted_proxies = ('192.168.114.100',)
-PRODUCTION = os.getenv('PRODUCTION', False)
+WHITE_LIST = os.getenv('WHITE_LIST', False)
 
 
 @app.before_request
 def limit_remote_addr():
     falses = (False, 'False', 'false', 'f')
-    if PRODUCTION not in falses :
+    if WHITE_LIST not in falses :
         remote = request.remote_addr
         route = list(request.access_route)
         while remote in trusted_proxies:

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -44,7 +44,7 @@ api = restful.Api(app)
 db.init_app(app)
 
 # api.data.gov
-trusted_proxies = ('192.168.114.100')
+trusted_proxies = ('192.168.114.100',)
 PRODUCTION = os.getenv('PRODUCTION', False)
 print(PRODUCTION)
 

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -45,13 +45,13 @@ db.init_app(app)
 
 # api.data.gov
 trusted_proxies = ('192.168.114.100',)
-WHITE_LIST = os.getenv('WHITE_LIST', False)
+FEC_API_WHITELIST_IPS = os.getenv('FEC_API_WHITELIST_IPS', False)
 
 
 @app.before_request
 def limit_remote_addr():
     falses = (False, 'False', 'false', 'f')
-    if WHITE_LIST not in falses :
+    if FEC_API_WHITELIST_IPS not in falses :
         remote = request.remote_addr
         route = list(request.access_route)
         while remote in trusted_proxies:

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -8,7 +8,7 @@ import logging
 import sys
 import os
 
-from flask import Flask
+from flask import Flask, abort, request
 from flask.ext import restful
 from flask.ext.restful import reqparse
 import flask.ext.restful.representations.json
@@ -42,6 +42,24 @@ app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = sqla_conn_string()
 api = restful.Api(app)
 db.init_app(app)
+
+# api.data.gov
+trusted_proxies = ('192.168.114.100')
+PRODUCTION = os.getenv('PRODUCTION', False)
+print(PRODUCTION)
+
+@app.before_request
+def limit_remote_addr():
+    if PRODUCTION == 'true':
+        print('running')
+        remote = request.remote_addr
+        route = list(request.access_route)
+        while remote in trusted_proxies:
+            remote = route.pop()
+        print(route.pop())
+
+        if remote not in trusted_proxies:
+            abort(403)
 
 @app.after_request
 def after_request(response):

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -50,7 +50,8 @@ PRODUCTION = os.getenv('PRODUCTION', False)
 
 @app.before_request
 def limit_remote_addr():
-    if PRODUCTION != False:
+    falses = (False, 'False', 'false', 'f')
+    if PRODUCTION not in falses :
         remote = request.remote_addr
         route = list(request.access_route)
         while remote in trusted_proxies:


### PR DESCRIPTION
This is for security and use by api.data.gov. We could add more ips later, if we wanted to. 
issue #518