### PR TITLE
Fix name of committee fulltext view.

### DIFF
--- a/tests/committee_tests.py
+++ b/tests/committee_tests.py
@@ -2,6 +2,7 @@ import urllib
 import datetime
 import functools
 
+import sqlalchemy as sa
 from marshmallow.utils import isoformat
 
 from tests import factories
@@ -42,6 +43,18 @@ class CommitteeFormatTest(ApiBaseTest):
         self.assertEqual(result['committee_type'], committee.committee_type)
         self.assertEqual(result['treasurer_name'], committee.treasurer_name)
         self.assertEqual(result['party'], committee.party)
+
+    def test_fulltext_search(self):
+        committee = factories.CommitteeFactory(name='Americans for a Better Tomorrow, Tomorrow')
+        decoy_committee = factories.CommitteeFactory()
+        factories.CommitteeSearchFactory(
+            cmte_sk=committee.committee_key,
+            fulltxt=sa.func.to_tsvector(committee.name),
+        )
+        results = self._results(api.url_for(CommitteeList, q='tomorrow'))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['committee_id'], committee.committee_id)
+        self.assertNotEqual(results[0]['committee_id'], decoy_committee.committee_id)
 
     def test_filter_by_candidate_id(self):
         candidate_id = 'id0'
@@ -156,13 +169,13 @@ class CommitteeFormatTest(ApiBaseTest):
 
         # checking one example from each field
         filter_fields = (
-            # ('committee_id', ['bartlet', 'ritchie']),
-            # ('state', ['CA', 'DC']),
+            ('committee_id', ['bartlet', 'ritchie']),
+            ('state', ['CA', 'DC']),
             ('name', 'Obama'),
-            # ('committee_type', 'S'),
-            # ('designation', 'P'),
-            # ('party', ['REP', 'DEM']),
-            # ('organization_type', 'C'),
+            ('committee_type', 'S'),
+            ('designation', 'P'),
+            ('party', ['REP', 'DEM']),
+            ('organization_type', 'C'),
         )
 
         org_response = self._response(api.url_for(CommitteeList))

--- a/tests/committee_tests.py
+++ b/tests/committee_tests.py
@@ -164,12 +164,12 @@ class CommitteeFormatTest(ApiBaseTest):
             factories.CommitteeFactory(designation='P'),
             factories.CommitteeFactory(party='DEM'),
             factories.CommitteeFactory(organization_type='C'),
-            factories.CommitteeFactory(committee_id='bartlet'),
+            factories.CommitteeFactory(committee_id='C01'),
         ]
 
         # checking one example from each field
         filter_fields = (
-            ('committee_id', ['bartlet', 'ritchie']),
+            ('committee_id', ['C01', 'C02']),
             ('state', ['CA', 'DC']),
             ('name', 'Obama'),
             ('committee_type', 'S'),

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -24,6 +24,12 @@ class CandidateSearchFactory(BaseFactory):
     cand_sk = factory.Sequence(lambda n: n)
 
 
+class CommitteeSearchFactory(BaseFactory):
+    class Meta:
+        model = models.CommitteeSearch
+    cmte_sk = factory.Sequence(lambda n: n)
+
+
 class PairedOptions(SQLAlchemyOptions):
     def _build_default_options(self):
         return super()._build_default_options() + [

--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -27,6 +27,13 @@ class CandidateSearch(BaseModel):
     fulltxt = db.Column(TSVECTOR)
 
 
+class CommitteeSearch(BaseModel):
+    __tablename__ = 'dimcmte_fulltext_mv'
+
+    cmte_sk = db.Column(db.Integer)
+    fulltxt = db.Column(TSVECTOR)
+
+
 class BaseCandidate(BaseModel):
     __abstract__ = True
 

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -22,12 +22,12 @@ filter_fields = {
 
 class CandidateList(Resource):
 
-    fulltext_query = """
+    fulltext_query = '''
         SELECT cand_sk
         FROM   dimcand_fulltext_mv
         WHERE  fulltxt @@ to_tsquery(:findme)
         ORDER BY ts_rank_cd(fulltxt, to_tsquery(:findme)) desc
-    """
+   '''
 
     @args.register_kwargs(args.paging)
     @args.register_kwargs(args.candidate_list)

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -33,7 +33,7 @@ class CommitteeList(Resource):
 
     fulltext_query = '''
         SELECT cmte_sk
-        FROM   dimcmte_fulltext
+        FROM   dimcmte_fulltext_mv
         WHERE  fulltxt @@ to_tsquery(:findme)
         ORDER BY ts_rank_cd(fulltxt, to_tsquery(:findme)) desc
     '''


### PR DESCRIPTION
* Fix typo in view name
* Add regression test

This patch fixes a three-character typo ("dimcmte_fulltext" becomes "dimcmte_fulltext_mv") and adds a regression test to make sure we're covering fulltext search on committees.