### PR TITLE
Restore correct `election_years` and `active_through` columns.

### DIFF
--- a/data/sql_updates/create_candidate_detail_view.sql
+++ b/data/sql_updates/create_candidate_detail_view.sql
@@ -69,8 +69,11 @@ from dimcand
         order by cand_sk, cand_id, election_yr desc
     ) full_ici using (cand_sk)
     left join dimcandoffice co using (cand_sk)
-    left join dimoffice using (office_sk)
-    inner join dimparty using (party_sk)
+    left join (
+        select distinct on (cand_sk) * from dimcandoffice order by cand_sk, candoffice_sk desc
+    ) last_co using (cand_sk)
+    inner join dimoffice on last_co.office_sk = dimoffice.office_sk
+    inner join dimparty on last_co.party_sk = dimparty.party_sk
     left join dimcandproperties dcp using (cand_sk)
     where dcp.election_yr >= :START_YEAR
 group by

--- a/data/sql_updates/create_candidates_view.sql
+++ b/data/sql_updates/create_candidates_view.sql
@@ -46,11 +46,12 @@ from dimcand
         where cand_ici_desc is not null
         order by cand_sk, cand_id, election_yr desc
     ) full_ici using (cand_sk)
+    left join dimcandoffice co using (cand_sk)
     left join (
         select distinct on (cand_sk) * from dimcandoffice order by cand_sk, candoffice_sk desc
-    ) co using (cand_sk)
-    inner join dimoffice using (office_sk)
-    inner join dimparty using (party_sk)
+    ) last_co using (cand_sk)
+    inner join dimoffice on last_co.office_sk = dimoffice.office_sk
+    inner join dimparty on last_co.party_sk = dimparty.party_sk
     left join (
         select distinct on (cand_sk) cand_sk, cand_nm from dimcandproperties
             order by cand_sk, candproperties_sk desc


### PR DESCRIPTION
When we fixed candidate party descriptions by altering the join between
`dimcand` and `dimcandoffice`, we also introduced a regression, such
that each candidate had at most one year in `election_years`. To select
both the correct row in `dimcandoffice` to determine party affiliation
and the correct rows to determine election years, we need two joins.
This patch adds a second join, and harmonizes the candidate views to use
the same logic.