### PR TITLE
Feature/remove nesting refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,7 @@ python:
   - "3.4"
 addons:
   postgresql: "9.4"
-env: SQLA_CONN="postgresql://:@/cfdm_test"
 before_script:
-  - psql -c 'create database cfdm_test;' -U postgres
-  - md5sum data/cfdm_test.pgdump.sql
-  - psql -f data/cfdm_test.pgdump.sql -U postgres cfdm_test
-  - psql -c "SELECT count(*) FROM dimcand" -U postgres cfdm_test
+  - psql -c 'create database "cfdm-unit-test";' -U postgres
   - pip install -r requirements.txt
-  - python manage.py update_schemas
 script: nosetests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 psycopg2
 git+git://github.com/flask-restful/flask-restful.git
-nose
 flask-sqlalchemy
 Flask-Script
 newrelic
 celery>=3.1.17
 SQLAlchemy>=0.9.9
 gunicorn
+
+nose>=1.3.6
+factory-boy>=2.5.2

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,120 @@
+import factory
+from factory.alchemy import SQLAlchemyOptions
+from factory.alchemy import SQLAlchemyModelFactory
+
+from webservices.rest import db
+from webservices.common import models
+from webservices.resources import totals
+
+
+class BaseFactory(SQLAlchemyModelFactory):
+    class Meta:
+        sqlalchemy_session = db.session
+
+
+class NameSearchFactory(BaseFactory):
+    class Meta:
+        model = models.NameSearch
+    cand_id = factory.Sequence(lambda n: n)
+    cmte_id = factory.Sequence(lambda n: n)
+
+
+class CandidateSearchFactory(BaseFactory):
+    class Meta:
+        model = models.CandidateSearch
+    cand_sk = factory.Sequence(lambda n: n)
+
+
+class PairedOptions(SQLAlchemyOptions):
+    def _build_default_options(self):
+        return super()._build_default_options() + [
+            factory.base.OptionDefault('paired_factory', None, inherit=True),
+        ]
+
+
+class PairedFactory(BaseFactory):
+
+    _options_class = PairedOptions
+
+    class Meta:
+        exclude = ('pair', )
+
+    pair = True
+
+    @classmethod
+    def _generate(cls, create, attrs):
+        ret = super()._generate(create, attrs)
+        if attrs.pop('pair', True) and create:
+            paired_factory = cls._meta.paired_factory()
+            ret._paired = paired_factory(pair=False, **{
+                key: value for key, value in attrs.items()
+                if key in set(paired_factory._meta.model.__table__.columns.keys())
+            })
+        return ret
+
+
+class BaseCandidateFactory(BaseFactory):
+    candidate_key = factory.Sequence(lambda n: n)
+    candidate_id = factory.Sequence(lambda n: 'id{0}'.format(n))
+
+
+class CandidateFactory(PairedFactory, BaseCandidateFactory):
+    class Meta:
+        model = models.Candidate
+        paired_factory = lambda: CandidateDetailFactory
+
+    election_years = [2012, 2014]
+
+
+class CandidateDetailFactory(PairedFactory, BaseCandidateFactory):
+    class Meta:
+        model = models.CandidateDetail
+        paired_factory = lambda: CandidateFactory
+
+
+class CandidateHistoryFactory(BaseCandidateFactory):
+    class Meta:
+        model = models.CandidateHistory
+    candidate_key = factory.Sequence(lambda n: n)
+    candidate_id = factory.Sequence(lambda n: 'id{0}'.format(n))
+
+
+class BaseCommitteeFactory(PairedFactory):
+    committee_key = factory.Sequence(lambda n: n + 1)
+    committee_id = factory.Sequence(lambda n: 'id{0}'.format(n))
+
+
+class CommitteeFactory(BaseCommitteeFactory):
+    class Meta:
+        model = models.Committee
+        paired_factory = lambda: CommitteeDetailFactory
+
+
+class CommitteeDetailFactory(BaseCommitteeFactory):
+    class Meta:
+        model = models.CommitteeDetail
+        paired_factory = lambda: CommitteeFactory
+
+
+class CandidateCommitteeLinkFactory(BaseFactory):
+    class Meta:
+        model = models.CandidateCommitteeLink
+
+
+class BaseTotalsFactory(BaseFactory):
+    committee_id = factory.LazyAttribute(lambda o: CommitteeFactory().committee_id)
+
+
+class TotalsHouseSenateFactory(BaseTotalsFactory):
+    class Meta:
+        model = totals.CommitteeTotalsHouseOrSenate
+
+
+class TotalsPresidentialFactory(BaseTotalsFactory):
+    class Meta:
+        model = totals.CommitteeTotalsPresidential
+
+
+class TotalsPacPartyFactory(BaseTotalsFactory):
+    class Meta:
+        model = totals.CommitteeTotalsPacOrParty

--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -1,12 +1,34 @@
 from flask.ext.sqlalchemy import SQLAlchemy
-from sqlalchemy.dialects.postgresql import ARRAY
-from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.dialects.postgresql import ARRAY, TSVECTOR
+
 
 db = SQLAlchemy()
 
 
-class Candidate(db.Model):
-    candidate_key = db.Column(db.Integer, primary_key=True)
+class BaseModel(db.Model):
+    __abstract__ = True
+    idx = db.Column(db.Integer, primary_key=True)
+
+
+class NameSearch(BaseModel):
+    __tablename__ = 'name_search_fulltext_mv'
+
+    cand_id = db.Column(db.Integer, nullable=True)
+    cmte_id = db.Column(db.Integer, nullable=True)
+    name = db.Column(db.String)
+    office_sought = db.Column(db.String)
+    name_vec = db.Column(TSVECTOR)
+
+
+class CandidateSearch(BaseModel):
+    __tablename__ = 'dimcand_fulltext_mv'
+
+    cand_sk = db.Column(db.Integer)
+    fulltxt = db.Column(TSVECTOR)
+
+
+class Candidate(BaseModel):
+    candidate_key = db.Column(db.Integer, unique=True)
     candidate_id = db.Column(db.String(10))
     candidate_status = db.Column(db.String(1))
     candidate_status_full = db.Column(db.String(11))
@@ -24,8 +46,8 @@ class Candidate(db.Model):
 
     __tablename__ = 'ofec_candidates_mv'
 
-class CandidateDetail(db.Model):
-    candidate_key = db.Column(db.Integer, primary_key=True)
+class CandidateDetail(BaseModel):
+    candidate_key = db.Column(db.Integer, unique=True)
     candidate_id = db.Column(db.String(10))
     candidate_status = db.Column(db.String(1))
     candidate_status_full = db.Column(db.String(11))
@@ -53,10 +75,10 @@ class CandidateDetail(db.Model):
     __tablename__ = 'ofec_candidate_detail_mv'
 
 
-class Committee(db.Model):
-    committee_key = db.Column(db.Integer, primary_key=True)
+class Committee(BaseModel):
+    committee_key = db.Column(db.Integer, unique=True)
     committee_id = db.Column(db.String(9))
-    candidate_ids = db.Column(ARRAY(db.String))
+    candidate_ids = db.Column(ARRAY(db.Text))
     designation = db.Column(db.String(1))
     designation_full = db.Column(db.String(25))
     treasurer_name = db.Column(db.String(100))
@@ -74,8 +96,8 @@ class Committee(db.Model):
     __tablename__ = 'ofec_committees_mv'
 
 
-class CommitteeDetail(db.Model):
-    committee_key = db.Column(db.Integer, primary_key=True)
+class CommitteeDetail(BaseModel):
+    committee_key = db.Column(db.Integer, unique=True)
     committee_id = db.Column(db.String(9))
     designation = db.Column(db.String(1))
     designation_full = db.Column(db.String(25))
@@ -136,8 +158,8 @@ class CommitteeDetail(db.Model):
     __tablename__ = 'ofec_committee_detail_mv'
 
 
-class CandidateCommitteeLink(db.Model):
-    linkage_key = db.Column(db.Integer, primary_key=True)
+class CandidateCommitteeLink(BaseModel):
+    linkage_key = db.Column(db.Integer)
     committee_key = db.Column('committee_key', db.Integer, db.ForeignKey(Committee.committee_key), db.ForeignKey(CommitteeDetail.committee_key))
     candidate_key = db.Column('candidate_key', db.Integer, db.ForeignKey(Candidate.candidate_key), db.ForeignKey(CandidateDetail.candidate_key))
     committee_id = db.Column('committee_id', db.String(10))
@@ -154,8 +176,8 @@ class CandidateCommitteeLink(db.Model):
 
     __tablename__ = 'ofec_name_linkage_mv'
 
-class CandidateHistory(db.Model):
-    properties_key = db.Column(db.Integer, primary_key=True)
+class CandidateHistory(BaseModel):
+    properties_key = db.Column(db.Integer)
     candidate_key = db.Column(db.Integer)
     candidate_id = db.Column(db.String(10))
     two_year_period = db.Column(db.Integer)

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -3,15 +3,15 @@ from math import ceil
 from sqlalchemy import desc
 from flask.ext.restful import Resource, reqparse, fields, marshal, inputs
 
-from webservices.common.models import db
+from webservices.common.models import db, BaseModel
 from webservices.common.util import merge_dicts, Pagination
 from webservices.resources.committees import Committee
 
 
-class CommitteeReports(db.Model):
+class CommitteeReports(BaseModel):
     __abstract__ = True
 
-    report_key = db.Column(db.BigInteger, primary_key=True)
+    report_key = db.Column(db.BigInteger)
     committee_id = db.Column(db.String(10))
     cycle = db.Column(db.Integer)
 
@@ -497,7 +497,8 @@ class ReportsView(Resource):
         page_num = args.get('page', 1)
         per_page = args.get('per_page', 20)
 
-        committee = Committee.query.filter_by(committee_id=committee_id).one()
+        # TODO(jmcarp) Handle multiple results better
+        committee = Committee.query.filter_by(committee_id=committee_id).first()
 
         reports_class, specific_fields = reports_model_map.get(
             committee.committee_type,

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -4,16 +4,16 @@ from sqlalchemy import desc
 from sqlalchemy.orm.exc import NoResultFound
 from flask.ext.restful import Resource, reqparse, fields, marshal, inputs
 
-from webservices.common.models import db
+from webservices.common.models import db, BaseModel
 from webservices.common.util import merge_dicts, Pagination
 from webservices.resources.committees import Committee
 
 
-class CommitteeTotals(db.Model):
+class CommitteeTotals(BaseModel):
     __abstract__ = True
 
-    committee_id = db.Column(db.String(10), primary_key=True)
-    cycle = db.Column(db.Integer, primary_key=True)
+    committee_id = db.Column(db.String(10))
+    cycle = db.Column(db.Integer)
     committee_type = db.Column(db.String(1))
 
     offsets_to_operating_expenditures = db.Column(db.Integer)
@@ -219,7 +219,8 @@ class TotalsView(Resource):
         per_page = args.get('per_page', 20)
         page_data = Pagination(page_num, per_page, 1)
 
-        committee = Committee.query.filter_by(committee_id=committee_id).one()
+        # TODO(jmcarp) Handle multiple results better
+        committee = Committee.query.filter_by(committee_id=committee_id).first()
 
         totals_class, specific_fields = totals_model_map.get(
             committee.committee_type,

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -97,7 +97,8 @@ class NameSearch(restful.Resource):
 
         qry = sa.sql.text(self.fulltext_qry)
         findme = ' & '.join(args['q'].split())
-        data = db.engine.execute(qry, findme=findme).fetchall()
+        with db.session.connection() as conn:
+            data = conn.execute(qry, findme=findme).fetchall()
         page_data = Pagination(1, 1, len(data))
 
         return {"api_version": "0.2",

--- a/webservices/test_api.py
+++ b/webservices/test_api.py
@@ -1,7 +1,10 @@
-import json
 import unittest
 
+import sqlalchemy as sa
+
 from .tests.common import ApiBaseTest
+from webservices import rest
+from tests import factories
 
 
 class OverallTest(ApiBaseTest):
@@ -16,32 +19,46 @@ class OverallTest(ApiBaseTest):
         return response['results']
 
     def test_full_text_search(self):
-        # changed from 'james' to 'arnold' because 'james' falls victim to stemming, and some results return 'jame' causing the assert to fail
-        results = self._results('/candidates?q=arnold')
-        for r in results:
-            #txt = json.dumps(r).lower()
-            self.assertIn('arnold', r['name'].lower())
+        candidate = factories.CandidateFactory(name='Josiah Bartlet')
+        search = factories.CandidateSearchFactory(
+            cand_sk=candidate.candidate_key,
+            fulltxt=sa.func.to_tsvector('Josiah Bartlet'),
+        )
+        rest.db.session.flush()
+        results = self._results('/candidates?q=bartlet')
+        self.assertEqual(len(results), 1)
+        self.assertIn('josiah', results[0]['name'].lower())
 
     def test_full_text_search_with_whitespace(self):
-        results = self._results('/candidates?q=barack obama')
-        for r in results:
-            txt = json.dumps(r).lower()
-            self.assertIn('obama', txt)
+        candidate = factories.CandidateFactory(name='Josiah Bartlet')
+        search = factories.CandidateSearchFactory(
+            cand_sk=candidate.candidate_key,
+            fulltxt=sa.func.to_tsvector('Josiah Bartlet'),
+        )
+        rest.db.session.flush()
+        results = self._results('/candidates?q=bartlet josiah')
+        self.assertEqual(len(results), 1)
+        self.assertIn('josiah', results[0]['name'].lower())
 
     def test_full_text_no_results(self):
         results = self._results('/candidates?q=asdlkflasjdflkjasdl;kfj')
         self.assertEquals(results, [])
 
     def test_year_filter(self):
+        factories.CandidateFactory(election_years=[1986, 1988])
+        factories.CandidateFactory(election_years=[2000, 2002])
         results = self._results('/candidates?year=1988')
+        self.assertEqual(len(results), 1)
         for r in results:
             self.assertIn(1988, r['election_years'])
 
     def test_per_page_defaults_to_20(self):
+        [factories.CandidateFactory() for _ in range(40)]
         results = self._results('/candidates')
         self.assertEquals(len(results), 20)
 
     def test_per_page_param(self):
+        [factories.CandidateFactory() for _ in range(20)]
         results = self._results('/candidates?per_page=5')
         self.assertEquals(len(results), 5)
 
@@ -54,12 +71,12 @@ class OverallTest(ApiBaseTest):
         self.assertEquals(response.status_code, 400)
 
     def test_page_param(self):
+        [factories.CandidateFactory() for _ in range(20)]
         page_one_and_two = self._results('/candidates?per_page=10&page=1')
         page_two = self._results('/candidates?per_page=5&page=2')
         self.assertEqual(page_two[0], page_one_and_two[5])
         for itm in page_two:
             self.assertIn(itm, page_one_and_two)
-
 
     @unittest.skip("We are just showing one year at a time, this would be a good feature for /candidate/<id> but it is not a priority right now")
     def test_multi_year(self):
@@ -83,47 +100,25 @@ class OverallTest(ApiBaseTest):
         elections = response[0]['elections']
         self.assertEquals(len(elections), 2)
 
-    def test_cand_filters(self):
-        # checking one example from each field
-        orig_response = self._response('/candidates')
-        original_count = orig_response['pagination']['count']
-
-        filter_fields = (
-            ('office','H'),
-            ('district', '00,02'),
-            ('state', 'CA'),
-            ('name', 'Obama'),
-            ('party', 'DEM'),
-            ('year', '2012,2014'),
-            ('candidate_id', 'H0VA08040,P80003338'),
-        )
-
-        for field, example in filter_fields:
-            page = "/candidates?%s=%s" % (field, example)
-            print(page)
-            # returns at least one result
-            results = self._results(page)
-            self.assertGreater(len(results), 0)
-            # doesn't return all results
-            response = self._response(page)
-            self.assertGreater(original_count, response['pagination']['count'])
-
-
-    def test_name_endpoint_returns_unique_candidates_and_committees(self):
-        results = self._results('/names?q=obama')
-        cand_ids = [r['candidate_id'] for r in results if r['candidate_id']]
-        self.assertEqual(len(cand_ids), len(set(cand_ids)))
-        cmte_ids = [r['committee_id'] for r in results if r['committee_id']]
-        self.assertEqual(len(cmte_ids), len(set(cmte_ids)))
-
-
     @unittest.skip('This is not a great view anymore')
     def test_multiple_cmtes_in_detail(self):
         response = self._results('/candidate/P80003338/committees')
         self.assertEquals(len(response[0]), 11)
         self.assertEquals(response['pagination']['count'], 11)
 
-# Totals
+    def test_totals_house_senate(self):
+        committee = factories.CommitteeFactory(committee_type='H')
+        committee_id = committee.committee_id
+        [
+            factories.TotalsHouseSenateFactory(committee_id=committee_id, cycle=2008),
+            factories.TotalsHouseSenateFactory(committee_id=committee_id, cycle=2012),
+        ]
+        response = self._results('/committee/{0}/totals'.format(committee_id))
+        self.assertEqual(len(response), 2)
+        self.assertEqual(response[0]['cycle'], 2012)
+        self.assertEqual(response[1]['cycle'], 2008)
+
+    # Totals
     @unittest.skip("not implemented yet")
     def test_reports_house_senate(self):
         results = self._results('/committee/C00002600/reports')
@@ -181,12 +176,19 @@ class OverallTest(ApiBaseTest):
         print(len(results))
         self.assertEquals(len(results), 2)
 
-
     # Typeahead name search
     def test_typeahead_name_search(self):
-        results = self._results('/names?q=oba')
-        self.assertGreaterEqual(len(results), 10)
-        for r in results:
-            self.assertIn('OBA', r['name'])
-
-
+        [
+            factories.NameSearchFactory(
+                name='Bartlet {0}'.format(idx),
+                name_vec=sa.func.to_tsvector('Bartlet for America {0}'.format(idx)),
+            )
+            for idx in range(30)
+        ]
+        rest.db.session.flush()
+        results = self._results('/names?q=bartlet')
+        self.assertEqual(len(results), 20)
+        cand_ids = [r['candidate_id'] for r in results if r['candidate_id']]
+        self.assertEqual(len(cand_ids), len(set(cand_ids)))
+        for each in results:
+            self.assertIn('bartlet', each['name'].lower())

--- a/webservices/tests/candidate_tests.py
+++ b/webservices/tests/candidate_tests.py
@@ -1,13 +1,48 @@
-from .common import ApiBaseTest
+import datetime
 import unittest
+import functools
+
+import sqlalchemy as sa
+
+from .common import ApiBaseTest
+from webservices import rest
+from tests import factories
+
+
+fields = dict(
+    name='John Hoynes',
+    form_type='F2',
+    address_street_1='1600 Pennsylvania Avenue',
+    address_city='Washington',
+    address_state='DC',
+    address_zip='20500',
+    party='DEM',
+    party_full='Democratic Party',
+    active_through=2014,
+    candidate_inactive='Y',
+    candidate_status='C',
+    incumbent_challenge='I',
+    candidate_status_full='Candidate',
+    office='H',
+    district='08',
+    state='VA',
+    office_full='House',
+)
 
 
 class CandidateFormatTest(ApiBaseTest):
     """Test/Document expected formats"""
     def test_candidate(self):
         """Compare results to expected fields."""
-        # @todo - use a factory rather than the test data
-        response = self._response('/candidate/H0VA08040')
+        candidate_old = factories.CandidateDetailFactory(
+            load_date=datetime.datetime(2014, 1, 2),
+            **fields
+        )
+        candidate = factories.CandidateDetailFactory(
+            load_date=datetime.datetime(2014, 1, 3),
+            **fields
+        )
+        response = self._response('/candidate/{0}'.format(candidate.candidate_id))
         self.assertResultsEqual(
             response['pagination'],
             {'count': 1, 'page': 1, 'pages': 1, 'per_page': 20})
@@ -15,77 +50,87 @@ class CandidateFormatTest(ApiBaseTest):
         self.assertEqual(len(response['results']), 1)
 
         result = response['results'][0]
-        self.assertEqual(result['candidate_id'], 'H0VA08040')
+        self.assertEqual(result['candidate_id'], candidate.candidate_id)
         self.assertEqual(result['form_type'], 'F2')
         # @todo - check for a value for expire_data
         self.assertEqual(result['expire_date'], None)
-        # most recent record should be first
-        self.assertEqual(result['load_date'], '2013-04-24 00:00:00')
-        self.assertResultsEqual(result['name'], 'MORAN, JAMES P. JR.')
-        #address
-        self.assertEqual(result['address_city'], 'ALEXANDRIA')
-        self.assertEqual(result['address_state'], 'VA')
-        self.assertEqual(result['address_street_1'], '311 NORTH WASHINGTON STREET')
-        self.assertEqual(result['address_street_2'], 'SUITE 200L')
-        self.assertEqual(result['address_zip'], '22314')
-        # office
-        self.assertResultsEqual(result['office'], 'H')
-        self.assertResultsEqual(result['district'],'08')
-        self.assertResultsEqual(result['state'], 'VA')
-        self.assertResultsEqual(result['office_full'], 'House')
-        # From party_mapping
-        self.assertResultsEqual(result['party'], 'DEM')
-        self.assertResultsEqual(result['party_full'], 'Democratic Party')
+        # # most recent record should be first
+        self.assertEqual(result['load_date'], str(candidate.load_date))
+        self.assertNotEqual(result['load_date'], str(candidate_old.load_date))
+        self.assertResultsEqual(result['name'], candidate.name)
+        # #address
+        self.assertEqual(result['address_city'], candidate.address_city)
+        self.assertEqual(result['address_state'], candidate.address_state)
+        self.assertEqual(result['address_street_1'], candidate.address_street_1)
+        self.assertEqual(result['address_zip'], candidate.address_zip)
+        # # office
+        self.assertResultsEqual(result['office'], candidate.office)
+        self.assertResultsEqual(result['district'], candidate.district)
+        self.assertResultsEqual(result['state'], candidate.state)
+        self.assertResultsEqual(result['office_full'], candidate.office_full)
+        # # From party_mapping
+        self.assertResultsEqual(result['party'], candidate.party)
+        self.assertResultsEqual(result['party_full'], candidate.party_full)
         # From status_mapping
-        self.assertResultsEqual(result['active_through'], 2014)
-        self.assertResultsEqual(result['candidate_inactive'], 'Y')
-        self.assertResultsEqual(result['candidate_status'], 'C')
-        self.assertResultsEqual(result['incumbent_challenge'], 'I')
-                # Expanded from candidate_status
-        self.assertResultsEqual(result['candidate_status_full'], 'Candidate')
-
+        self.assertResultsEqual(result['active_through'], candidate.active_through)
+        self.assertResultsEqual(result['candidate_inactive'], candidate.candidate_inactive)
+        self.assertResultsEqual(result['candidate_status'], candidate.candidate_status)
+        self.assertResultsEqual(result['incumbent_challenge'], candidate.incumbent_challenge)
+        self.assertResultsEqual(result['candidate_status_full'], candidate.candidate_status_full)
 
     def _results(self, qry):
         response = self._response(qry)
         return response['results']
 
     def test_fields(self):
-        # testing key defaults
-        response = self._results('/candidate/P80003338')
+        candidate = factories.CandidateDetailFactory()
+        response = self._results('/candidate/{0}'.format(candidate.candidate_id))
         response = response[0]
-
-        self.assertEquals(response['name'], 'OBAMA, BARACK')
 
         fields = ('party', 'party_full', 'state', 'district', 'incumbent_challenge_full', 'incumbent_challenge', 'candidate_status', 'candidate_status_full', 'office', 'active_through')
 
         for field in fields:
-            print(field)
-            print(response[field])
-            self.assertEquals(field in response, True)
+            self.assertIn(field, response)
 
     def test_extra_fields(self):
-        response = self._results('/candidate/P80003338')
-        self.assertIn('PO BOX 8102', response[0]['address_street_1'])
-        self.assertIn('60680',response[0]['address_zip'])
+        candidate = factories.CandidateDetailFactory(
+            address_street_1='PO Box 8102',
+            address_zip='60680',
+        )
+        response = self._results('/candidate/{0}'.format(candidate.candidate_id))
+        response = response[0]
+        self.assertIn(candidate.address_street_1, response['address_street_1'])
+        self.assertIn(candidate.address_zip, response['address_zip'])
 
     def test_cand_filters(self):
-        # checking one example from each field
-        orig_response = self._response('/candidates')
-        original_count = orig_response['pagination']['count']
+        [
+            factories.CandidateFactory(office='H'),
+            factories.CandidateFactory(district='00'),
+            factories.CandidateFactory(district='02'),
+            factories.CandidateFactory(state='CA'),
+            factories.CandidateFactory(name='Obama'),
+            factories.CandidateFactory(party='DEM'),
+            factories.CandidateFactory(election_years=[2006]),
+            factories.CandidateFactory(candidate_id='barlet'),
+            factories.CandidateFactory(candidate_id='ritchie'),
+        ]
 
         filter_fields = (
-            ('office','H'),
+            ('office', 'H'),
             ('district', '00,02'),
             ('state', 'CA'),
             ('name', 'Obama'),
             ('party', 'DEM'),
-            ('year', '2012,2014'),
-            ('candidate_id', 'H0VA08040,P80003338'),
+            ('year', '2006'),
+            ('candidate_id', 'bartlet,ritchie')
         )
+
+        # checking one example from each field
+        orig_response = self._response('/candidates')
+        original_count = orig_response['pagination']['count']
 
         for field, example in filter_fields:
             page = "/candidates?%s=%s" % (field, example)
-            print(page)
             # returns at least one result
             results = self._results(page)
             self.assertGreater(len(results), 0)
@@ -93,98 +138,41 @@ class CandidateFormatTest(ApiBaseTest):
             response = self._response(page)
             self.assertGreater(original_count, response['pagination']['count'])
 
-    def test_name_endpoint_returns_unique_candidates_and_committees(self):
-        results = self._results('/names?q=obama')
-        cand_ids = [r['candidate_id'] for r in results if r['candidate_id']]
-        self.assertEqual(len(cand_ids), len(set(cand_ids)))
-
-
     def test_candidate_history_by_year(self):
-        results = self._results('/candidate/P80003338/history/2008')
-
-        expected_result = {
-            "address_city": "CHICAGO",
-            "address_state": "IL",
-            "address_street_1": "PO BOX 8102",
-            "address_street_2": None,
-            "address_zip": "60680",
-            "candidate_id": "P80003338",
-            "candidate_inactive": None,
-            "candidate_status": "C",
-            "candidate_status_full": "Statutory candidate",
-            "district": None,
-            "expire_date": "2011-04-04 00:00:00",
-            "form_type": "F2",
-            "incumbent_challenge": "O",
-            "incumbent_challenge_full": "Open (Open seat)",
-            "load_date": "2008-09-17 00:00:00",
-            "name": "OBAMA, BARACK",
-            "office": "P",
-            "office_full": "President",
-            "party": "DEM",
-            "party_full": "Democratic Party",
-            "state": "US",
-            "two_year_period": 2008
-        }
-
-
-        self.assertEqual(results[0], expected_result)
+        key = 0
+        id = 'id0'
+        partial = functools.partial(
+            factories.CandidateHistoryFactory,
+            candidate_id=id, candidate_key=key,
+        )
+        histories = [
+            partial(two_year_period=2012),
+            partial(two_year_period=2008),
+        ]
+        results = self._results('/candidate/{0}/history/{1}'.format(id, histories[1].two_year_period))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['candidate_id'], id)
+        self.assertEqual(results[0]['two_year_period'], histories[1].two_year_period)
 
     def test_candidate_history(self):
-        results = self._results('/candidate/P80003338/history')
-        recent_results = self._results('/candidate/P80003338/history/recent')
+        key = 0
+        id = 'id0'
+        partial = functools.partial(
+            factories.CandidateHistoryFactory,
+            candidate_id=id, candidate_key=key,
+        )
+        histories = [
+            partial(two_year_period=2012),
+            partial(two_year_period=2008),
+        ]
+        results = self._results('/candidate/{0}/history'.format(id))
+        recent_results = self._results('/candidate/{0}/history/recent'.format(id))
 
-        expected_result_0 = {
-            'address_street_1': 'PO BOX 8102',
-            'office_full': 'President',
-            'district': None,
-            'address_city': 'CHICAGO',
-            'address_state': 'IL',
-            'expire_date': None,
-            'candidate_status_full': 'Statutory candidate',
-            'candidate_inactive': None,
-            'load_date': '2011-07-19 00:00:00',
-            'office': 'P',
-            'party': 'DEM',
-            'incumbent_challenge': 'I',
-            'incumbent_challenge_full': 'Incumbent (Current seat holder running for election)',
-            'form_type': 'F2Z',
-            'party_full': 'Democratic Party',
-            'name': 'OBAMA, BARACK',
-            'address_street_2': None,
-            'candidate_id': 'P80003338',
-            'address_zip': '60680',
-            'two_year_period': 2012,
-            'candidate_status': 'C', 'state': 'US',
-        }
-        expected_result_1 = {
-            "address_city": "CHICAGO",
-            "address_state": "IL",
-            "address_street_1": "PO BOX 8102",
-            "address_street_2": None,
-            "address_zip": "60680",
-            "candidate_id": "P80003338",
-            "candidate_inactive": None,
-            "candidate_status": "C",
-            "candidate_status_full": "Statutory candidate",
-            "district": None,
-            "expire_date": "2011-04-04 00:00:00",
-            "form_type": "F2",
-            "incumbent_challenge": "O",
-            "incumbent_challenge_full": "Open (Open seat)",
-            "load_date": "2008-09-17 00:00:00",
-            "name": "OBAMA, BARACK",
-            "office": "P",
-            "office_full": "President",
-            "party": "DEM",
-            "party_full": "Democratic Party",
-            "state": "US",
-            "two_year_period": 2008
-        }
-        print (expected_result_0)
         # history/recent
-        self.assertEqual(recent_results[0], expected_result_0)
+        self.assertEqual(recent_results[0]['candidate_id'], histories[0].candidate_id)
         self.assertEqual(len(recent_results), 1)
         # /history
-        self.assertEqual(results[0], expected_result_0)
-        self.assertEqual(results[1], expected_result_1)
+        self.assertEqual(results[0]['candidate_id'], id)
+        self.assertEqual(results[1]['candidate_id'], id)
+        self.assertEqual(results[0]['two_year_period'], histories[0].two_year_period)
+        self.assertEqual(results[1]['two_year_period'], histories[1].two_year_period)

--- a/webservices/tests/committee_tests.py
+++ b/webservices/tests/committee_tests.py
@@ -1,8 +1,16 @@
-import json
-import unittest
+import datetime
 
-from webservices.common import models
 from .common import ApiBaseTest
+from tests import factories
+from webservices import rest
+
+
+def extend(*dicts):
+    ret = {}
+    for each in dicts:
+        ret.update(each)
+    return ret
+
 
 ## old, re-factored Committee tests ##
 class CommitteeFormatTest(ApiBaseTest):
@@ -11,110 +19,72 @@ class CommitteeFormatTest(ApiBaseTest):
         return response['results']
 
     def test_committee_list_fields(self):
-        # example with committee
-        response = self._response('/committees?committee_id=C00048587')
+        committee = factories.CommitteeFactory(
+            original_registration_date=datetime.datetime(1982, 12, 31),
+            committee_type='P',
+            treasurer_name='Robert J. Lipshutz',
+            party='DEM',
+        )
+        response = self._response('/committees?committee_id={0}'.format(committee.committee_id))
         result = response['results'][0]
         # main fields
         # original registration date doesn't make sense in this example, need to look into this more
-        self.assertEqual(result['original_registration_date'], '1982-12-31 00:00:00')
-        self.assertEqual(result['committee_type'], 'P')
-        self.assertEqual(result['treasurer_name'], 'ROBERT J. LIPSHUTZ')
-        self.assertEqual(result['party'], 'DEM')
-        self.assertEqual(result['committee_type_full'], 'Presidential')
-        self.assertEqual(result['name'], '1976 DEMOCRATIC PRESIDENTIAL CAMPAIGN COMMITTEE, INC. (PCC-1976 GENERAL ELECTION)')
-        self.assertEqual(result['committee_id'], 'C00048587')
-        self.assertEqual(result['designation_full'], 'Principal campaign committee')
-        self.assertEqual(result['state'], 'GA')
-        self.assertEqual(result['party_full'], 'Democratic Party')
-        self.assertEqual(result['designation'], 'P')
-        # no expired committees in test data to test just checking it exists
-        self.assertEqual(result['expire_date'], None)
-        # Example with org type
-        response = self._response('/committees?organization_type=C')
-        results = response['results'][0]
-        self.assertEqual(results['organization_type_full'], 'Corporation')
-        self.assertEqual(results['organization_type'], 'C')
+        self.assertEqual(result['original_registration_date'], str(committee.original_registration_date))
+        self.assertEqual(result['committee_type'], committee.committee_type)
+        self.assertEqual(result['treasurer_name'], committee.treasurer_name)
+        self.assertEqual(result['party'], committee.party)
 
     def test_filter_by_candidate_id(self):
-        response = self._response('/committees?candidate_id=H2CA37213')
+        candidate_id = 'id0'
+        candidate_committees = [factories.CommitteeFactory(candidate_ids=[candidate_id]) for _ in range(2)]
+        other_committees = [factories.CommitteeFactory() for _ in range(3)]  # noqa
+        response = self._response('/committees?candidate_id={0}'.format(candidate_id))
         self.assertEqual(
             len(response['results']),
-            models.Committee.query.filter(
-                models.Committee.candidate_ids.overlap(['H2CA37213'])
-            ).count(),
+            len(candidate_committees)
         )
 
     def test_filter_by_candidate_ids(self):
-        response = self._response('/committees?candidate_id=H2CA37213,H2CA38088')
+        candidate_ids = ['id0', 'id1']
+        candidate1_committees = [factories.CommitteeFactory(candidate_ids=[candidate_ids[0]]) for _ in range(2)]
+        candidate2_committees = [factories.CommitteeFactory(candidate_ids=[candidate_ids[1]]) for _ in range(2)]
+        other_committees = [factories.CommitteeFactory() for _ in range(3)]  # noqa
+        response = self._response('/committees?candidate_id={0}'.format(','.join(candidate_ids)))
         self.assertEqual(
             len(response['results']),
-            models.Committee.query.filter(
-                models.Committee.candidate_ids.overlap(['H2CA37213', 'H2CA38088'])
-            ).count(),
+            len(candidate1_committees) + len(candidate2_committees)
         )
 
     def test_committee_detail_fields(self):
-        response = self._response('/committee/C00048587')
+        committee = factories.CommitteeDetailFactory(
+            original_registration_date=datetime.datetime(1982, 12, 31),
+            committee_type='P',
+            treasurer_name='Robert J. Lipshutz',
+            party='DEM',
+            form_type='F1Z',
+            load_date=datetime.datetime(1982, 12, 31),
+            street_1='1795 Peachtree Road',
+            zip='30309',
+        )
+        response = self._response('/committee/{0}'.format(committee.committee_id))
         result = response['results'][0]
         # main fields
-        self.assertEqual(result['original_registration_date'], '1982-12-31 00:00:00')
-        self.assertEqual(result['committee_type'], 'P')
-        self.assertEqual(result['treasurer_name'], 'ROBERT J. LIPSHUTZ')
-        self.assertEqual(result['party'], 'DEM')
-        self.assertEqual(result['committee_type_full'], 'Presidential')
-        self.assertEqual(result['name'], '1976 DEMOCRATIC PRESIDENTIAL CAMPAIGN COMMITTEE, INC. (PCC-1976 GENERAL ELECTION)')
-        self.assertEqual(result['committee_id'], 'C00048587')
-        self.assertEqual(result['designation_full'], 'Principal campaign committee')
-        self.assertEqual(result['state'], 'GA')
-        self.assertEqual(result['party_full'], 'Democratic Party')
-        self.assertEqual(result['designation'], 'P')
-        # no expired committees in test data to test just checking it exists
-        self.assertEqual(result['expire_date'], None)
+        self.assertEqual(result['original_registration_date'], str(committee.original_registration_date))
+        self.assertEqual(result['committee_type'], committee.committee_type)
+        self.assertEqual(result['treasurer_name'], committee.treasurer_name)
+        self.assertEqual(result['party'], committee.party)
         # Things on the detailed view
-        self.assertEqual(result['filing_frequency'], 'T')
-        self.assertEqual(result['form_type'], 'F1Z')
-        self.assertEqual(result['load_date'], '1982-12-31 00:00:00')
-        self.assertEqual(result['street_1'], '1795 PEACHTREE ROAD , NE')
-        self.assertEqual(result['zip'], '30309')
-        # Example with org type
-        response = self._response('/committees?organization_type=C')
-        results = response['results'][0]
-        self.assertEqual(results['organization_type_full'], 'Corporation')
-        self.assertEqual(results['organization_type'], 'C')
-
+        self.assertEqual(result['form_type'], committee.form_type)
+        self.assertEqual(result['load_date'], str(committee.load_date))
+        self.assertEqual(result['street_1'], committee.street_1)
+        self.assertEqual(result['zip'], committee.zip)
 
     def test_committee_search_double_committee_id(self):
-        response = self._response('/committees?committee_id=C00048587,C00116574&year=*')
+        committees = [factories.CommitteeFactory() for _ in range(2)]
+        ids = ','.join(each.committee_id for each in committees)
+        response = self._response('/committees?committee_id={0}&year=*'.format(ids))
         results = response['results']
         self.assertEqual(len(results), 2)
-
-    def test_committee_search_filters(self):
-        original_response = self._response('/committees')
-        original_count = original_response['pagination']['count']
-
-        party_response = self._response('/committees?party=REP')
-        party_count = party_response['pagination']['count']
-        self.assertEquals((original_count > party_count), True)
-
-        committee_type_response = self._response('/committees?committee_type=P')
-        committee_type_count = committee_type_response['pagination']['count']
-        self.assertEquals((original_count > committee_type_count), True)
-
-        name_response = self._response('/committees?name=Obama')
-        name_count = name_response['pagination']['count']
-        self.assertEquals((original_count > name_count), True)
-
-        committee_id_response = self._response('/committees?committee_id=C00116574')
-        committee_id_count = committee_id_response['pagination']['count']
-        self.assertEquals((original_count > committee_id_count), True)
-
-        designation_response = self._response('/committees?designation=P')
-        designation_count = designation_response['pagination']['count']
-        self.assertEquals((original_count > designation_count), True)
-
-        state_response = self._response('/committees?state=CA')
-        state_count = state_response['pagination']['count']
-        self.assertEquals((original_count > state_count), True)
 
     # /committees?
     def test_err_on_unsupported_arg(self):
@@ -122,28 +92,81 @@ class CommitteeFormatTest(ApiBaseTest):
         self.assertEquals(response.status_code, 400)
 
     def test_committee_party(self):
+        factories.CommitteeFactory(
+            party='REP',
+            party_full='Republican Party',
+        )
         response = self._results('/committees?party=REP')
         self.assertEquals(response[0]['party'], 'REP')
         self.assertEquals(response[0]['party_full'], 'Republican Party')
 
+    # TODO(jmcarp) Refactor as parameterized tests
+    # TODO(jmcarp) Generalize to /committees endpoint
+    # TODO(jmcarp) Generalize to candidate models
+    def test_filters_generic(self):
+        committee = factories.CommitteeFactory()
+        committee_id = committee.committee_id
+        base_url = '/committee/{0}'.format(committee_id)
+        self._check_filter('designation', ['B', 'P'], base_url, committee_id=committee_id)
+        self._check_filter('organization_type', ['M', 'T'], base_url, committee_id=committee_id)
+        self._check_filter('committee_type', ['H', 'X'], base_url, committee_id=committee_id)
+
+    def _check_filter(self, field, values, base_url, alt=None, **attrs):
+
+        # Build fixtures
+        factories.CommitteeFactory(**extend(attrs, {field: alt}))
+        [
+            factories.CommitteeFactory(**extend(attrs, {field: value}))
+            for value in values
+        ]
+
+        # Assert that exactly one record is found for each single-valued search
+        # (e.g. field=value1)
+        for value in values:
+            url = '{0}?{1}={2}'.format(base_url, field, value)
+            results = self._results(url)
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0][field], value)
+
+        # Assert that `len(values)` records are found for multi-valued search
+        # (e.g. field=value1,value2...valueN)
+        url = '{0}?{1}={2}'.format(
+            base_url,
+            field,
+            ','.join(str(each) for each in values),
+        )
+        results = self._results(url)
+        self.assertEqual(len(results), len(values))
+        for result in results:
+            self.assertIn(result[field], values)
+
     def test_committee_filters(self):
-        org_response = self._response('/committees')
-        original_count = org_response['pagination']['count']
+        [
+            factories.CommitteeFactory(state='CA'),
+            factories.CommitteeFactory(name='Obama'),
+            factories.CommitteeFactory(committee_type='S'),
+            factories.CommitteeFactory(designation='P'),
+            factories.CommitteeFactory(party='DEM'),
+            factories.CommitteeFactory(organization_type='C'),
+            factories.CommitteeFactory(committee_id='bartlet'),
+        ]
 
         # checking one example from each field
         filter_fields = (
-            ('committee_id', 'C00484188,C00000422'),
+            ('committee_id', 'bartlet,ritchie'),
             ('state', 'CA,DC'),
             ('name', 'Obama'),
             ('committee_type', 'S'),
             ('designation', 'P'),
             ('party', 'REP,DEM'),
-            ('organization_type','C'),
+            ('organization_type', 'C'),
         )
+
+        org_response = self._response('/committees')
+        original_count = org_response['pagination']['count']
 
         for field, example in filter_fields:
             page = "/committees?%s=%s" % (field, example)
-            print(page)
             # returns at least one result
             results = self._results(page)
             self.assertGreater(len(results), 0)
@@ -152,22 +175,48 @@ class CommitteeFormatTest(ApiBaseTest):
             self.assertGreater(original_count, response['pagination']['count'])
 
     def test_committees_by_cand_id(self):
-        results =  self._results('/candidate/P60000247/committees')
+        candidate_id = 'id0'
+        committees = [factories.CommitteeFactory() for _ in range(3)]
+        rest.db.session.flush()
+        [
+            factories.CandidateCommitteeLinkFactory(
+                candidate_id=candidate_id,
+                committee_id=committee.committee_id,
+                committee_key=committee.committee_key,
+            )
+            for committee in committees
+        ]
+        results = self._results('/candidate/{0}/committees'.format(candidate_id))
 
-        ids = [x['committee_id'] for x in results]
-
-        self.assertIn('C00048587', ids)
-        self.assertIn('C00111245', ids)
-        self.assertIn('C00108407', ids)
+        self.assertEqual(
+            set((each['committee_id'] for each in results)),
+            set((each.committee_id for each in committees)),
+        )
 
     def test_committee_by_cand_filter(self):
-        results =  self._results('/candidate/P60000247/committees?designation=P')
-        self.assertEquals(1, len(results))
+        candidate_id = 'id0'
+        committee = factories.CommitteeFactory(designation='P')
+        rest.db.session.flush()
+        factories.CandidateCommitteeLinkFactory(
+            candidate_id=candidate_id,
+            committee_key=committee.committee_key,
+            committee_id=committee.committee_id,
+        )
+        results = self._results(
+            '/candidate/{0}/committees?designation=P'.format(
+                candidate_id,
+            )
+        )
+        self.assertEqual(1, len(results))
 
-    def test_committee_by_cand(self):
-        results =  self._results('http://localhost:5000/candidate/P60000247/committees?year=*')
-        self.assertEquals(3, len(results))
-
-    def test_canditites_by_com(self):
-        results =  self._results('/committee/C00111245/candidates?year=*')
+    def test_candidates_by_com(self):
+        committee_id = 'id0'
+        candidate = factories.CandidateFactory()
+        rest.db.session.flush()
+        factories.CandidateCommitteeLinkFactory(
+            candidate_id=candidate.candidate_id,
+            candidate_key=candidate.candidate_key,
+            committee_id=committee_id,
+        )
+        results = self._results('/committee/{0}/candidates?year=*'.format(committee_id))
         self.assertEquals(1, len(results))

--- a/webservices/tests/common.py
+++ b/webservices/tests/common.py
@@ -1,26 +1,51 @@
-import codecs
+import os
 import json
+import codecs
 import unittest
 
 from webservices import rest
 
 
+def _reset_schema():
+    rest.db.engine.execute('drop schema if exists public cascade;')
+    rest.db.engine.execute('create schema public;')
+
+
 class ApiBaseTest(unittest.TestCase):
+
     @property
     def __test__(self):
         """Don't test the base class"""
         return self.__class__ != ApiBaseTest
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        super(ApiBaseTest, cls).setUpClass()
         rest.app.config['TESTING'] = True
-        self.app = rest.app.test_client()
-        self.ctx = rest.app.app_context()
-        self.ctx.push()
+        conn_string = os.getenv('SQLA_TEST_CONN', 'postgresql:///cfdm-unit-test')
+        rest.app.config['SQLALCHEMY_DATABASE_URI'] = conn_string
+        cls.app = rest.app.test_client()
+        cls.ctx = rest.app.app_context()
+        cls.ctx.push()
+        _reset_schema()
+        rest.db.create_all()
+
+    def setUp(self):
         self.longMessage = True
         self.maxDiff = None
+        self.connection = rest.db.engine.connect()
+        self.transaction = self.connection.begin()
 
     def tearDown(self):
-        self.ctx.pop()
+        self.transaction.rollback()
+        self.connection.close()
+        rest.db.session.remove()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(ApiBaseTest, cls).tearDownClass()
+        _reset_schema()
+        cls.ctx.pop()
 
     def _response(self, qry):
         response = self.app.get(qry)
@@ -75,4 +100,3 @@ class ApiBaseTest(unittest.TestCase):
         """
         import pprint; pp = pprint.PrettyPrinter(indent=4)
         pp.pprint(thing)
-


### PR DESCRIPTION
#654 created some merge conflicts with #648. This patch resolves conflicts so that #648 will be merge-able again. This PR is targeting @LindsayYoung's earlier PR, so this can be merged into `feature/remove_nesting_refactor` before merging `feature/remove_nesting_refactor` into `develop`.