### PR TITLE
Use buildpack-multi for webapp.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -14,16 +14,6 @@ if [ "$#" -ne 1 ]; then
   exit 1
 fi
 
-echo "Building JS in openFEC-web-app..."
-cd ../openFEC-web-app
-npm run build
-
-if [ $? -ne 0 ]; then
-  echo "JS build failed."
-  exit $?
-fi
-
-cd -
 echo "Targeting Cloud Foundry space..."
 cf target -o fec -s "$1"
 echo

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -14,7 +14,7 @@ applications:
     WEB_CONCURRENCY: 4
 - name: web
   path: ../openFEC-web-app
-  buildpack: python_buildpack
+  buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
   host: fec-dev-web
   env:
     NEW_RELIC_APP_NAME: OpenFEC Web (development)

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -16,7 +16,7 @@ applications:
     WEB_CONCURRENCY: 4
 - name: web
   path: ../openFEC-web-app
-  buildpack: python_buildpack
+  buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
   host: fec-prod-web
   env:
     NEW_RELIC_APP_NAME: OpenFEC Web (production)

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -14,7 +14,7 @@ applications:
     WEB_CONCURRENCY: 4
 - name: web
   path: ../openFEC-web-app
-  buildpack: python_buildpack
+  buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
   host: fec-stage-web
   env:
     NEW_RELIC_APP_NAME: OpenFEC Web (staging)


### PR DESCRIPTION
This is necessary for a parallel change to the webapp that builds assets
remotely. The webapp needs to use both the python buildpack (to run the
app) and the node buildpack (to compile the assets).