### PR TITLE
Move form filter to correct join.

### DIFF
--- a/data/sql_updates/create_committee_detail_view.sql
+++ b/data/sql_updates/create_committee_detail_view.sql
@@ -99,11 +99,11 @@ from dimcmte
     -- do a DISTINCT ON subselect to get the most recent properties for a committee
     left join (
         select distinct on (cmte_sk) * from dimcmteproperties
-            where form_tp = 'F1'
             order by cmte_sk, receipt_dt desc
     ) cp_most_recent using (cmte_sk)
     left join(
         select cmte_sk, min(receipt_dt) receipt_dt from dimcmteproperties
+            where form_tp = 'F1'
             group by cmte_sk
     ) cp_original using (cmte_sk)
     left join dimparty p on cp_most_recent.cand_pty_affiliation = p.party_affiliation


### PR DESCRIPTION
Based on correspondence with FEC, we should only use F1 filings to
determine original filing dates, but we can use the most recent filings
regardless of form type for other committee properties. I got this
almost right in #678 but applied the F1 filter to the most recent
committee properties rather than the original properties. This patch
moves the filter to the right join.

Thanks @lindsayyoung and @arowla for identifying the issue.