### PR TITLE
[wip] Run migration in subprocess on cf push.

### DIFF
--- a/run_api.py
+++ b/run_api.py
@@ -1,14 +1,21 @@
-import doctest
 import os
 import sys
+import doctest
+import subprocess
 
 
 from webservices.rest import app
 
 
 if __name__ == '__main__':
-    
+
     port = os.getenv('VCAP_APP_PORT', '5000')
+    instance_id = os.getenv('CF_INSTANCE_INDEX')
+
+    # Run database migration in separate process to avoid Cloud Foundry timeout
+    # Note: Only run if first application process
+    if instance_id == '0':
+        subprocess.Popen(['python manage.py', 'refresh_db'])
 
     if len(sys.argv) > 1 and sys.argv[1].lower().startswith('test'):
         doctest.testmod()


### PR DESCRIPTION
Here's a very simple proposed solution for #547. The database migration script is run automatically on pushing the application to Cloud Foundry. To avoid Cloud Foundry stopping the migration after its timeout period, the migration is run in a subprocess that continues to run after its parent exits. I verified that `subprocess` works as expected on Cloud Foundry in a separate testing project, but haven't been able to get this to build yet. I'll update here once I verify that this works.

@arowla @LindsayYoung does this seem reasonable?