### PR TITLE
Feature/auto subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,16 @@ If you want to deploy to one of our Cloud Foundry instances, use `deploy.sh`. It
 
 The script will automatically target the correct manifest file for the environment/space you specify, and it will also deploy the web app at the same time as the API.
 
-`./deploy.sh [dev|stage|prod]`
+    $ ./deploy.sh [dev|stage|prod]
 
 Deploys of a single app can be performed manually by targeting the env/space, and specifying the corresponding manifest, as well as the app you want, like so:
 
-`cf target [dev|stage|prod] && cf push -f manifest_<[dev|stage|prod]>.yml [api|web]`
+    $ cf target [dev|stage|prod] && cf push -f manifest_<[dev|stage|prod]>.yml [api|web]
 
+### Working with test data
 
+This repo includes a small subset of the production database (built 2015/05/05) at `data/subset.sql`. To build a new test subset, use the `build_test` invoke task:
 
+    $ invoke build_test <source> <dest>
 
+where both `source` and `dest` are valid PostgreSQL connection strings.

--- a/data/subset-config.json
+++ b/data/subset-config.json
@@ -23,6 +23,60 @@
         "referred_columns": ["cand_sk"],
         "constrained_columns": ["cand_sk"]
       }
+    ],
+    "dimcmteproperties": [
+      {
+        "referred_schema": null,
+        "referred_table": "dimcmte",
+        "referred_columns": ["cmte_sk"],
+        "constrained_columns": ["cmte_sk"]
+      }
+    ],
+    "dimcmtetpdsgn": [
+      {
+        "referred_schema": null,
+        "referred_table": "dimcmte",
+        "referred_columns": ["cmte_sk"],
+        "constrained_columns": ["cmte_sk"]
+      }
+    ],
+    "facthousesenate_f3": [
+      {
+        "referred_schema": null,
+        "referred_table": "dimcmte",
+        "referred_columns": ["cmte_sk"],
+        "constrained_columns": ["cmte_sk"]
+      }
+    ],
+    "factpacsandparties_f3x": [
+      {
+        "referred_schema": null,
+        "referred_table": "dimcmte",
+        "referred_columns": ["cmte_sk"],
+        "constrained_columns": ["cmte_sk"]
+      }
+    ],
+    "factpresidential_f3p": [
+      {
+        "referred_schema": null,
+        "referred_table": "dimcmte",
+        "referred_columns": ["cmte_sk"],
+        "constrained_columns": ["cmte_sk"]
+      }
+    ],
+    "dimlinkages": [
+      {
+        "referred_schema": null,
+        "referred_table": "dimcand",
+        "referred_columns": ["cand_sk"],
+        "constrained_columns": ["cand_sk"]
+      },
+      {
+        "referred_schema": null,
+        "referred_table": "dimcmte",
+        "referred_columns": ["cmte_sk"],
+        "constrained_columns": ["cmte_sk"]
+      }
     ]
   }
 }

--- a/data/subset-config.json
+++ b/data/subset-config.json
@@ -1,0 +1,28 @@
+{
+  "constraints": {
+    "dimcandproperties": [
+      {
+        "referred_schema": null,
+        "referred_table": "dimcand",
+        "referred_columns": ["cand_sk"],
+        "constrained_columns": ["cand_sk"]
+      }
+    ],
+    "dimcandstatus_ici": [
+      {
+        "referred_schema": null,
+        "referred_table": "dimcand",
+        "referred_columns": ["cand_sk"],
+        "constrained_columns": ["cand_sk"]
+      }
+    ],
+    "dimcandoffice": [
+      {
+        "referred_schema": null,
+        "referred_table": "dimcand",
+        "referred_columns": ["cand_sk"],
+        "constrained_columns": ["cand_sk"]
+      }
+    ]
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ gunicorn
 
 nose>=1.3.6
 factory-boy>=2.5.2
+
+invoke>=0.10.1
+git+https://github.com/jmcarp/rdbms-subsetter@current

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,54 @@
+from invoke import run
+from invoke import task
+
+DEFAULT_FRACTION = 0.015
+FULL_TABLES = [
+    'dimparty',
+    'dimoffice',
+    'dimyears',
+]
+EXCLUDE_TABLES = [
+    'sched_a',
+    'sched_b',
+]
+
+
+@task
+def fetch_schemas(source, dest):
+    cmd = 'pg_dump {0} --schema-only --no-owner'.format(source)
+    for table in EXCLUDE_TABLES:
+        cmd += ' --exclude-table {0}'.format(table)
+    cmd += ' | psql {0}'.format(dest)
+    run(cmd)
+
+
+@task
+def fetch_full(source, dest):
+    cmd = 'pg_dump {0} --no-owner'.format(source)
+    for table in FULL_TABLES:
+        cmd += ' --table {0}'.format(table)
+    cmd += ' | psql {0}'.format(dest)
+    run(cmd, echo=True)
+
+
+@task
+def fetch_subset(source, dest, fraction=DEFAULT_FRACTION):
+    cmd = 'rdbms-subsetter {source} {dest} {fraction}'.format(**locals())
+    for table in (FULL_TABLES + EXCLUDE_TABLES):
+        cmd += ' --exclude-table {0}'.format(table)
+    cmd += ' --config data/subset-config.json'
+    cmd += ' --yes'
+    run(cmd, echo=True)
+
+
+@task
+def build_test(source, dest, fraction=DEFAULT_FRACTION):
+    fetch_schemas(source, dest)
+    fetch_full(source, dest)
+    fetch_subset(source, dest, fraction=fraction)
+
+
+@task
+def dump(source, dest):
+    cmd = 'pg_dump {source} --no-owner -f {dest}'.format(**locals())
+    run(cmd, echo=True)

--- a/tasks.py
+++ b/tasks.py
@@ -1,15 +1,23 @@
 from invoke import run
 from invoke import task
 
+
 DEFAULT_FRACTION = 0.015
 FULL_TABLES = [
+    'dimdates',
     'dimparty',
-    'dimoffice',
     'dimyears',
+    'dimoffice',
+    'dimreporttype',
 ]
 EXCLUDE_TABLES = [
     'sched_a',
     'sched_b',
+]
+# Include Nancy Pelosi and John Boehner for debugging purposes
+FORCE_INCLUDE = [
+    ('dimcand', 10024584),
+    ('dimcand', 10034937),
 ]
 
 
@@ -36,6 +44,8 @@ def fetch_subset(source, dest, fraction=DEFAULT_FRACTION):
     cmd = 'rdbms-subsetter {source} {dest} {fraction}'.format(**locals())
     for table in (FULL_TABLES + EXCLUDE_TABLES):
         cmd += ' --exclude-table {0}'.format(table)
+    for table, key in FORCE_INCLUDE:
+        cmd += ' --force {0}:{1}'.format(table, key)
     cmd += ' --config data/subset-config.json'
     cmd += ' --yes'
     run(cmd, echo=True)


### PR DESCRIPTION
Create a new test subset for local development, plus scripts to generate more test subsets as needed (e.g. if FEC updates the underlying data or schemas). I'm using `invoke` for the CLI, but I'm happy to refactor with bash or make if you all prefer--I'm just faster writing Python. I also had to make a few small changes to `rdbms-subsetter` to get this to work, so `requirements.txt` is pointed at my fork for now.

To load the new test subset:
```bash
psql -f data/subset.sql <dest>
```

To build a fresh subset:
```bash
invoke build_test <source> <dest>
```

[Resolves #681]