### PR TITLE
Feature/exclude form z only filers

### DIFF
--- a/data/sql_updates/create_candidate_detail_view.sql
+++ b/data/sql_updates/create_candidate_detail_view.sql
@@ -49,6 +49,12 @@ select
     max(dimoffice.expire_date) as office_expire_date,
     max(dimparty.expire_date) as party_expire_date
 from dimcand
+    -- Restrict to candidates with at least one non-F2Z filing
+    inner join (
+        select distinct cand_sk
+        from dimcandproperties
+        where form_tp != 'F2Z'
+    ) f2 using (cand_sk)
     left join (
         select distinct on (cand_sk, cand_id)
             s.cand_sk, c.cand_id, s.election_yr, s.cand_status, s.cand_inactive_flg, s.expire_date

--- a/data/sql_updates/create_candidate_history_view.sql
+++ b/data/sql_updates/create_candidate_history_view.sql
@@ -47,6 +47,12 @@ from ofec_two_year_periods
             inner join dimparty using (party_sk)
         order by cand_sk, two_year_period, dcp.candproperties_sk desc
     ) as dcp_by_period on ofec_two_year_periods.year = two_year_period
+    -- Restrict to candidates with at least one non-F2Z filing
+    inner join (
+        select distinct cand_sk
+        from dimcandproperties
+        where form_tp != 'F2Z'
+    ) f2 using (cand_sk)
     where two_year_period >= :START_YEAR
 ;
 

--- a/data/sql_updates/create_candidates_view.sql
+++ b/data/sql_updates/create_candidates_view.sql
@@ -33,6 +33,12 @@ select
     max(dimoffice.office_state) as state,
     max(candprops.cand_nm) as name
 from dimcand
+    -- Restrict to candidates with at least one non-F2Z filing
+    inner join (
+        select distinct cand_sk
+        from dimcandproperties
+        where form_tp != 'F2Z'
+    ) f2 using (cand_sk)
     left join (
         select distinct on (cand_sk) cand_sk, election_yr, cand_status, ici_code
             from dimcandstatusici

--- a/data/sql_updates/create_fulltext_table.sql
+++ b/data/sql_updates/create_fulltext_table.sql
@@ -15,7 +15,7 @@ create materialized view dimcand_fulltext_mv_tmp as
     left outer join dimcandproperties p on c.cand_sk = p.cand_sk
     inner join (
         select distinct cand_sk from dimcandproperties
-        where form_tp = 'F2'
+        where form_tp != 'F2Z'
     ) f2 on c.cand_sk = f2.cand_sk
     where p.election_yr >= :START_YEAR
     order by c.cand_sk, p.election_yr desc
@@ -63,7 +63,7 @@ with
             join dimoffice o on (co.office_sk = o.office_sk)
             inner join (
                 select distinct cand_sk from dimcandproperties
-                where form_tp = 'F2'
+                where form_tp != 'F2Z'
             ) f2 on c.cand_sk = f2.cand_sk
         where p.election_yr >= :START_YEAR
         order by c.cand_sk, p.election_yr desc

--- a/data/sql_updates/create_fulltext_table.sql
+++ b/data/sql_updates/create_fulltext_table.sql
@@ -13,6 +13,10 @@ create materialized view dimcand_fulltext_mv_tmp as
         as fulltxt
     from dimcand c
     left outer join dimcandproperties p on c.cand_sk = p.cand_sk
+    inner join (
+        select distinct cand_sk from dimcandproperties
+        where form_tp = 'F2'
+    ) f2 on c.cand_sk = f2.cand_sk
     where p.election_yr >= :START_YEAR
     order by c.cand_sk, p.election_yr desc
 ;
@@ -57,6 +61,10 @@ with
             join dimcandproperties p on (p.cand_sk = c.cand_sk)
             join dimcandoffice co on (co.cand_sk = c.cand_sk)
             join dimoffice o on (co.office_sk = o.office_sk)
+            inner join (
+                select distinct cand_sk from dimcandproperties
+                where form_tp = 'F2'
+            ) f2 on c.cand_sk = f2.cand_sk
         where p.election_yr >= :START_YEAR
         order by c.cand_sk, p.election_yr desc
     ), ranked_cmte as (

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -79,7 +79,7 @@ class TestViews(common.IntegrationTestCase):
 
     def test_exclude_z_only_filers(self):
         dcp = sa.Table('dimcandproperties', db.metadata, autoload=True, autoload_with=db.engine)
-        s = sa.select([dcp.c.cand_sk]).where(dcp.c.form_tp == 'F2').distinct()
+        s = sa.select([dcp.c.cand_sk]).where(dcp.c.form_tp != 'F2Z').distinct()
         expected = [int(each.cand_sk) for each in db.engine.execute(s).fetchall()]
         for model in CANDIDATE_MODELS:
             observed = [each.candidate_key for each in model.query.all()]


### PR DESCRIPTION
Based on discussion with FEC, candidates who have *only* filed form F2Z should be excluded from views. This patch excludes these candidates from all candidate and full-text search views and updates integration tests accordingly. See #793 for details.