### PR TITLE
Use FEC_API_DEBUG flag to control debug mode.

### DIFF
--- a/run_api.py
+++ b/run_api.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import ast
 import os
 import sys
 import doctest
@@ -24,5 +23,5 @@ if __name__ == '__main__':
     if len(sys.argv) > 1 and sys.argv[1].lower().startswith('test'):
         doctest.testmod()
     else:
-        debug = not ast.literal_eval(os.getenv('PRODUCTION', False))
+        debug = bool(os.getenv('FEC_API_DEBUG', ''))
         app.run(debug=debug, port=int(port), host='0.0.0.0')


### PR DESCRIPTION
Make environment configuration consistent with webapp, which uses
FEC_WEB_DEBUG flag for debug mode.

[resolves #582]

I noticed that openFEC-web-app handles this issue with a `FEC_WEB_DEBUG` flag, so figured it would be simplest to use that approach here for consistency. The `PRODUCTION` flag was only used to set debug mode on the app, so I think it's reasonable to use the more specific name. 