### PR TITLE
Fix sorting on candidate search view.

### DIFF
--- a/tests/candidate_tests.py
+++ b/tests/candidate_tests.py
@@ -221,7 +221,12 @@ class CandidateFormatTest(ApiBaseTest):
         candidate_ids = [each.candidate_id for each in candidates]
         results = self._results(api.url_for(CandidateList, sort='candidate_status'))
         self.assertEqual([each['candidate_id'] for each in results], candidate_ids[::-1])
+        results = self._results(api.url_for(CandidateSearch, sort='candidate_status'))
+        self.assertEqual([each['candidate_id'] for each in results], candidate_ids[::-1])
         results = self._results(api.url_for(CandidateList, sort='-candidate_status'))
+        self.assertEqual([each['candidate_id'] for each in results], candidate_ids)
+        results = self._results(api.url_for(CandidateSearch, sort='-candidate_status'))
+        self.assertEqual([each['candidate_id'] for each in results], candidate_ids)
 
     def test_candidate_multi_sort(self):
         candidates = [

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -1,0 +1,14 @@
+class ApiError(Exception):
+    status_code = 400
+
+    def __init__(self, message, status_code=None, payload=None):
+        super(ApiError, self).__init__()
+        self.message = message
+        self.status_code = status_code or self.status_code
+        self.payload = payload
+
+    def to_dict(self):
+        ret = self.payload or {}
+        ret['message'] = self.message
+        return ret
+

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -42,7 +42,7 @@ class CandidateList(Resource):
     @args.register_kwargs(args.candidate_list)
     @args.register_kwargs(args.candidate_detail)
     @args.register_kwargs(args.make_sort_args(default=['name']))
-    @schemas.marshal_with(schemas.CandidateListPageSchema())
+    @schemas.marshal_with(schemas.CandidatePageSchema())
     def get(self, **kwargs):
         query = self.get_candidates(kwargs)
         return utils.fetch_page(query, kwargs, model=Candidate)

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -81,7 +81,7 @@ class CandidateSearch(CandidateList):
     def query(self):
         # Eagerly load principal committees to avoid extra queries
         return Candidate.query.options(
-            sa.orm.joinedload(Candidate.principal_committees)
+            sa.orm.subqueryload(Candidate.principal_committees)
         )
 
     @args.register_kwargs(args.paging)

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -41,11 +41,11 @@ class CandidateList(Resource):
     @args.register_kwargs(args.paging)
     @args.register_kwargs(args.candidate_list)
     @args.register_kwargs(args.candidate_detail)
-    @args.register_kwargs(args.make_sort_args())
+    @args.register_kwargs(args.make_sort_args(default=['name']))
     @schemas.marshal_with(schemas.CandidateListPageSchema())
     def get(self, **kwargs):
         query = self.get_candidates(kwargs)
-        return utils.fetch_page(query, kwargs)
+        return utils.fetch_page(query, kwargs, model=Candidate)
 
     def get_candidates(self, kwargs):
 
@@ -68,7 +68,7 @@ class CandidateList(Resource):
         if kwargs['cycle']:
             candidates = candidates.filter(Candidate.cycles.overlap(kwargs['cycle']))
 
-        return candidates.order_by(Candidate.name)
+        return candidates
 
 
 @spec.doc(
@@ -81,7 +81,7 @@ class CandidateSearch(CandidateList):
     def query(self):
         # Eagerly load principal committees to avoid extra queries
         return Candidate.query.options(
-            sa.orm.subqueryload(Candidate.principal_committees)
+            sa.orm.joinedload(Candidate.principal_committees)
         )
 
     @args.register_kwargs(args.paging)
@@ -91,7 +91,7 @@ class CandidateSearch(CandidateList):
     @schemas.marshal_with(schemas.CandidateSearchPageSchema())
     def get(self, **kwargs):
         query = self.get_candidates(kwargs)
-        return utils.fetch_page(query, kwargs)
+        return utils.fetch_page(query, kwargs, model=Candidate)
 
 
 @spec.doc(
@@ -106,11 +106,11 @@ class CandidateView(Resource):
 
     @args.register_kwargs(args.paging)
     @args.register_kwargs(args.candidate_detail)
-    @args.register_kwargs(args.make_sort_args())
+    @args.register_kwargs(args.make_sort_args(default=['-expire_date']))
     @schemas.marshal_with(schemas.CandidateDetailPageSchema())
     def get(self, candidate_id=None, committee_id=None, **kwargs):
         query = self.get_candidate(kwargs, candidate_id, committee_id)
-        return utils.fetch_page(query, kwargs)
+        return utils.fetch_page(query, kwargs, model=CandidateDetail)
 
     def get_candidate(self, kwargs, candidate_id=None, committee_id=None):
         if candidate_id is not None:
@@ -130,7 +130,7 @@ class CandidateView(Resource):
         if kwargs['cycle']:
             candidates = candidates.filter(CandidateDetail.cycles.overlap(kwargs['cycle']))
 
-        return candidates.order_by(CandidateDetail.expire_date.desc())
+        return candidates
 
 
 class CandidateHistoryView(Resource):

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -28,6 +28,7 @@ from webservices import args
 from webservices import docs
 from webservices import spec
 from webservices import schemas
+from webservices import exceptions
 from webservices.common.models import db
 from webservices.resources.candidates import CandidateList, CandidateSearch, CandidateView, CandidateHistoryView
 from webservices.resources.totals import TotalsView
@@ -61,6 +62,14 @@ v1 = Blueprint('v1', __name__, url_prefix='/v1')
 api = restful.Api(v1)
 
 app.register_blueprint(v1)
+
+
+@app.errorhandler(exceptions.ApiError)
+def handle_error(error):
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    return response
+
 
 # api.data.gov
 trusted_proxies = ('54.208.160.112', '54.208.160.151')

--- a/webservices/sorting.py
+++ b/webservices/sorting.py
@@ -1,15 +1,29 @@
 import sqlalchemy as sa
 
+from webservices.exceptions import ApiError
 
-def parse_option(option):
+
+def parse_option(option, model=None):
+    """Parse sort option to SQLAlchemy order expression.
+
+    :param str option: Column name, possibly prefixed with "-"
+    :param model: Optional SQLAlchemy model to sort on
+    :raises: ApiError if column not found on model
+    """
     order = sa.desc if option.startswith('-') else sa.asc
     column = option.lstrip('-')
-    return order, column
+    if model:
+        try:
+            column = getattr(model, column)
+        except AttributeError:
+            raise ApiError('Field "{0}" not found'.format(column))
+    return order(column)
 
-def sort(query, options, clear=False):
+
+def sort(query, options, model=None, clear=False):
     if clear:
         query = query.order_by(False)
     for option in options:
-        order, column = parse_option(option)
-        query = query.order_by(order(column))
+        order = parse_option(option, model=model)
+        query = query.order_by(order)
     return query

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -2,7 +2,7 @@ from webservices import paging
 from webservices import sorting
 
 
-def fetch_page(query, kwargs, clear=False):
-    query = sorting.sort(query, kwargs['sort'], clear=clear)
+def fetch_page(query, kwargs, model=None, clear=False):
+    query = sorting.sort(query, kwargs['sort'], model=model, clear=clear)
     paginator = paging.SqlalchemyPaginator(query, kwargs['per_page'])
     return paginator.get_page(kwargs['page'])


### PR DESCRIPTION
When using `subqueryload` for eager loading with the `CandidateSearch`
resource, we have to specify which model we're sorting on, e.g.
`Candidate.candidate_id` instead of "candidate_id". This patch adds an
optional `model` argument to the `fetch_page` helper, which retrieves
the column property from the model if provided. We also now throw a 400
if a user tries to sort on a column that doesn't belong to the relevant
model.

h/t @msecret