### PR TITLE
Add candidate search endpoint with nested principal committee.

### DIFF
--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -51,7 +51,16 @@ class BaseCandidate(BaseModel):
 class Candidate(BaseCandidate):
     __tablename__ = 'ofec_candidates_mv'
 
-    committees = db.relationship('CandidateCommitteeLink', backref='candidates')
+    # Customize join to restrict to principal committees
+    principal_committees = db.relationship(
+        'Committee',
+        secondary='ofec_name_linkage_mv',
+        secondaryjoin=' and '.join([
+            'Committee.committee_key == ofec_name_linkage_mv.c.committee_key',
+            'Committee.designation == "P"',
+        ]),
+        order_by='desc(Committee.last_file_date)',
+    )
 
 
 class CandidateDetail(BaseCandidate):
@@ -67,7 +76,6 @@ class CandidateDetail(BaseCandidate):
     address_street_2 = db.Column(db.String(200))
     address_zip = db.Column(db.String(10))
     candidate_inactive = db.Column(db.String(1))
-    committees = db.relationship('CandidateCommitteeLink', backref='candidatedetail')
 
 
 class BaseCommittee(BaseModel):
@@ -96,7 +104,6 @@ class Committee(BaseCommittee):
     __tablename__ = 'ofec_committees_mv'
 
     candidate_ids = db.Column(ARRAY(db.Text))
-    candidates = db.relationship('CandidateCommitteeLink', backref='committees')
 
 
 class CommitteeDetail(BaseCommittee):
@@ -143,26 +150,33 @@ class CommitteeDetail(BaseCommittee):
     custodian_name_suffix = db.Column(db.String(50))
     custodian_name_title = db.Column(db.String(50))
     custodian_zip = db.Column(db.String(9))
-    candidates = db.relationship('CandidateCommitteeLink', backref='committeedetail')
 
 
 class CandidateCommitteeLink(BaseModel):
     __tablename__ = 'ofec_name_linkage_mv'
 
     linkage_key = db.Column(db.Integer)
-    committee_key = db.Column('committee_key', db.Integer, db.ForeignKey(Committee.committee_key), db.ForeignKey(CommitteeDetail.committee_key))
-    candidate_key = db.Column('candidate_key', db.Integer, db.ForeignKey(Candidate.candidate_key), db.ForeignKey(CandidateDetail.candidate_key))
-    committee_id = db.Column('committee_id', db.String(10))
-    candidate_id = db.Column('candidate_id', db.String(10))
-    election_year = db.Column('election_year', db.Integer)
-    active_through = db.Column('active_through', db.Integer)
-    expire_date = db.Column('expire_date', db.DateTime())
-    committee_name = db.Column('committee_name', db.DateTime())
-    candidate_name = db.Column('candidate_name', db.DateTime())
-    committee_designation = db.Column('committee_designation', db.String(1))
-    committee_designation_full = db.Column(db.String(25))
-    committee_type = db.Column('committee_type', db.String(1))
-    committee_type_full = db.Column('committee_type_full', db.String(50))
+    committee_key = db.Column(
+        db.Integer,
+        db.ForeignKey('ofec_committees_mv.committee_key'),
+        db.ForeignKey('ofec_committee_detail_mv.committee_key'),
+    )
+    candidate_key = db.Column(
+        db.Integer,
+        db.ForeignKey('ofec_candidates_mv.candidate_key'),
+        db.ForeignKey('ofec_candidate_detail_mv.candidate_key'),
+    )
+    committee_id = db.Column(db.String)
+    candidate_id = db.Column(db.String)
+    election_year = db.Column(db.Integer)
+    active_through = db.Column(db.Integer)
+    expire_date = db.Column(db.DateTime)
+    committee_name = db.Column(db.String)
+    candidate_name = db.Column(db.String)
+    committee_designation = db.Column(db.String)
+    committee_designation_full = db.Column(db.String)
+    committee_type = db.Column(db.String)
+    committee_type_full = db.Column(db.String)
 
 
 class CommitteeReports(BaseModel):

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -1,4 +1,4 @@
-from sqlalchemy.sql import text
+import sqlalchemy as sa
 from flask.ext.restful import Resource
 
 from webservices import args
@@ -29,6 +29,10 @@ class CandidateList(Resource):
         ORDER BY ts_rank_cd(fulltxt, to_tsquery(:findme)) desc
     """
 
+    @property
+    def query(self):
+        return Candidate.query
+
     @args.register_kwargs(args.paging)
     @args.register_kwargs(args.candidate_list)
     @args.register_kwargs(args.candidate_detail)
@@ -40,13 +44,13 @@ class CandidateList(Resource):
 
     def get_candidates(self, kwargs):
 
-        candidates = Candidate.query
+        candidates = self.query
 
         if kwargs.get('q'):
             findme = ' & '.join(kwargs['q'].split())
             candidates = candidates.filter(
                 Candidate.candidate_key.in_(
-                    db.session.query('cand_sk').from_statement(text(self.fulltext_query)).params(findme=findme)
+                    db.session.query('cand_sk').from_statement(sa.text(self.fulltext_query)).params(findme=findme)
                 )
             )
 
@@ -60,6 +64,25 @@ class CandidateList(Resource):
             candidates = candidates.filter(Candidate.cycles.overlap(kwargs['cycle']))
 
         return candidates.order_by(Candidate.name)
+
+
+class CandidateSearch(CandidateList):
+
+    @property
+    def query(self):
+        # Eagerly load principal committees to avoid extra queries
+        return Candidate.query.options(
+            sa.orm.subqueryload(Candidate.principal_committees)
+        )
+
+    @args.register_kwargs(args.paging)
+    @args.register_kwargs(args.candidate_list)
+    @args.register_kwargs(args.candidate_detail)
+    @schemas.marshal_with(schemas.CandidateSearchPageSchema())
+    def get(self, **kwargs):
+        candidates = self.get_candidates(kwargs)
+        paginator = paging.SqlalchemyPaginator(candidates, kwargs['per_page'])
+        return paginator.get_page(kwargs['page'])
 
 
 @spec.doc(path_params=[

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -27,7 +27,7 @@ import sqlalchemy as sa
 from webservices import args
 from webservices import schemas
 from webservices.common.models import db
-from webservices.resources.candidates import CandidateList, CandidateView, CandidateHistoryView
+from webservices.resources.candidates import CandidateList, CandidateSearch, CandidateView, CandidateHistoryView
 from webservices.resources.totals import TotalsView
 from webservices.resources.reports import ReportsView
 from webservices.resources.committees import CommitteeList, CommitteeView
@@ -124,6 +124,7 @@ class Help(restful.Resource):
 
 api.add_resource(Help, '/')
 api.add_resource(CandidateList, '/candidates')
+api.add_resource(CandidateSearch, '/candidates/search')
 api.add_resource(
     CandidateView,
     '/candidate/<string:candidate_id>',

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -94,64 +94,6 @@ register_schema(NameSearchSchema)
 register_schema(NameSearchListSchema)
 
 
-class CandidateSchema(ma.Schema):
-    candidate_id = ma.fields.String()
-    cycles = ma.fields.List(ma.fields.Integer())
-    candidate_status_full = ma.fields.String()
-    candidate_status = ma.fields.String()
-    district = ma.fields.String()
-    incumbent_challenge_full = ma.fields.String()
-    incumbent_challenge = ma.fields.String()
-    office_full = ma.fields.String()
-    office = ma.fields.String()
-    party_full = ma.fields.String()
-    party = ma.fields.String()
-    state = ma.fields.String()
-    name = ma.fields.String()
-
-
-class CandidateListSchema(CandidateSchema):
-    active_through = ma.fields.Integer()
-    election_years = ma.fields.List(ma.fields.Integer())
-
-
-class CandidateDetailSchema(CandidateListSchema):
-    expire_date = ma.fields.DateTime()
-    load_date = ma.fields.DateTime()
-    form_type = ma.fields.String()
-    address_city = ma.fields.String()
-    address_state = ma.fields.String()
-    address_street_1 = ma.fields.String()
-    address_street_2 = ma.fields.String()
-    address_zip = ma.fields.String()
-    candidate_inactive = ma.fields.String()
-
-
-class CandidateHistorySchema(CandidateSchema):
-    two_year_period = ma.fields.Integer()
-    expire_date = ma.fields.String()
-    load_date = ma.fields.String()
-    form_type = ma.fields.String()
-    address_city = ma.fields.String()
-    address_state = ma.fields.String()
-    address_street_1 = ma.fields.String()
-    address_street_2 = ma.fields.String()
-    address_zip = ma.fields.String()
-    candidate_inactive = ma.fields.String()
-
-
-CandidateListPageSchema = make_page_schema(CandidateListSchema)
-CandidateDetailPageSchema = make_page_schema(CandidateDetailSchema)
-CandidateHistoryPageSchema = make_page_schema(CandidateHistorySchema)
-
-register_schema(CandidateListSchema)
-register_schema(CandidateDetailSchema)
-register_schema(CandidateHistorySchema)
-register_schema(CandidateListPageSchema)
-register_schema(CandidateDetailPageSchema)
-register_schema(CandidateHistoryPageSchema)
-
-
 class CommitteeSchema(ma.Schema):
     committee_id = ma.fields.String()
     name = ma.fields.String()
@@ -222,6 +164,72 @@ register_schema(CommitteeSchema)
 register_schema(CommitteeDetailSchema)
 register_schema(CommitteePageSchema)
 register_schema(CommitteeDetailPageSchema)
+
+
+class CandidateSchema(ma.Schema):
+    candidate_id = ma.fields.String()
+    cycles = ma.fields.List(ma.fields.Integer())
+    candidate_status_full = ma.fields.String()
+    candidate_status = ma.fields.String()
+    district = ma.fields.String()
+    incumbent_challenge_full = ma.fields.String()
+    incumbent_challenge = ma.fields.String()
+    office_full = ma.fields.String()
+    office = ma.fields.String()
+    party_full = ma.fields.String()
+    party = ma.fields.String()
+    state = ma.fields.String()
+    name = ma.fields.String()
+
+
+class CandidateListSchema(CandidateSchema):
+    active_through = ma.fields.Integer()
+    election_years = ma.fields.List(ma.fields.Integer())
+
+
+class CandidateSearchSchema(CandidateListSchema):
+    principal_committees = ma.fields.Nested(CommitteeSchema, many=True)
+
+
+class CandidateDetailSchema(CandidateListSchema):
+    expire_date = ma.fields.DateTime()
+    load_date = ma.fields.DateTime()
+    form_type = ma.fields.String()
+    address_city = ma.fields.String()
+    address_state = ma.fields.String()
+    address_street_1 = ma.fields.String()
+    address_street_2 = ma.fields.String()
+    address_zip = ma.fields.String()
+    candidate_inactive = ma.fields.String()
+
+
+class CandidateHistorySchema(CandidateSchema):
+    two_year_period = ma.fields.Integer()
+    expire_date = ma.fields.String()
+    load_date = ma.fields.String()
+    form_type = ma.fields.String()
+    address_city = ma.fields.String()
+    address_state = ma.fields.String()
+    address_street_1 = ma.fields.String()
+    address_street_2 = ma.fields.String()
+    address_zip = ma.fields.String()
+    candidate_inactive = ma.fields.String()
+
+
+CandidateListPageSchema = make_page_schema(CandidateListSchema)
+CandidateSearchPageSchema = make_page_schema(CandidateSearchSchema)
+CandidateDetailPageSchema = make_page_schema(CandidateDetailSchema)
+CandidateHistoryPageSchema = make_page_schema(CandidateHistorySchema)
+
+register_schema(CandidateListSchema)
+register_schema(CandidateSearchSchema)
+register_schema(CandidateDetailSchema)
+register_schema(CandidateHistorySchema)
+
+register_schema(CandidateListPageSchema)
+register_schema(CandidateSearchPageSchema)
+register_schema(CandidateDetailPageSchema)
+register_schema(CandidateHistoryPageSchema)
 
 
 class ReportsSchema(ma.Schema):


### PR DESCRIPTION
* Add `principal_committees` relationship to `Candidate`.
* Add `/candidates/search` endpoint; includes nested principal committees.
* Use `subqueryload` to avoid n+1 database queries.
* Update unit tests.

Pinging @arowla for review and @msecret to let me know if this will be adequate for candidate search. If you'd like the reverse nesting, I'll add that as well. By the way, we could also encode the output variables in the query parameter (e.g. `/candidates?nest=true`), but then it's hard to decide how to describe the output format (not sure how/whether Swagger handles optional output fields OTOH).