### PR TITLE
Force HTTPS in production.

### DIFF
--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -21,6 +21,7 @@ applications:
   env:
     NEW_RELIC_APP_NAME: OpenFEC Web (production)
     FEC_WEB_API_URL: https://api.open.fec.gov/
+    FEC_FORCE_HTTPS: true
     # These must be set manually via `cf set-env`
     # FEC_WEB_PASSWORD
     # FEC_WEB_USERNAME


### PR DESCRIPTION
Enable HTTPS redirect implemented in https://github.com/18F/openFEC-web-app/pull/117 in prod space. Related to #619.