### PR TITLE
Remove duplicated reports.

### DIFF
--- a/data/sql_updates/create_reports_house_senate_view.sql
+++ b/data/sql_updates/create_reports_house_senate_view.sql
@@ -6,7 +6,6 @@ select
     facthousesenate_f3_sk as report_key,
     cmte_id as committee_id,
     two_yr_period_sk as cycle,
-    cmte_tp as committee_type,
     start_date.dw_date as coverage_start_date,
     end_date.dw_date as coverage_end_date,
     agr_amt_pers_contrib_gen as aggregate_amount_personal_contributions_general,
@@ -94,7 +93,6 @@ select
     f3.load_date as load_date
 from
     dimcmte c
-    inner join dimcmtetpdsgn ctd using (cmte_sk)
     inner join facthousesenate_f3 f3 using (cmte_sk)
     inner join dimreporttype rt using (reporttype_sk)
     left join dimdates start_date on cvg_start_dt_sk = start_date.date_sk and cvg_start_dt_sk != 1

--- a/data/sql_updates/create_reports_pacs_parties_view.sql
+++ b/data/sql_updates/create_reports_pacs_parties_view.sql
@@ -6,7 +6,6 @@ select
     factpacsandparties_f3x_sk as report_key,
     cmte_id as committee_id,
     two_yr_period_sk as cycle,
-    cmte_tp as committee_type,
     start_date.dw_date as coverage_start_date,
     end_date.dw_date as coverage_end_date,
     all_loans_received_per as all_loans_received_period,
@@ -118,7 +117,6 @@ select
     f3x.load_date as load_date
 from
     dimcmte c
-    inner join dimcmtetpdsgn ctd using (cmte_sk)
     inner join factpacsandparties_f3x f3x using (cmte_sk)
     inner join dimreporttype rt using (reporttype_sk)
     left join dimdates start_date on cvg_start_dt_sk = start_date.date_sk and cvg_start_dt_sk != 1

--- a/data/sql_updates/create_reports_presidential_view.sql
+++ b/data/sql_updates/create_reports_presidential_view.sql
@@ -6,7 +6,6 @@ select
     factpresidential_f3p_sk as report_key,
     cmte_id as committee_id,
     two_yr_period_sk as cycle,
-    cmte_tp as committee_type,
     start_date.dw_date as coverage_start_date,
     end_date.dw_date as coverage_end_date,
     begin_image_num as beginning_image_number,
@@ -95,7 +94,6 @@ select
     f3p.load_date as load_date
 from
     dimcmte c
-    inner join dimcmtetpdsgn ctd using (cmte_sk)
     inner join factpresidential_f3p f3p using (cmte_sk)
     inner join dimreporttype rt using (reporttype_sk)
     left join dimdates start_date on cvg_start_dt_sk = start_date.date_sk and cvg_start_dt_sk != 1


### PR DESCRIPTION
Previously, we were joining `dimcmte` on `dimcmtetpdsgn` to generate
views for committee reports. Because committees may have multiple
designations, this was in some cases creating duplicate reports. Since
we only used the join on `dimcmtetpdsgn` to fetch the committee type,
and since this value was neither imported into SQLAlchemy nor serialized
to the API, the simplest way to handle the duplication was to remove the
join.