### PR TITLE
Optimize queries to build materialized views.

### DIFF
--- a/data/sql_updates/create_candidates_view.sql
+++ b/data/sql_updates/create_candidates_view.sql
@@ -34,7 +34,7 @@ from dimcand
     inner join dimparty using (party_sk)
     left join (
         select distinct on (cand_sk) cand_sk, cand_nm from dimcandproperties
-            order by cand_sk desc
+            order by cand_sk, candproperties_sk desc
     ) candprops on dimcand.cand_sk = candprops.cand_sk
 group by
     dimcand.cand_sk,

--- a/data/sql_updates/create_candidates_view.sql
+++ b/data/sql_updates/create_candidates_view.sql
@@ -33,12 +33,8 @@ from dimcand
     inner join dimoffice using (office_sk)
     inner join dimparty using (party_sk)
     left join (
-        select props.cand_sk, cand_nm from (
-            select cand_sk, max(candproperties_sk) as candproperties_sk from dimcand
-                join dimcandproperties using (cand_sk)
-                group by cand_sk
-        ) props
-            join dimcandproperties using (candproperties_sk)
+        select distinct on (cand_sk) cand_sk, cand_nm from dimcandproperties
+            order by cand_sk desc
     ) candprops on dimcand.cand_sk = candprops.cand_sk
 group by
     dimcand.cand_sk,

--- a/data/sql_updates/create_candidates_view.sql
+++ b/data/sql_updates/create_candidates_view.sql
@@ -25,13 +25,21 @@ select
     max(dimparty.party_affiliation) as party,
     max(dimparty.party_affiliation_desc) as party_full,
     max(dimoffice.office_state) as state,
-    (select cand_nm from dimcandproperties cp where cp.cand_sk = dimcand.cand_sk order by candproperties_sk desc limit 1) as name
+    max(candprops.cand_nm) as name
 from dimcand
     left join (select distinct on (cand_sk) cand_sk, election_yr, cand_status, ici_code from dimcandstatusici order by cand_sk, election_yr desc) csi_recent using (cand_sk)
     left join dimcandstatusici csi_all using (cand_sk)
     inner join dimcandoffice co on co.cand_sk = dimcand.cand_sk and (csi_recent.election_yr is null or co.cand_election_yr = csi_recent.election_yr)  -- only joined to get to dimoffice
     inner join dimoffice using (office_sk)
     inner join dimparty using (party_sk)
+    left join (
+        select props.cand_sk, cand_nm from (
+            select cand_sk, max(candproperties_sk) as candproperties_sk from dimcand
+                join dimcandproperties using (cand_sk)
+                group by cand_sk
+        ) props
+            join dimcandproperties using (candproperties_sk)
+    ) candprops on dimcand.cand_sk = candprops.cand_sk
 group by
     dimcand.cand_sk,
     dimcand.cand_id,

--- a/data/sql_updates/create_committee_detail_view.sql
+++ b/data/sql_updates/create_committee_detail_view.sql
@@ -39,8 +39,7 @@ select distinct
     cp_most_recent.expire_date as expire_date,
     cp_most_recent.cand_pty_affiliation as party,
     p.party_affiliation_desc as party_full,
-    -- contrary to most recent, we'll need to pull just the oldest load_date here, since they don't give us registration dates yet
-    (select distinct on (cmte_sk) load_date from dimcmteproperties cp where cp.cmte_sk = dimcmte.cmte_sk order by cmte_sk, cmteproperties_sk) as original_registration_date,
+    dates.load_date as original_registration_date,
     cp_most_recent.cmte_nm as name,
     -- (select all cand_id from dimlinkages dl where dl.cmte_sk = dimcmte.cmte_sk) as candidate_ids
     -- Below here are committee variables for the detail view
@@ -97,6 +96,10 @@ from dimcmte
         select distinct on (cmte_sk) cmte_sk, cmte_nm, cmte_zip, cmte_treasurer_nm, org_tp, org_tp_desc, cmte_st, expire_date, cand_pty_affiliation, cmte_st1, cmte_st2, cmte_city, cmte_st_desc, cmte_zip cmte_treasurer_city, cmte_treasurer_f_nm, cmte_treasurer_l_nm, cmte_treasurer_m_nm, cmte_treasurer_ph_num, cmte_treasurer_prefix, cmte_treasurer_st, cmte_treasurer_st1, cmte_treasurer_st2, cmte_treasurer_suffix, cmte_treasurer_title, cmte_treasurer_zip, cmte_custodian_city, cmte_custodian_f_nm, cmte_custodian_l_nm, cmte_custodian_m_nm, cmte_custodian_nm, cmte_custodian_ph_num, cmte_custodian_prefix, cmte_custodian_st, cmte_custodian_st1, cmte_custodian_st2, cmte_custodian_suffix, cmte_custodian_title, cmte_custodian_zip, cmte_email, cmte_fax, cmte_web_url, filing_freq, form_tp, leadership_pac, load_date, lobbyist_registrant_pac_flg, party_cmte_type, party_cmte_type_desc, qual_dt from dimcmteproperties order by cmte_sk, cmteproperties_sk desc
     ) cp_most_recent using (cmte_sk)
     left join dimparty p on cp_most_recent.cand_pty_affiliation = p.party_affiliation
+    left join (
+        select distinct on (cmte_sk) cmte_sk, load_date from dimcmteproperties
+            order by cmte_sk, cmteproperties_sk
+    ) dates on dimcmte.cmte_sk = dates.cmte_sk
     -- inner join dimlinkages dl using (cmte_sk)
 ;
 

--- a/data/sql_updates/create_committees_view.sql
+++ b/data/sql_updates/create_committees_view.sql
@@ -39,8 +39,7 @@ select distinct
     cp_most_recent.expire_date as expire_date,
     cp_most_recent.cand_pty_affiliation as party,
     p.party_affiliation_desc as party_full,
-    -- contrary to most recent, we'll need to pull just the oldest load_date here, since they don't give us registration dates yet
-    (select distinct on (cmte_sk) load_date from dimcmteproperties cp where cp.cmte_sk = dimcmte.cmte_sk order by cmte_sk, cmteproperties_sk) as original_registration_date,
+    dates.load_date as original_registration_date,
     cp_most_recent.cmte_nm as name,
     candidates.candidate_ids
 from dimcmte
@@ -51,6 +50,10 @@ from dimcmte
     ) cp_most_recent using (cmte_sk)
     left join dimparty p on cp_most_recent.cand_pty_affiliation = p.party_affiliation
     left join (select cmte_sk, array_agg(distinct cand_id)::text[] as candidate_ids from dimlinkages dl group by cmte_sk) candidates on candidates.cmte_sk = dimcmte.cmte_sk
+    left join (
+        select distinct on (cmte_sk) cmte_sk, load_date from dimcmteproperties
+            order by cmte_sk, cmteproperties_sk
+    ) dates on dimcmte.cmte_sk = dates.cmte_sk
     -- inner join dimlinkages dl using (cmte_sk)
 ;
 

--- a/data/sql_updates/create_linkage_names_view.sql
+++ b/data/sql_updates/create_linkage_names_view.sql
@@ -44,11 +44,11 @@ select
 from dimlinkages l
     left join (
         select distinct on (cand_sk) cand_sk, cand_nm from dimcandproperties
-            order by cand_sk desc
+            order by cand_sk, candproperties_sk desc
     ) candprops on l.cand_sk = candprops.cand_sk
     left join (
         select distinct on (cmte_sk) cmte_sk, cmte_nm from dimcmteproperties
-            order by cmte_sk desc
+            order by cmte_sk, cmteproperties_sk desc
     ) cmteprops on l.cmte_sk = cmteprops.cmte_sk
     left join (
         select cand_id, max(dl.cand_election_yr) as active_through from dimlinkages

--- a/data/sql_updates/create_linkage_names_view.sql
+++ b/data/sql_updates/create_linkage_names_view.sql
@@ -43,20 +43,12 @@ select
     cmteprops.cmte_nm as committee_name
 from dimlinkages l
     left join (
-        select props.cand_sk, cand_nm from (
-            select cand_sk, max(candproperties_sk) as candproperties_sk from dimlinkages
-                join dimcandproperties using (cand_sk)
-                group by cand_sk
-        ) props
-            join dimcandproperties using (candproperties_sk)
+        select distinct on (cand_sk) cand_sk, cand_nm from dimcandproperties
+            order by cand_sk desc
     ) candprops on l.cand_sk = candprops.cand_sk
     left join (
-        select props.cmte_sk, cmte_nm from (
-            select cmte_sk, max(cmteproperties_sk) as cmteproperties_sk from dimlinkages
-                join dimcmteproperties using (cmte_sk)
-                group by cmte_sk
-        ) props
-            join dimcmteproperties using (cmteproperties_sk)
+        select distinct on (cmte_sk) cmte_sk, cmte_nm from dimcmteproperties
+            order by cmte_sk desc
     ) cmteprops on l.cmte_sk = cmteprops.cmte_sk
     left join (
         select cand_id, max(dl.cand_election_yr) as active_through from dimlinkages

--- a/data/sql_updates/create_linkage_names_view.sql
+++ b/data/sql_updates/create_linkage_names_view.sql
@@ -5,7 +5,7 @@ select
     l.cand_sk as candidate_key,
     l.cmte_sk as committee_key,
     l.cand_id as candidate_id,
-    (select max(cand_election_yr) from dimlinkages dl where dl.cand_id = l.cand_id) as active_through,
+    active.active_through,
     l.cand_election_yr as election_year,
     l.cmte_id as committee_id,
     l.cmte_tp as committee_type,
@@ -39,9 +39,31 @@ select
     l.link_date as link_date,
     l.load_date as load_date,
     l.expire_date as expire_date,
-    (select cand_nm from dimcandproperties where dimcandproperties.cand_sk = l.cand_sk order by candproperties_sk desc limit 1) as candidate_name,
-    (select cmte_nm from dimcmteproperties where dimcmteproperties.cmte_sk = l.cmte_sk order by cmteproperties_sk desc limit 1) as committee_name
-from dimlinkages l;
+    candprops.cand_nm as candidate_name,
+    cmteprops.cmte_nm as committee_name
+from dimlinkages l
+    left join (
+        select props.cand_sk, cand_nm from (
+            select cand_sk, max(candproperties_sk) as candproperties_sk from dimlinkages
+                join dimcandproperties using (cand_sk)
+                group by cand_sk
+        ) props
+            join dimcandproperties using (candproperties_sk)
+    ) candprops on l.cand_sk = candprops.cand_sk
+    left join (
+        select props.cmte_sk, cmte_nm from (
+            select cmte_sk, max(cmteproperties_sk) as cmteproperties_sk from dimlinkages
+                join dimcmteproperties using (cmte_sk)
+                group by cmte_sk
+        ) props
+            join dimcmteproperties using (cmteproperties_sk)
+    ) cmteprops on l.cmte_sk = cmteprops.cmte_sk
+    left join (
+        select cand_id, max(dl.cand_election_yr) as active_through from dimlinkages
+            join dimlinkages dl using (cand_id)
+            group by cand_id
+    ) active on l.cand_id = active.cand_id
+;
 
 create index on ofec_name_linkage_mv_tmp(candidate_key);
 create index on ofec_name_linkage_mv_tmp(committee_key);


### PR DESCRIPTION
A handful of materialized view queries used per-row SELECT statements,
so that a separate SELECT was emitted for each row of the view. This
patch replaces per-row SELECTs with JOINs, which makes queries
noticeably faster on the production data.

Once this gets merged, we should see faster schema migrations and view refreshes. On the local data, these changes took migration time from ~7s to ~3s. On GoldenGate, queries that took an unacceptably long time (I got impatient and cancelled anything that ran for 10 minutes without finishing) actually finished.