### PR TITLE
Use `idx` as primary key to ensure uniqueness.

### DIFF
--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -5,8 +5,13 @@ from sqlalchemy.ext.associationproxy import association_proxy
 db = SQLAlchemy()
 
 
-class Candidate(db.Model):
-    candidate_key = db.Column(db.Integer, primary_key=True)
+class BaseModel(db.Model):
+    __abstract__ = True
+    idx = db.Column(db.Integer, primary_key=True)
+
+
+class Candidate(BaseModel):
+    candidate_key = db.Column(db.Integer)
     candidate_id = db.Column(db.String(10))
     candidate_status = db.Column(db.String(1))
     candidate_status_full = db.Column(db.String(11))
@@ -25,8 +30,8 @@ class Candidate(db.Model):
 
     __tablename__ = 'ofec_candidates_mv'
 
-class CandidateDetail(db.Model):
-    candidate_key = db.Column(db.Integer, primary_key=True)
+class CandidateDetail(BaseModel):
+    candidate_key = db.Column(db.Integer)
     candidate_id = db.Column(db.String(10))
     candidate_status = db.Column(db.String(1))
     candidate_status_full = db.Column(db.String(11))
@@ -55,8 +60,8 @@ class CandidateDetail(db.Model):
     __tablename__ = 'ofec_candidate_detail_mv'
 
 
-class Committee(db.Model):
-    committee_key = db.Column(db.Integer, primary_key=True)
+class Committee(BaseModel):
+    committee_key = db.Column(db.Integer)
     committee_id = db.Column(db.String(9))
     candidate_ids = db.Column(ARRAY(db.String))
     designation = db.Column(db.String(1))
@@ -78,8 +83,8 @@ class Committee(db.Model):
     __tablename__ = 'ofec_committees_mv'
 
 
-class CommitteeDetail(db.Model):
-    committee_key = db.Column(db.Integer, primary_key=True)
+class CommitteeDetail(BaseModel):
+    committee_key = db.Column(db.Integer)
     committee_id = db.Column(db.String(9))
     designation = db.Column(db.String(1))
     designation_full = db.Column(db.String(25))
@@ -141,8 +146,8 @@ class CommitteeDetail(db.Model):
     __tablename__ = 'ofec_committee_detail_mv'
 
 
-class CandidateCommitteeLink(db.Model):
-    linkage_key = db.Column(db.Integer, primary_key=True)
+class CandidateCommitteeLink(BaseModel):
+    linkage_key = db.Column(db.Integer)
     committee_key = db.Column('committee_key', db.Integer, db.ForeignKey(Committee.committee_key), db.ForeignKey(CommitteeDetail.committee_key))
     candidate_key = db.Column('candidate_key', db.Integer, db.ForeignKey(Candidate.candidate_key), db.ForeignKey(CandidateDetail.candidate_key))
     committee_id = db.Column('committee_id', db.String(10))
@@ -159,8 +164,8 @@ class CandidateCommitteeLink(db.Model):
 
     __tablename__ = 'ofec_name_linkage_mv'
 
-class CandidateHistory(db.Model):
-    properties_key = db.Column(db.Integer, primary_key=True)
+class CandidateHistory(BaseModel):
+    properties_key = db.Column(db.Integer)
     candidate_key = db.Column(db.Integer)
     candidate_id = db.Column(db.String(10))
     two_year_period = db.Column(db.Integer)

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -3,15 +3,15 @@ from math import ceil
 from sqlalchemy import desc
 from flask.ext.restful import Resource, reqparse, fields, marshal, inputs
 
-from webservices.common.models import db
+from webservices.common.models import db, BaseModel
 from webservices.common.util import merge_dicts, Pagination
 from webservices.resources.committees import Committee
 
 
-class CommitteeReports(db.Model):
+class CommitteeReports(BaseModel):
     __abstract__ = True
 
-    report_key = db.Column(db.BigInteger, primary_key=True)
+    report_key = db.Column(db.BigInteger)
     committee_id = db.Column(db.String(10))
     cycle = db.Column(db.Integer)
 
@@ -497,7 +497,8 @@ class ReportsView(Resource):
         page_num = args.get('page', 1)
         per_page = args.get('per_page', 20)
 
-        committee = Committee.query.filter_by(committee_id=committee_id).one()
+        # TODO(jmcarp) Handle multiple results better
+        committee = Committee.query.filter_by(committee_id=committee_id).first()
 
         reports_class, specific_fields = reports_model_map.get(
             committee.committee_type,

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -4,16 +4,16 @@ from sqlalchemy import desc
 from sqlalchemy.orm.exc import NoResultFound
 from flask.ext.restful import Resource, reqparse, fields, marshal, inputs
 
-from webservices.common.models import db
+from webservices.common.models import db, BaseModel
 from webservices.common.util import merge_dicts, Pagination
 from webservices.resources.committees import Committee
 
 
-class CommitteeTotals(db.Model):
+class CommitteeTotals(BaseModel):
     __abstract__ = True
 
-    committee_id = db.Column(db.String(10), primary_key=True)
-    cycle = db.Column(db.Integer, primary_key=True)
+    committee_id = db.Column(db.String(10))
+    cycle = db.Column(db.Integer)
     committee_type = db.Column(db.String(1))
 
     offsets_to_operating_expenditures = db.Column(db.Integer)
@@ -219,7 +219,8 @@ class TotalsView(Resource):
         per_page = args.get('per_page', 20)
         page_data = Pagination(page_num, per_page, 1)
 
-        committee = Committee.query.filter_by(committee_id=committee_id).one()
+        # TODO(jmcarp) Handle multiple results better
+        committee = Committee.query.filter_by(committee_id=committee_id).first()
 
         totals_class, specific_fields = totals_model_map.get(
             committee.committee_type,


### PR DESCRIPTION
Based on discussion with @LindsayYoung and @arowla. Note: I changed `one` to `first` for committee lookups in the reports and totals views, since I was running into duplicate key errors while debugging this. We can think about a better solution later on, but I think this is fine for now.

[Resolves #612]