### PR TITLE
Explicitly keep us on the old stack

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -1,5 +1,6 @@
 ---
 memory: 512M
+stack: lucid64
 applications:
 - name: api
   path: .

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -1,5 +1,6 @@
 ---
 memory: 512M
+stack: lucid64
 applications:
 - name: api
   path: .

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -1,5 +1,6 @@
 ---
 memory: 512M
+stack: lucid64
 applications:
 - name: api
   path: .


### PR DESCRIPTION
... until the new one's Python buildpack is ready