### PR TITLE
Feature/consistent queries

### DIFF
--- a/data/sql_updates/create_committee_history.sql
+++ b/data/sql_updates/create_committee_history.sql
@@ -12,6 +12,7 @@ with
             union
             select cmte_sk, rpt_yr from facthousesenate_f3
         ) years
+        where rpt_yr >= :START_YEAR
     ),
     cycle_agg as (
         select
@@ -43,7 +44,7 @@ inner join dimcmtetpdsgn dd using (cmte_sk)
 left join dimparty p on dcp.cand_pty_affiliation = p.party_affiliation
 left join cycles on dcp.cmte_sk = cycles.cmte_sk and dcp.rpt_yr <= cycles.cycle
 left join cycle_agg on dcp.cmte_sk = cycle_agg.cmte_sk
-where dcp.rpt_yr >= :START_YEAR
+where array_length(cycle_agg.cycles, 1) > 0
 order by dcp.cmte_sk, cycle desc, dcp.rpt_yr desc, dd.receipt_date desc
 ;
 

--- a/data/sql_updates/create_fulltext_table.sql
+++ b/data/sql_updates/create_fulltext_table.sql
@@ -1,6 +1,6 @@
 drop table if exists dimcand_fulltext;
-drop materialized view if exists dimcand_fulltext_mv_tmp;
-create materialized view dimcand_fulltext_mv_tmp as
+drop materialized view if exists ofec_candidate_fulltext_mv_tmp;
+create materialized view ofec_candidate_fulltext_mv_tmp as
     select distinct on (c.cand_sk)
         row_number() over () as idx,
         c.cand_sk,
@@ -26,12 +26,12 @@ create materialized view dimcand_fulltext_mv_tmp as
     order by c.cand_sk, p.election_yr desc
 ;
 
-create unique index on dimcand_fulltext_mv_tmp(idx);
-create index on dimcand_fulltext_mv_tmp using gin(fulltxt);
+create unique index on ofec_candidate_fulltext_mv_tmp(idx);
+create index on ofec_candidate_fulltext_mv_tmp using gin(fulltxt);
 
 drop table if exists dimcmte_fulltext;
-drop materialized view if exists dimcmte_fulltext_mv_tmp;
-create materialized view dimcmte_fulltext_mv_tmp as
+drop materialized view if exists ofec_committee_fulltext_mv_tmp;
+create materialized view ofec_committee_fulltext_mv_tmp as
     select distinct on (c.cmte_sk)
         row_number() over () as idx,
         c.cmte_sk,
@@ -62,12 +62,12 @@ create materialized view dimcmte_fulltext_mv_tmp as
     order by c.cmte_sk, p.receipt_dt desc
 ;
 
-create unique index on dimcmte_fulltext_mv_tmp(idx);
-create index on dimcmte_fulltext_mv_tmp using gin(fulltxt);
+create unique index on ofec_committee_fulltext_mv_tmp(idx);
+create index on ofec_committee_fulltext_mv_tmp using gin(fulltxt);
 
 drop table if exists name_search_fulltext;
-drop materialized view if exists name_search_fulltext_mv_tmp;
-create materialized view name_search_fulltext_mv_tmp as
+drop materialized view if exists ofec_candidate_committee_fulltext_mv_tmp;
+create materialized view ofec_candidate_committee_fulltext_mv_tmp as
 with
     ranked_cand as (
         select distinct on (c.cand_sk)
@@ -130,5 +130,5 @@ with
     from ranked_cmte
 ;
 
-create unique index on name_search_fulltext_mv_tmp(idx);
-create index on name_search_fulltext_mv_tmp using gin(name_vec);
+create unique index on ofec_candidate_committee_fulltext_mv_tmp(idx);
+create index on ofec_candidate_committee_fulltext_mv_tmp using gin(name_vec);

--- a/data/sql_updates/create_fulltext_table.sql
+++ b/data/sql_updates/create_fulltext_table.sql
@@ -17,6 +17,11 @@ create materialized view dimcand_fulltext_mv_tmp as
         select distinct cand_sk from dimcandproperties
         where form_tp != 'F2Z'
     ) f2 on c.cand_sk = f2.cand_sk
+    -- Use same joins as main candidate views to ensure same candidates
+    -- present in all views
+    left join dimcandoffice co on c.cand_sk = co.cand_sk
+    inner join dimoffice using (office_sk)
+    inner join dimparty using (party_sk)
     where p.election_yr >= :START_YEAR
     order by c.cand_sk, p.election_yr desc
 ;
@@ -38,8 +43,22 @@ create materialized view dimcmte_fulltext_mv_tmp as
             end
         as fulltxt
     from dimcmte c
-    left outer join dimcmteproperties p using (cmte_sk)
-    where p.rpt_yr >= :START_YEAR
+    left join dimcmteproperties p using (cmte_sk)
+    left join (
+        select
+            cmte_sk,
+            array_agg(distinct(rpt_yr + rpt_yr % 2))::int[] as cycles
+        from (
+            select cmte_sk, rpt_yr from factpacsandparties_f3x
+            union
+            select cmte_sk, rpt_yr from factpresidential_f3p
+            union
+            select cmte_sk, rpt_yr from facthousesenate_f3
+        ) years
+        where rpt_yr >= :START_YEAR
+        group by cmte_sk
+    ) cp_agg using (cmte_sk)
+    where array_length(cp_agg.cycles, 1) > 0
     order by c.cmte_sk, p.receipt_dt desc
 ;
 
@@ -58,13 +77,14 @@ with
             null::text as cmte_id,
             o.office_tp as office_sought
         from dimcand c
-            join dimcandproperties p on (p.cand_sk = c.cand_sk)
-            join dimcandoffice co on (co.cand_sk = c.cand_sk)
-            join dimoffice o on (co.office_sk = o.office_sk)
-            inner join (
-                select distinct cand_sk from dimcandproperties
-                where form_tp != 'F2Z'
-            ) f2 on c.cand_sk = f2.cand_sk
+        join dimcandproperties p on (p.cand_sk = c.cand_sk)
+        join dimcandoffice co on (co.cand_sk = c.cand_sk)
+        join dimoffice o on (co.office_sk = o.office_sk)
+        join dimparty using (party_sk)
+        inner join (
+            select distinct cand_sk from dimcandproperties
+            where form_tp != 'F2Z'
+        ) f2 on c.cand_sk = f2.cand_sk
         where p.election_yr >= :START_YEAR
         order by c.cand_sk, p.election_yr desc
     ), ranked_cmte as (
@@ -73,8 +93,22 @@ with
             to_tsvector(p.cmte_nm) as name_vec,
             c.cmte_id
         from dimcmte c
-            join dimcmteproperties p using (cmte_sk)
-        where p.rpt_yr >= :START_YEAR
+        left join dimcmteproperties p using (cmte_sk)
+        left join (
+            select
+                cmte_sk,
+                array_agg(distinct(rpt_yr + rpt_yr % 2))::int[] as cycles
+            from (
+                select cmte_sk, rpt_yr from factpacsandparties_f3x
+                union
+                select cmte_sk, rpt_yr from factpresidential_f3p
+                union
+                select cmte_sk, rpt_yr from facthousesenate_f3
+            ) years
+            where rpt_yr >= :START_YEAR
+            group by cmte_sk
+        ) cp_agg using (cmte_sk)
+        where array_length(cp_agg.cycles, 1) > 0
         order by c.cmte_sk, p.receipt_dt desc
     )
     select

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -77,6 +77,26 @@ class TestViews(common.IntegrationTestCase):
         ).count()
         self.assertEqual(count, 0)
 
+    def test_committee_counts(self):
+        counts = [
+            models.Committee.query.count(),
+            models.CommitteeDetail.query.count(),
+            models.CommitteeHistory.query.distinct(models.CommitteeHistory.committee_id).count(),
+            models.CommitteeSearch.query.count(),
+            models.NameSearch.query.filter(models.NameSearch.cmte_id != None).count(),
+        ]
+        assert len(set(counts)) == 1
+
+    def test_candidate_counts(self):
+        counts = [
+            models.Candidate.query.count(),
+            models.CandidateDetail.query.count(),
+            models.CandidateHistory.query.distinct(models.CandidateHistory.candidate_id).count(),
+            models.CandidateSearch.query.count(),
+            models.NameSearch.query.filter(models.NameSearch.cand_id != None).count(),
+        ]
+        assert len(set(counts)) == 1
+
     def test_exclude_z_only_filers(self):
         dcp = sa.Table('dimcandproperties', db.metadata, autoload=True, autoload_with=db.engine)
         s = sa.select([dcp.c.cand_sk]).where(dcp.c.form_tp != 'F2Z').distinct()

--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -11,7 +11,7 @@ class BaseModel(db.Model):
 
 
 class NameSearch(BaseModel):
-    __tablename__ = 'name_search_fulltext_mv'
+    __tablename__ = 'ofec_candidate_committee_fulltext_mv'
 
     cand_id = db.Column(db.Integer, nullable=True)
     cmte_id = db.Column(db.Integer, nullable=True)
@@ -21,14 +21,14 @@ class NameSearch(BaseModel):
 
 
 class CandidateSearch(BaseModel):
-    __tablename__ = 'dimcand_fulltext_mv'
+    __tablename__ = 'ofec_candidate_fulltext_mv'
 
     cand_sk = db.Column(db.Integer)
     fulltxt = db.Column(TSVECTOR)
 
 
 class CommitteeSearch(BaseModel):
-    __tablename__ = 'dimcmte_fulltext_mv'
+    __tablename__ = 'ofec_committee_fulltext_mv'
 
     cmte_sk = db.Column(db.Integer)
     fulltxt = db.Column(TSVECTOR)

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -29,7 +29,7 @@ class CandidateList(Resource):
 
     fulltext_query = '''
         SELECT cand_sk
-        FROM   dimcand_fulltext_mv
+        FROM   ofec_candidate_fulltext_mv
         WHERE  fulltxt @@ to_tsquery(:findme)
         ORDER BY ts_rank_cd(fulltxt, to_tsquery(:findme)) desc
    '''

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -38,7 +38,7 @@ class CommitteeList(Resource):
 
     fulltext_query = '''
         SELECT cmte_sk
-        FROM   dimcmte_fulltext_mv
+        FROM   ofec_committee_fulltext_mv
         WHERE  fulltxt @@ to_tsquery(:findme)
         ORDER BY ts_rank_cd(fulltxt, to_tsquery(:findme)) desc
     '''

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -104,7 +104,7 @@ class NameSearch(restful.Resource):
         cmte_id as committee_id,
         name,
         office_sought
-    from name_search_fulltext_mv
+    from ofec_candidate_committee_fulltext_mv
     where name_vec @@ to_tsquery(:findme || ':*')
     order by ts_rank_cd(name_vec, to_tsquery(:findme || ':*')) desc
     limit 20


### PR DESCRIPTION
Ensure consistent candidates and committees across queries.

Fixes bug where candidates and committees can be found in typeahead search but not in candidate and committee endpoints, leading to 500s on the webapp.