### PR TITLE
Calculate committee cycles from fact tables.

### DIFF
--- a/data/sql_updates/create_committee_detail_view.sql
+++ b/data/sql_updates/create_committee_detail_view.sql
@@ -88,7 +88,13 @@ from dimcmte
         select
             cmte_sk,
             array_agg(distinct(rpt_yr + rpt_yr % 2))::int[] as cycles
-        from dimcmteproperties
+        from (
+            select cmte_sk, rpt_yr from factpacsandparties_f3x
+            union
+            select cmte_sk, rpt_yr from factpresidential_f3p
+            union
+            select cmte_sk, rpt_yr from facthousesenate_f3
+        ) years
         where rpt_yr >= :START_YEAR
         group by cmte_sk
     ) cp_agg using (cmte_sk)

--- a/data/sql_updates/create_committee_history.sql
+++ b/data/sql_updates/create_committee_history.sql
@@ -1,8 +1,28 @@
 drop materialized view if exists ofec_committee_history_mv_tmp;
 create materialized view ofec_committee_history_mv_tmp as
-select distinct on (cmte_sk, cycle)
+with
+    cycles as (
+        select distinct
+            cmte_sk,
+            rpt_yr + rpt_yr % 2 as cycle
+        from (
+            select cmte_sk, rpt_yr from factpacsandparties_f3x
+            union
+            select cmte_sk, rpt_yr from factpresidential_f3p
+            union
+            select cmte_sk, rpt_yr from facthousesenate_f3
+        ) years
+    ),
+    cycle_agg as (
+        select
+            cmte_sk,
+            array_agg(cycles.cycle)::int[] as cycles
+        from cycles
+        group by cmte_sk
+    )
+select distinct on (dcp.cmte_sk, cycle)
     row_number() over () as idx,
-    dcp.rpt_yr + dcp.rpt_yr % 2 as cycle,
+    cycles.cycle,
     dcp.cmte_sk as committee_key,
     dcp.cmte_id as committee_id,
     dcp.cmte_nm as name,
@@ -17,20 +37,14 @@ select distinct on (cmte_sk, cycle)
     dd.cmte_tp as committee_type,
     expand_committee_type(dd.cmte_tp) as committee_type_full,
     clean_party(p.party_affiliation_desc) as party_full,
-    agg.cycles as cycles
+    cycle_agg.cycles
 from dimcmteproperties dcp
 inner join dimcmtetpdsgn dd using (cmte_sk)
 left join dimparty p on dcp.cand_pty_affiliation = p.party_affiliation
-left join (
-    select
-        cmte_sk,
-        array_agg(distinct(rpt_yr + rpt_yr % 2)) as cycles
-    from dimcmteproperties
-    group by cmte_sk
-) agg using (cmte_sk)
-where dd.receipt_date <= dcp.receipt_dt
-and dcp.rpt_yr >= :START_YEAR
-order by cmte_sk, cycle desc, dd.receipt_date desc
+left join cycles on dcp.cmte_sk = cycles.cmte_sk and dcp.rpt_yr <= cycles.cycle
+left join cycle_agg on dcp.cmte_sk = cycle_agg.cmte_sk
+where dcp.rpt_yr >= :START_YEAR
+order by dcp.cmte_sk, cycle desc, dcp.rpt_yr desc, dd.receipt_date desc
 ;
 
 create unique index on ofec_committee_history_mv_tmp(idx);

--- a/data/sql_updates/create_committees_view.sql
+++ b/data/sql_updates/create_committees_view.sql
@@ -41,7 +41,13 @@ from dimcmte
         select
             cmte_sk,
             array_agg(distinct(rpt_yr + rpt_yr % 2))::int[] as cycles
-        from dimcmteproperties
+        from (
+            select cmte_sk, rpt_yr from factpacsandparties_f3x
+            union
+            select cmte_sk, rpt_yr from factpresidential_f3p
+            union
+            select cmte_sk, rpt_yr from facthousesenate_f3
+        ) years
         where rpt_yr >= :START_YEAR
         group by cmte_sk
     ) cp_agg using (cmte_sk)


### PR DESCRIPTION
We currently calculate committee cycles from committee statements of
organization (F1 filings), but committees may file financial reports
(e.g. F3s) in cycles during which they have not filed F1s. This patch
uses F3s instead of F1s to calculate active cycles per committee. Among
other issues, this resolves the missing data for the 2015-2016 cycle
reported by FEC.