### PR TITLE
Change New Relic config

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
-web: newrelic-admin run-program python run_api.py
-
+web: newrelic-admin run-program gunicorn run_api:app

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -5,6 +5,9 @@ applications:
 - name: api
   path: .
   host: fec-dev-api
+  env:
+    NEW_RELIC_APP_NAME: OpenFEC (development)
+    NEW_RELIC_LOG: stdout
 - name: web
   path: ../openFEC-web-app
   buildpack: python_buildpack

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -6,7 +6,7 @@ applications:
   path: .
   host: fec-dev-api
   env:
-    NEW_RELIC_APP_NAME: OpenFEC (development)
+    NEW_RELIC_APP_NAME: OpenFEC API (development)
     NEW_RELIC_LOG: stdout
     WEB_CONCURRENCY: 4
 - name: web

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -8,6 +8,7 @@ applications:
   env:
     NEW_RELIC_APP_NAME: OpenFEC (development)
     NEW_RELIC_LOG: stdout
+    WEB_CONCURRENCY: 4
 - name: web
   path: ../openFEC-web-app
   buildpack: python_buildpack

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -9,6 +9,7 @@ applications:
     PRODUCTION: True
     NEW_RELIC_APP_NAME: OpenFEC (production)
     NEW_RELIC_LOG: stdout
+    WEB_CONCURRENCY: 4
 - name: web
   path: ../openFEC-web-app
   buildpack: python_buildpack

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -7,6 +7,8 @@ applications:
   host: fec-prod-api
   env:
     PRODUCTION: True
+    NEW_RELIC_APP_NAME: OpenFEC (production)
+    NEW_RELIC_LOG: stdout
 - name: web
   path: ../openFEC-web-app
   buildpack: python_buildpack

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -7,7 +7,7 @@ applications:
   host: fec-prod-api
   env:
     PRODUCTION: True
-    NEW_RELIC_APP_NAME: OpenFEC (production)
+    NEW_RELIC_APP_NAME: OpenFEC API (production)
     NEW_RELIC_LOG: stdout
     WEB_CONCURRENCY: 4
 - name: web

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -5,6 +5,9 @@ applications:
 - name: api
   path: .
   host: fec-stage-api
+  env:
+    NEW_RELIC_APP_NAME: OpenFEC (staging)
+    NEW_RELIC_LOG: stdout
 - name: web
   path: ../openFEC-web-app
   buildpack: python_buildpack

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -8,6 +8,7 @@ applications:
   env:
     NEW_RELIC_APP_NAME: OpenFEC (staging)
     NEW_RELIC_LOG: stdout
+    WEB_CONCURRENCY: 4
 - name: web
   path: ../openFEC-web-app
   buildpack: python_buildpack

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -6,7 +6,7 @@ applications:
   path: .
   host: fec-stage-api
   env:
-    NEW_RELIC_APP_NAME: OpenFEC (staging)
+    NEW_RELIC_APP_NAME: OpenFEC API (staging)
     NEW_RELIC_LOG: stdout
     WEB_CONCURRENCY: 4
 - name: web

--- a/newrelic.ini
+++ b/newrelic.ini
@@ -27,13 +27,12 @@
 # You must specify the license key associated with your New
 # Relic account. This key binds the Python Agent's data to your
 # account in the New Relic service.
-license_key = NEW_RELIC_LICENSE_KEY
 
 # The appplication name. Set this to be the name of your
 # application as you would like it to show up in New Relic UI.
 # The UI will then auto-map instances of your application into a
 # entry on your home dashboard page.
-app_name = OpenFEC
+
 
 # When "true", the agent collects performance data about your
 # application and reports this data to the New Relic UI at
@@ -195,7 +194,7 @@ thread_profiler.enabled = true
 #
 
 [NEW_RELIC_ENV:development]
-monitor_mode = false
+monitor_mode = true
 
 [NEW_RELIC_ENV:test]
 monitor_mode = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ Flask-Script
 newrelic
 celery>=3.1.17
 SQLAlchemy>=0.9.9
-
+gunicorn

--- a/run_api.py
+++ b/run_api.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import newrelic.agent
 import doctest
 import os
 import sys
@@ -10,7 +9,6 @@ from webservices.rest import app
 
 
 if __name__ == '__main__':
-    newrelic.agent.initialize()
     port = os.getenv('VCAP_APP_PORT', '5000')
     instance_id = os.getenv('CF_INSTANCE_INDEX')
 


### PR DESCRIPTION
Removes some settings from `newrelic.ini` and moving them to env variables.
Removes double reporting by only using the `Procfile` command instead of the `run_api` instantiation. 

It requires a `NEW_RELIC_LICENSE_KEY` to be set.

Fixes #602
/cc @arowla 

Also, use Gunicorn for better performance and better reporting.