### PR TITLE
Cron refresh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_script:
   - psql -f data/cfdm_test.pgdump.sql -U postgres cfdm_test
   - psql -c "SELECT count(*) FROM dimcand" -U postgres cfdm_test
   - pip install -r requirements.txt
-  - python manage.py refresh_db
+  - python manage.py update_schemas
 script: nosetests

--- a/cron.py
+++ b/cron.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+import celery
+from celery.schedules import crontab
+
+import manage
+
+
+app = celery.Celery('cron')
+app.conf.update(
+    BROKER_URL='sqla+sqlite:///beat.sqlite',
+    CELERY_IMPORTS=('cron', ),
+    CELERYBEAT_SCHEDULE={
+        'refresh': {
+            'task': 'cron.refresh',
+            'schedule': crontab(minute=0, hour=0),
+        }
+    }
+)
+
+
+@app.task
+def refresh():
+    with manage.app.test_request_context():
+        manage.refresh_materialized()
+
+
+if __name__ == '__main__':
+    app.worker_main(['worker', '--beat'])

--- a/cron.py
+++ b/cron.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python
+"""Run background tasks in a crontab-like system using celery beat. Celery does
+not daemonize itself, so this script should be run in a subprocess or managed
+using supervisor or a similar tool.
+
+Simple invocation: ::
+
+    $ ./cron.py
+
+Customizable invocation: ::
+
+    celery worker -app cron --beat
+
+"""
 
 import celery
 from celery.schedules import crontab

--- a/data/refresh/refresh.sql
+++ b/data/refresh/refresh.sql
@@ -1,4 +1,4 @@
--- Refresh all materialized views; borrwed from
+-- Refresh all materialized views; borrowed from
 -- https://github.com/sorokine/RefreshAllMaterializedViews
 
 CREATE OR REPLACE FUNCTION refresh_materialized(schema_arg TEXT DEFAULT 'public')

--- a/data/refresh/refresh.sql
+++ b/data/refresh/refresh.sql
@@ -1,0 +1,19 @@
+-- Refresh all materialized views; borrwed from
+-- https://github.com/sorokine/RefreshAllMaterializedViews
+
+CREATE OR REPLACE FUNCTION refresh_materialized(schema_arg TEXT DEFAULT 'public')
+RETURNS INT AS $$
+  DECLARE
+    view RECORD;
+  BEGIN
+    RAISE NOTICE 'Refreshing materialized view in schema %', schema_arg;
+    FOR view IN SELECT matviewname FROM pg_matviews WHERE schemaname = schema_arg
+    LOOP
+      RAISE NOTICE 'Refreshing %.%', schema_arg, view.matviewname;
+      EXECUTE 'REFRESH MATERIALIZED VIEW ' || schema_arg || '.' || view.matviewname;
+    END LOOP;
+    RETURN 1;
+  END
+$$ LANGUAGE plpgsql;
+
+SELECT refresh_materialized();

--- a/manage.py
+++ b/manage.py
@@ -21,7 +21,9 @@ def list_routes():
 
         methods = ','.join(rule.methods)
         url = url_for(rule.endpoint, **options)
-        line = urllib.parse.unquote("{:50s} {:20s} {}".format(rule.endpoint, methods, url))
+        line = urllib.parse.unquote(
+            '{:50s} {:20s} {}'.format(rule.endpoint, methods, url)
+        )
         output.append(line)
 
     for line in sorted(output):
@@ -30,7 +32,7 @@ def list_routes():
 
 @manager.command
 def refresh_db():
-    print("Starting DB refresh...")
+    print('Starting DB refresh...')
     sql_dir = get_full_path('data/sql_updates/')
     files = glob.glob(sql_dir + '*.sql')
 
@@ -40,7 +42,15 @@ def refresh_db():
             sql = '\n'.join(sql_fh.readlines())
             db.engine.execute(sql)
 
-    print("Finished DB refresh.")
+    print('Finished DB refresh.')
+
+
+@manager.command
+def refresh_materialized():
+    print('Refreshing materialized views...')
+    with open('data/refresh/refresh.sql') as fp:
+        db.engine.execute(fp.read().replace('%', '%%'))
+    print('Finished refreshing materialized views.')
 
 
 if __name__ == "__main__":

--- a/manage.py
+++ b/manage.py
@@ -1,10 +1,11 @@
-from webservices.common.util import get_full_path
-from flask.ext.script import Manager
 from flask import url_for
+from flask.ext.script import Manager
 
-from webservices.rest import app, db
 import glob
+import subprocess
 import urllib.parse
+from webservices.rest import app, db
+from webservices.common.util import get_full_path
 
 
 manager = Manager(app)
@@ -51,6 +52,20 @@ def refresh_materialized():
     with open('data/refresh/refresh.sql') as fp:
         db.engine.execute(fp.read().replace('%', '%%'))
     print('Finished refreshing materialized views.')
+
+
+@manager.command
+def start_beat():
+    subprocess.Popen(['python', 'cron.py'])
+
+
+@manager.command
+def stop_beat():
+    """See http://celery.readthedocs.org/en/latest/userguide/workers.html#stopping-the-worker"""
+    subprocess.Popen(
+        "ps aux | grep 'cron.py' | awk '{print $2}' | xargs kill -9",
+        shell=True,
+    )
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 psycopg2 
-sqlalchemy 
 git+git://github.com/flask-restful/flask-restful.git
 nose
 flask-sqlalchemy
 Flask-Script
+celery>=3.1.17
+SQLAlchemy>=0.9.9

--- a/run_api.py
+++ b/run_api.py
@@ -1,8 +1,11 @@
+#!/usr/bin/env python
+
 import os
 import sys
 import doctest
 import subprocess
 
+import manage
 from webservices.rest import app
 
 
@@ -11,10 +14,11 @@ if __name__ == '__main__':
     port = os.getenv('VCAP_APP_PORT', '5000')
     instance_id = os.getenv('CF_INSTANCE_INDEX')
 
-    # Run database migration in separate process to avoid Cloud Foundry timeout
-    # Note: Only run if first application process
+    # If running on Cloud Foundry and using 0th instance, start celery beat
+    # worker and run schema update in subprocess
     if instance_id == '0':
-        subprocess.Popen(['python', 'manage.py', 'refresh_db'])
+        manage.start_beat()
+        subprocess.Popen(['python', 'manage.py', 'update_schemas'])
 
     if len(sys.argv) > 1 and sys.argv[1].lower().startswith('test'):
         doctest.testmod()

--- a/run_api.py
+++ b/run_api.py
@@ -1,14 +1,21 @@
-import doctest
 import os
 import sys
+import doctest
+import subprocess
 
 
 from webservices.rest import app
 
 
 if __name__ == '__main__':
-    
+
     port = os.getenv('VCAP_APP_PORT', '5000')
+    instance_id = os.getenv('CF_INSTANCE_INDEX')
+
+    # Run database migration in separate process to avoid Cloud Foundry timeout
+    # Note: Only run if first application process
+    if instance_id == '0':
+        subprocess.Popen(['python manage.py', 'refresh_db'])
 
     if len(sys.argv) > 1 and sys.argv[1].lower().startswith('test'):
         doctest.testmod()

--- a/run_api.py
+++ b/run_api.py
@@ -3,7 +3,6 @@ import sys
 import doctest
 import subprocess
 
-
 from webservices.rest import app
 
 
@@ -15,7 +14,7 @@ if __name__ == '__main__':
     # Run database migration in separate process to avoid Cloud Foundry timeout
     # Note: Only run if first application process
     if instance_id == '0':
-        subprocess.Popen(['python manage.py', 'refresh_db'])
+        subprocess.Popen(['python', 'manage.py', 'refresh_db'])
 
     if len(sys.argv) > 1 and sys.argv[1].lower().startswith('test'):
         doctest.testmod()

--- a/scripts/bootstrap/fec_bootstrap.sh
+++ b/scripts/bootstrap/fec_bootstrap.sh
@@ -17,7 +17,7 @@ dropdb cfdm_test 2>/dev/null
 createdb cfdm_test
 psql -f data/cfdm_test.pgdump.sql cfdm_test >/dev/null
 echo "Refreshing DB"
-python manage.py refresh_db
+python manage.py update_schemas
 deactivate
 cd ..
 


### PR DESCRIPTION
Add cron-like task based on Celery Beat to refresh materialized views nightly. Subsumes #566.

This has been updated and should now actually work with the usual CF workflow. Note that the celery beat task isn't debounced at the moment, so invocations could stack up if it were scheduled too frequently--but this shouldn't be an issue for running nightly.

Also, postgres 9.4 added a `REFRESH MATERIALIZED VIEW CONCURRENTLY` function, which might make the refresh faster. @arowla: if we upgrade, we might want to give that a try (we're using 9.3, right?).

* Add cron-like task to run `refresh_materialized` every night at midnight
* Rename management command `refresh_db` to `update_schemas`
* Add management command `refresh_materialized`; refreshes all materialized views
* Add management commands `start_beat` and `stop_beat` to start and stop celery beat workers
* On `run_api`, run `update_schemas` in a subprocess
* On `run_api`, restart celery beat workers