### PR TITLE
Fix principal committee join.

### DIFF
--- a/tests/candidate_tests.py
+++ b/tests/candidate_tests.py
@@ -109,6 +109,7 @@ class CandidateFormatTest(ApiBaseTest):
         results = self._results(api.url_for(CandidateSearch))
         self.assertEqual(len(results), 1)
         self.assertIn('principal_committees', results[0])
+        self.assertEqual(len(results[0]['principal_committees']), 1)
         self.assertEqual(
             results[0]['principal_committees'][0]['committee_id'],
             principal_committee.committee_id,

--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -62,10 +62,10 @@ class Candidate(BaseCandidate):
     principal_committees = db.relationship(
         'Committee',
         secondary='ofec_name_linkage_mv',
-        secondaryjoin=' and '.join([
-            'Committee.committee_key == ofec_name_linkage_mv.c.committee_key',
-            'Committee.designation == "P"',
-        ]),
+        secondaryjoin='''and_(
+            Committee.committee_key == ofec_name_linkage_mv.c.committee_key,
+            Committee.designation == 'P',
+        )''',
         order_by='desc(Committee.last_file_date)',
     )
 


### PR DESCRIPTION
Fix a syntax error on secondary join between Candidate and Committee
tables. Also fix insufficiently strict unit test.

Resolves an issue reported by @noahmanger in https://github.com/18F/openFEC-web-app/pull/165#issuecomment-103174202. Good catch!