### PR TITLE
Fix static files needed for swagger documentation.

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,4 +1,5 @@
 cache
+node_modules
 
 data/bin/set_env_vars.real.sh
 .DS_Store

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -7,6 +7,7 @@ env:
 applications:
 - name: api
   path: .
+  buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
   host: fec-dev-api
   env:
     NEW_RELIC_APP_NAME: OpenFEC API (development)

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -8,6 +8,7 @@ env:
 applications:
 - name: api
   path: .
+  buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
   host: fec-prod-api
   env:
     PRODUCTION: True

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -7,6 +7,7 @@ env:
 applications:
 - name: api
   path: .
+  buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
   host: fec-stage-api
   env:
     NEW_RELIC_APP_NAME: OpenFEC API (staging)

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -210,10 +210,11 @@ yaml.add_representer(
 )
 
 # Adapted from https://github.com/noirbizarre/flask-restplus
+here, _ = os.path.split(__file__)
 docs = Blueprint(
     'docs',
     __name__,
-    static_folder='/Users/jmcarp/code/openFEC/',
+    static_folder=os.path.join(here, os.pardir, 'node_modules', 'swagger-ui'),
     static_url_path='/docs/static',
 )
 
@@ -229,7 +230,7 @@ def api_spec():
 
 @docs.add_app_template_global
 def swagger_static(filename):
-    return url_for('docs.static', filename='node_modules/swagger-ui/dist/{0}'.format(filename))
+    return url_for('docs.static', filename='dist/{0}'.format(filename))
 
 
 @docs.route('/swagger/ui/')


### PR DESCRIPTION
* Fetch swagger-ui source remotely
* Ignore local `node_modules` (was interfering with remote download)
* Fix hard-coded static asset path

This is the code that's currently deployed to dev.