### PR TITLE
Changed staging branch from 'master' to 'release'

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -136,7 +136,7 @@ def _detect_space(branch=None, yes=False):
 
 DEPLOY_RULES = (
     ('prod', _detect_prod),
-    ('stage', lambda _, branch: branch == 'master'),
+    ('stage', lambda _, branch: branch == 'release'),
     ('dev', lambda _, branch: branch == 'develop'),
 )
 


### PR DESCRIPTION
Realized that git flow uses a branch called 'release' to prepare releases before it gets merged into master AND tagged... so we should probably host the release branch on staging.