### PR TITLE
Use most recent candidate properties in materialized views.

### DIFF
--- a/data/sql_updates/create_candidate_detail_view.sql
+++ b/data/sql_updates/create_candidate_detail_view.sql
@@ -47,11 +47,8 @@ from dimcand
         order by cand_sk, cand_id, election_yr desc
     ) csi_recent using (cand_sk, cand_id)
     left join (
-        select distinct on (cand_sk, cand_id)
-            p.cand_sk, p.cand_nm, c.cand_id, p.cand_st, p.expire_date, p.load_date, p.cand_city, p.cand_st1, p.cand_st2, p.cand_zip, p.cand_ici_desc, p.cand_ici_cd, p.form_tp
-        from dimcandproperties p
-            inner join dimcand c using (cand_sk)
-        order by cand_sk, cand_id, load_date desc
+        select distinct on (cand_sk) * from dimcandproperties
+            order by cand_sk, candproperties_sk desc
     ) cand_p_most_recent using(cand_sk, cand_id)
     left join dimcandstatusici csi_all using (cand_sk)
     left join dimcandoffice co on co.cand_sk = dimcand.cand_sk and (csi_recent.election_yr is null or co.cand_election_yr = csi_recent.election_yr)  -- only joined to get to dimoffice

--- a/data/sql_updates/create_candidate_history_view.sql
+++ b/data/sql_updates/create_candidate_history_view.sql
@@ -42,7 +42,7 @@ from ofec_two_year_periods
             left join dimcandoffice co using (cand_sk)
             inner join dimoffice using (office_sk)
             inner join dimparty using (party_sk)
-        order by cand_sk, two_year_period, dcp.load_date desc
+        order by cand_sk, two_year_period, dcp.candproperties_sk desc
     ) as dcp_by_period on ofec_two_year_periods.year = two_year_period
 ;
 


### PR DESCRIPTION
Continuing in the same vein as #674, this patch sorts by
`candproperties_sk` instead of the now-uninformative `load_date` when
building views that pull from the `dimcandproperties` table.

@LindsayYoung I think this resolves the issue you brought up in conversation on #674 about getting the most recent candidate properties for the candidate history view.