### PR TITLE
Update first and last filing dates for committees.

### DIFF
--- a/data/sql_updates/create_committee_detail_view.sql
+++ b/data/sql_updates/create_committee_detail_view.sql
@@ -94,7 +94,7 @@ select distinct
 from dimcmte
     inner join dimcmtetpdsgn dd using (cmte_sk)
     -- do a DISTINCT ON subselect to get the most recent properties for a committee
-    inner join (
+    left join (
         select distinct on (cmte_sk) * from dimcmteproperties
             where form_tp = 'F1'
             order by cmte_sk, receipt_dt desc

--- a/data/sql_updates/create_committee_detail_view.sql
+++ b/data/sql_updates/create_committee_detail_view.sql
@@ -40,7 +40,6 @@ select distinct
     cp_most_recent.expire_date as expire_date,
     cp_most_recent.cand_pty_affiliation as party,
     p.party_affiliation_desc as party_full,
-    dates.load_date as original_registration_date,
     cp_most_recent.cmte_nm as name,
     -- (select all cand_id from dimlinkages dl where dl.cmte_sk = dimcmte.cmte_sk) as candidate_ids
     -- Below here are committee variables for the detail view
@@ -88,14 +87,22 @@ select distinct
     cp_most_recent.lobbyist_registrant_pac_flg as lobbyist_registrant_pac,
     cp_most_recent.party_cmte_type as party_type,
     cp_most_recent.party_cmte_type_desc as party_type_full,
-    cp_most_recent.qual_dt as qualifying_date
+    cp_most_recent.qual_dt as qualifying_date,
+    cp_most_recent.receipt_dt as last_file_date,
+    cp_original.receipt_dt as first_file_date
 
 from dimcmte
     inner join dimcmtetpdsgn dd using (cmte_sk)
     -- do a DISTINCT ON subselect to get the most recent properties for a committee
     inner join (
-        select distinct on (cmte_sk) cmte_sk, cmte_nm, cmte_zip, cmte_treasurer_nm, org_tp, org_tp_desc, cmte_st, expire_date, cand_pty_affiliation, cmte_st1, cmte_st2, cmte_city, cmte_st_desc, cmte_zip cmte_treasurer_city, cmte_treasurer_f_nm, cmte_treasurer_l_nm, cmte_treasurer_m_nm, cmte_treasurer_ph_num, cmte_treasurer_prefix, cmte_treasurer_st, cmte_treasurer_st1, cmte_treasurer_st2, cmte_treasurer_suffix, cmte_treasurer_title, cmte_treasurer_zip, cmte_custodian_city, cmte_custodian_f_nm, cmte_custodian_l_nm, cmte_custodian_m_nm, cmte_custodian_nm, cmte_custodian_ph_num, cmte_custodian_prefix, cmte_custodian_st, cmte_custodian_st1, cmte_custodian_st2, cmte_custodian_suffix, cmte_custodian_title, cmte_custodian_zip, cmte_email, cmte_fax, cmte_web_url, form_tp, leadership_pac, load_date, lobbyist_registrant_pac_flg, party_cmte_type, party_cmte_type_desc, qual_dt from dimcmteproperties order by cmte_sk, cmteproperties_sk desc
+        select distinct on (cmte_sk) * from dimcmteproperties
+            where form_tp = 'F1'
+            order by cmte_sk, receipt_dt desc
     ) cp_most_recent using (cmte_sk)
+    left join(
+        select cmte_sk, min(receipt_dt) receipt_dt from dimcmteproperties
+            group by cmte_sk
+    ) cp_original using (cmte_sk)
     left join dimparty p on cp_most_recent.cand_pty_affiliation = p.party_affiliation
     left join (
         select distinct on (cmte_sk) cmte_sk, load_date from dimcmteproperties

--- a/data/sql_updates/create_committees_view.sql
+++ b/data/sql_updates/create_committees_view.sql
@@ -47,7 +47,7 @@ select distinct
 from dimcmte
     left join dimcmtetpdsgn dd using (cmte_sk)
     -- do a DISTINCT ON subselect to get the most recent properties for a committee
-    inner join (
+    left join (
         select distinct on (cmte_sk) * from dimcmteproperties
             where form_tp = 'F1'
             order by cmte_sk, receipt_dt desc

--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -88,9 +88,10 @@ class Committee(BaseModel):
     committee_type = db.Column(db.String(1))
     committee_type_full = db.Column(db.String(50))
     expire_date = db.Column(db.DateTime())
+    first_file_date = db.Column(db.DateTime)
+    last_file_date = db.Column(db.DateTime)
     party = db.Column(db.String(3))
     party_full = db.Column(db.String(50))
-    original_registration_date = db.Column(db.DateTime())
     name = db.Column(db.String(100))
 
     __tablename__ = 'ofec_committees_mv'
@@ -108,9 +109,10 @@ class CommitteeDetail(BaseModel):
     committee_type = db.Column(db.String(1))
     committee_type_full = db.Column(db.String(50))
     expire_date = db.Column(db.DateTime())
+    first_file_date = db.Column(db.DateTime)
+    last_file_date = db.Column(db.DateTime)
     party = db.Column(db.String(3))
     party_full = db.Column(db.String(50))
-    original_registration_date = db.Column(db.DateTime())
     name = db.Column(db.String(100))
     # detail view additions
     filing_frequency = db.Column(db.String(1))

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -176,7 +176,12 @@ class CommitteeList(Resource):
         if args.get('year') is None:
             earliest_year = int(sorted(default_year().split(','))[0])
             # still going or expired after the earliest year we are looking for
-            committees = committees.filter(or_(extract('year', Committee.expire_date) >= earliest_year, Committee.expire_date == None))
+            committees = committees.filter(
+                or_(
+                    extract('year', Committee.last_file_date) >= earliest_year,
+                    Committee.last_file_date == None,
+                )
+            )  # noqa
 
         # Should this handle a list of years to make it consistent with /candidate ?
         elif args.get('year') and args['year'] != '*':

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -27,7 +27,8 @@ committee_fields = {
     'committee_type_full': fields.String,
     'committee_type': fields.String,
     'expire_date': fields.String,
-    'original_registration_date': fields.String,
+    'first_file_date': fields.String,
+    'last_file_date': fields.String,
     'candidates': fields.Nested(candidate_commitee_fields),
 }
 committee_detail_fields = {
@@ -44,7 +45,8 @@ committee_detail_fields = {
     'committee_type_full': fields.String,
     'committee_type': fields.String,
     'expire_date': fields.String,
-    'original_registration_date': fields.String,
+    'first_file_date': fields.String,
+    'last_file_date': fields.String,
     'candidates': fields.Nested(candidate_commitee_fields),
     'filing_frequency' : fields.String,
     'email' : fields.String,
@@ -179,9 +181,9 @@ class CommitteeList(Resource):
         # Should this handle a list of years to make it consistent with /candidate ?
         elif args.get('year') and args['year'] != '*':
             # before expiration
-            committees = committees.filter(or_(extract('year', Committee.expire_date) >= int(args['year']), Committee.expire_date == None))
+            committees = committees.filter(or_(extract('year', Committee.last_file_date) >= int(args['year']), Committee.last_file_date == None))
             # after origination
-            committees = committees.filter(extract('year', Committee.original_registration_date) <= int(args['year']))
+            committees = committees.filter(extract('year', Committee.first_file_date) <= int(args['year']))
 
         count = committees.count()
 
@@ -249,9 +251,9 @@ class CommitteeView(Resource):
         # To support '*' across all endpoints
         if args.get('year') and args['year'] != '*':
             # before expiration
-            committees = committees.filter(or_(extract('year', CommitteeDetail.expire_date) >= int(args['year']), CommitteeDetail.expire_date == None))
+            committees = committees.filter(or_(extract('year', CommitteeDetail.last_file_date) >= int(args['year']), CommitteeDetail.last_file_date == None))
             # after origination
-            committees = committees.filter(extract('year', CommitteeDetail.original_registration_date) <= int(args['year']))
+            committees = committees.filter(extract('year', CommitteeDetail.first_file_date) <= int(args['year']))
 
         count = committees.count()
 

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -180,10 +180,14 @@ class CommitteeList(Resource):
 
         # Should this handle a list of years to make it consistent with /candidate ?
         elif args.get('year') and args['year'] != '*':
-            # before expiration
-            committees = committees.filter(or_(extract('year', Committee.last_file_date) >= int(args['year']), Committee.last_file_date == None))
-            # after origination
-            committees = committees.filter(extract('year', Committee.first_file_date) <= int(args['year']))
+            year = int(args['year'])
+            committees = committees.filter(
+                or_(
+                    extract('year', Committee.last_file_date) >= year,
+                    Committee.last_file_date == None,
+                ),
+                extract('year', Committee.first_file_date) <= year,
+            )  # noqa
 
         count = committees.count()
 
@@ -250,10 +254,14 @@ class CommitteeView(Resource):
 
         # To support '*' across all endpoints
         if args.get('year') and args['year'] != '*':
-            # before expiration
-            committees = committees.filter(or_(extract('year', CommitteeDetail.last_file_date) >= int(args['year']), CommitteeDetail.last_file_date == None))
-            # after origination
-            committees = committees.filter(extract('year', CommitteeDetail.first_file_date) <= int(args['year']))
+            year = int(args['year'])
+            committees = committees.filter(
+                or_(
+                    extract('year', CommitteeDetail.last_file_date) >= year,
+                    CommitteeDetail.last_file_date == None,
+                ),
+                extract('year', CommitteeDetail.first_file_date) <= year,
+            )  # noqa
 
         count = committees.count()
 

--- a/webservices/tests/committee_tests.py
+++ b/webservices/tests/committee_tests.py
@@ -20,7 +20,7 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_list_fields(self):
         committee = factories.CommitteeFactory(
-            original_registration_date=datetime.datetime(1982, 12, 31),
+            first_file_date=datetime.datetime(1982, 12, 31),
             committee_type='P',
             treasurer_name='Robert J. Lipshutz',
             party='DEM',
@@ -29,7 +29,7 @@ class CommitteeFormatTest(ApiBaseTest):
         result = response['results'][0]
         # main fields
         # original registration date doesn't make sense in this example, need to look into this more
-        self.assertEqual(result['original_registration_date'], str(committee.original_registration_date))
+        self.assertEqual(result['first_file_date'], str(committee.first_file_date))
         self.assertEqual(result['committee_type'], committee.committee_type)
         self.assertEqual(result['treasurer_name'], committee.treasurer_name)
         self.assertEqual(result['party'], committee.party)
@@ -57,7 +57,7 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_detail_fields(self):
         committee = factories.CommitteeDetailFactory(
-            original_registration_date=datetime.datetime(1982, 12, 31),
+            first_file_date=datetime.datetime(1982, 12, 31),
             committee_type='P',
             treasurer_name='Robert J. Lipshutz',
             party='DEM',
@@ -69,7 +69,7 @@ class CommitteeFormatTest(ApiBaseTest):
         response = self._response('/committee/{0}'.format(committee.committee_id))
         result = response['results'][0]
         # main fields
-        self.assertEqual(result['original_registration_date'], str(committee.original_registration_date))
+        self.assertEqual(result['first_file_date'], str(committee.first_file_date))
         self.assertEqual(result['committee_type'], committee.committee_type)
         self.assertEqual(result['treasurer_name'], committee.treasurer_name)
         self.assertEqual(result['party'], committee.party)


### PR DESCRIPTION
Note: Based on the recommendation of FEC, this patch only considers
receipt dates from F1 filings. Since we're doing an `INNER JOIN` to combine
`dimcmte` and `dimcmteproperties`, committees that have never filed an F1
are excluded. We could switch to a `LEFT JOIN`, but then we'd have a bunch
of committees with `NULL` dates and values from `dimcmteproperties`.

Thoughts @lindsayyoung @arowla?

[Resolves #624]
[Resolves #649]