### PR TITLE
Feature/typeahead search by resource

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -52,8 +52,20 @@ def make_sort_args(default=None):
     }
 
 
+def one_of(value, options):
+    if value not in options:
+        raise webargs.ValidationError('Value "{0}" not in "{1}"'.format(value, options))
+
+
 names = {
     'q': Arg(str, required=True, description='Name (candidate or committee) to search for'),
+    'type': Arg(
+        str,
+        use=lambda v: v.lower(),
+        validate=functools.partial(one_of, options=['candidate', 'committee']),
+        description='Resource type to search for. May be "candidate" or "committee"; if '
+        'not specified, search both resources.',
+    ),
 }
 
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -102,8 +102,8 @@ class ApiSchema(ma.Schema):
 
 
 class NameSearchSchema(ma.Schema):
-    candidate_id = ma.fields.String()
-    committee_id = ma.fields.String()
+    candidate_id = ma.fields.String(attribute='cand_id')
+    committee_id = ma.fields.String(attribute='cmte_id')
     name = ma.fields.String()
     office_sought = ma.fields.String()
 


### PR DESCRIPTION
Allow restricting typeahead search by resource type.

Examples:
* /names?q=bartlet&type=candidate
* /names?q=ritchie&type=committee
* /names?q=santos

This patch also has the side effect of deleting a long triple-quoted SQL
block and replacing it with an ORM query, which is IMO easier to
understand and maintain.

Requested by @msecret