### PR TITLE
Update import scripts for golden gate.

### DIFF
--- a/data/sql_updates/create_candidate_history_view.sql
+++ b/data/sql_updates/create_candidate_history_view.sql
@@ -3,7 +3,7 @@ create materialized view ofec_candidate_history_mv as
 select
     dcp_by_period.candproperties_sk as properties_key,
     dcp_by_period.cand_sk as candidate_key,
-    dcp_by_period.cand_id as candidate_id,
+    dcp_by_period.candidate_id,
     dcp_by_period.cand_nm as name,
     dcp_by_period.record_expire_date as expire_date,
     dcp_by_period.record_load_date as load_date,
@@ -28,7 +28,7 @@ select
     dcp_by_period.party_affiliation_desc as party_full
 from ofec_two_year_periods
     left join (
-        select distinct on (two_year_period, cand_sk) ((CAST(EXTRACT(YEAR FROM dcp.load_date) AS INT) + CAST(EXTRACT(YEAR FROM dcp.load_date) AS INT) % 2)) as two_year_period, dcp.expire_date as record_expire_date, dcp.load_date as record_load_date, dcp.form_tp as record_form_tp, *
+        select distinct on (two_year_period, cand_sk) ((CAST(EXTRACT(YEAR FROM dcp.load_date) AS INT) + CAST(EXTRACT(YEAR FROM dcp.load_date) AS INT) % 2)) as two_year_period, dcp.expire_date as record_expire_date, dcp.load_date as record_load_date, dcp.form_tp as record_form_tp, dcp.cand_id as candidate_id, *
         from dimcandproperties dcp
             left join dimcand dc using (cand_sk)
             left join dimcandstatusici dsi using (cand_sk)

--- a/data/sql_updates/create_committee_detail_view.sql
+++ b/data/sql_updates/create_committee_detail_view.sql
@@ -81,7 +81,7 @@ select distinct
     cp_most_recent.cmte_email as email,
     cp_most_recent.cmte_fax as fax,
     cp_most_recent.cmte_web_url as website,
-    cp_most_recent.filing_freq as filing_frequency,
+    dd.filing_freq as filing_frequency,
     cp_most_recent.form_tp as form_type,
     cp_most_recent.leadership_pac as leadership_pac,
     cp_most_recent.load_date as load_date,
@@ -94,7 +94,7 @@ from dimcmte
     inner join dimcmtetpdsgn dd using (cmte_sk)
     -- do a DISTINCT ON subselect to get the most recent properties for a committee
     inner join (
-        select distinct on (cmte_sk) cmte_sk, cmte_nm, cmte_zip, cmte_treasurer_nm, org_tp, org_tp_desc, cmte_st, expire_date, cand_pty_affiliation, cmte_st1, cmte_st2, cmte_city, cmte_st_desc, cmte_zip cmte_treasurer_city, cmte_treasurer_f_nm, cmte_treasurer_l_nm, cmte_treasurer_m_nm, cmte_treasurer_ph_num, cmte_treasurer_prefix, cmte_treasurer_st, cmte_treasurer_st1, cmte_treasurer_st2, cmte_treasurer_suffix, cmte_treasurer_title, cmte_treasurer_zip, cmte_custodian_city, cmte_custodian_f_nm, cmte_custodian_l_nm, cmte_custodian_m_nm, cmte_custodian_nm, cmte_custodian_ph_num, cmte_custodian_prefix, cmte_custodian_st, cmte_custodian_st1, cmte_custodian_st2, cmte_custodian_suffix, cmte_custodian_title, cmte_custodian_zip, cmte_email, cmte_fax, cmte_web_url, filing_freq, form_tp, leadership_pac, load_date, lobbyist_registrant_pac_flg, party_cmte_type, party_cmte_type_desc, qual_dt from dimcmteproperties order by cmte_sk, cmteproperties_sk desc
+        select distinct on (cmte_sk) cmte_sk, cmte_nm, cmte_zip, cmte_treasurer_nm, org_tp, org_tp_desc, cmte_st, expire_date, cand_pty_affiliation, cmte_st1, cmte_st2, cmte_city, cmte_st_desc, cmte_zip cmte_treasurer_city, cmte_treasurer_f_nm, cmte_treasurer_l_nm, cmte_treasurer_m_nm, cmte_treasurer_ph_num, cmte_treasurer_prefix, cmte_treasurer_st, cmte_treasurer_st1, cmte_treasurer_st2, cmte_treasurer_suffix, cmte_treasurer_title, cmte_treasurer_zip, cmte_custodian_city, cmte_custodian_f_nm, cmte_custodian_l_nm, cmte_custodian_m_nm, cmte_custodian_nm, cmte_custodian_ph_num, cmte_custodian_prefix, cmte_custodian_st, cmte_custodian_st1, cmte_custodian_st2, cmte_custodian_suffix, cmte_custodian_title, cmte_custodian_zip, cmte_email, cmte_fax, cmte_web_url, form_tp, leadership_pac, load_date, lobbyist_registrant_pac_flg, party_cmte_type, party_cmte_type_desc, qual_dt from dimcmteproperties order by cmte_sk, cmteproperties_sk desc
     ) cp_most_recent using (cmte_sk)
     left join dimparty p on cp_most_recent.cand_pty_affiliation = p.party_affiliation
     -- inner join dimlinkages dl using (cmte_sk)

--- a/data/sql_updates/create_linkage_names_view.sql
+++ b/data/sql_updates/create_linkage_names_view.sql
@@ -36,7 +36,6 @@ select
         when 'B' then 'Lobbyist/Registrant PAC'
         when 'D' then 'Leadership PAC'
         else 'unknown' end as committee_designation_full,
-    l.link_date as link_date,
     l.load_date as load_date,
     l.expire_date as expire_date,
     (select cand_nm from dimcandproperties where dimcandproperties.cand_sk = l.cand_sk order by candproperties_sk desc limit 1) as candidate_name,

--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -149,7 +149,6 @@ class CandidateCommitteeLink(db.Model):
     candidate_id = db.Column('candidate_id', db.String(10))
     election_year = db.Column('election_year', db.Integer)
     active_through = db.Column('active_through', db.Integer)
-    link_date = db.Column('link_date', db.DateTime())
     expire_date = db.Column('expire_date', db.DateTime())
     committee_name = db.Column('committee_name', db.DateTime())
     candidate_name = db.Column('candidate_name', db.DateTime())


### PR DESCRIPTION
Note: This patch will fail on Travis, since the data in the repo have
diverged from the data on golden gate. This patch should be updated with
new sample data before merge.

* Disambiguate `candidate_id` column
    * Column now exists on multiple tables in join, leading to ambiguous reference
* Pull `filing_freq` from `dimcmtetpdsgn` rather than `dimcmteproperties`
* Remove `link_date` column