### PR TITLE
Feature/api version

### DIFF
--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -43,6 +43,7 @@ class Candidate(BaseModel):
     party_full = db.Column(db.String(255))
     state = db.Column(db.String(2))
     name = db.Column(db.String(100))
+    committees = db.relationship('CandidateCommitteeLink', backref='candidates')
 
     __tablename__ = 'ofec_candidates_mv'
 
@@ -71,6 +72,7 @@ class CandidateDetail(BaseModel):
     address_street_2 = db.Column(db.String(200))
     address_zip = db.Column(db.String(10))
     candidate_inactive = db.Column(db.String(1))
+    committees = db.relationship('CandidateCommitteeLink', backref='candidatedetail')
 
     __tablename__ = 'ofec_candidate_detail_mv'
 
@@ -92,6 +94,7 @@ class Committee(BaseModel):
     party_full = db.Column(db.String(50))
     original_registration_date = db.Column(db.DateTime())
     name = db.Column(db.String(100))
+    candidates = db.relationship('CandidateCommitteeLink', backref='committees')
 
     __tablename__ = 'ofec_committees_mv'
 
@@ -154,6 +157,7 @@ class CommitteeDetail(BaseModel):
     custodian_name_suffix = db.Column(db.String(50))
     custodian_name_title = db.Column(db.String(50))
     custodian_zip = db.Column(db.String(9))
+    candidates = db.relationship('CandidateCommitteeLink', backref='committeedetail')
 
     __tablename__ = 'ofec_committee_detail_mv'
 

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -8,7 +8,7 @@ import logging
 import sys
 import os
 
-from flask import Flask, abort, request
+from flask import Flask, Blueprint, abort, request
 from flask.ext import restful
 from flask.ext.restful import reqparse
 import flask.ext.restful.representations.json
@@ -40,8 +40,12 @@ def sqla_conn_string():
 
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = sqla_conn_string()
-api = restful.Api(app)
 db.init_app(app)
+
+v1 = Blueprint('v1', __name__, url_prefix='/v1')
+api = restful.Api(v1)
+
+app.register_blueprint(v1)
 
 # api.data.gov
 trusted_proxies = ('54.208.160.112', '54.208.160.151')
@@ -93,7 +97,7 @@ class NameSearch(restful.Resource):
     )
 
     def get(self):
-        args = self.parser.parse_args(strict=True)
+        args = self.parser.parse_args()
 
         qry = sa.sql.text(self.fulltext_qry)
         findme = ' & '.join(args['q'].split())

--- a/webservices/tests/candidate_tests.py
+++ b/webservices/tests/candidate_tests.py
@@ -2,11 +2,12 @@ import datetime
 import unittest
 import functools
 
-import sqlalchemy as sa
-
 from .common import ApiBaseTest
-from webservices import rest
 from tests import factories
+from webservices.rest import api
+from webservices.rest import CandidateList
+from webservices.rest import CandidateView
+from webservices.rest import CandidateHistoryView
 
 
 fields = dict(
@@ -42,7 +43,9 @@ class CandidateFormatTest(ApiBaseTest):
             load_date=datetime.datetime(2014, 1, 3),
             **fields
         )
-        response = self._response('/candidate/{0}'.format(candidate.candidate_id))
+        response = self._response(
+            api.url_for(CandidateView, candidate_id=candidate.candidate_id)
+        )
         self.assertResultsEqual(
             response['pagination'],
             {'count': 1, 'page': 1, 'pages': 1, 'per_page': 20})
@@ -113,7 +116,9 @@ class CandidateFormatTest(ApiBaseTest):
 
     def test_fields(self):
         candidate = factories.CandidateDetailFactory()
-        response = self._results('/candidate/{0}'.format(candidate.candidate_id))
+        response = self._results(
+            api.url_for(CandidateView, candidate_id=candidate.candidate_id)
+        )
         response = response[0]
 
         fields = ('party', 'party_full', 'state', 'district', 'incumbent_challenge_full', 'incumbent_challenge', 'candidate_status', 'candidate_status_full', 'office', 'active_through')
@@ -126,7 +131,9 @@ class CandidateFormatTest(ApiBaseTest):
             address_street_1='PO Box 8102',
             address_zip='60680',
         )
-        response = self._results('/candidate/{0}'.format(candidate.candidate_id))
+        response = self._results(
+            api.url_for(CandidateView, candidate_id=candidate.candidate_id)
+        )
         response = response[0]
         self.assertIn('committees', response)
         self.assertIn(candidate.address_street_1, response['address_street_1'])
@@ -141,7 +148,6 @@ class CandidateFormatTest(ApiBaseTest):
         election = response[0]['committees'][0]
         print(election)
         for field in fields:
-            print(field)
             self.assertEquals(field in election, True)
 
     def test_cand_filters(self):
@@ -168,11 +174,11 @@ class CandidateFormatTest(ApiBaseTest):
         )
 
         # checking one example from each field
-        orig_response = self._response('/candidates')
+        orig_response = self._response(api.url_for(CandidateList))
         original_count = orig_response['pagination']['count']
 
         for field, example in filter_fields:
-            page = "/candidates?%s=%s" % (field, example)
+            page = api.url_for(CandidateList, **{field: example})
             # returns at least one result
             results = self._results(page)
             self.assertGreater(len(results), 0)
@@ -191,7 +197,13 @@ class CandidateFormatTest(ApiBaseTest):
             partial(two_year_period=2012),
             partial(two_year_period=2008),
         ]
-        results = self._results('/candidate/{0}/history/{1}'.format(id, histories[1].two_year_period))
+        results = self._results(
+            api.url_for(
+                CandidateHistoryView,
+                candidate_id=id,
+                year=histories[1].two_year_period,
+            )
+        )
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['candidate_id'], id)
         self.assertEqual(results[0]['two_year_period'], histories[1].two_year_period)
@@ -207,8 +219,12 @@ class CandidateFormatTest(ApiBaseTest):
             partial(two_year_period=2012),
             partial(two_year_period=2008),
         ]
-        results = self._results('/candidate/{0}/history'.format(id))
-        recent_results = self._results('/candidate/{0}/history/recent'.format(id))
+        results = self._results(
+            api.url_for(CandidateHistoryView, candidate_id=id)
+        )
+        recent_results = self._results(
+            api.url_for(CandidateHistoryView, candidate_id=id, year='recent')
+        )
 
         # history/recent
         self.assertEqual(recent_results[0]['candidate_id'], histories[0].candidate_id)


### PR DESCRIPTION
Prefix API URLs with the current API version, starting with `v1`.

Note: Depends on https://github.com/18F/openFEC-web-app/pull/108

[Resolves #44].