### PR TITLE
Feature/candidate committees by cycle

### DIFF
--- a/data/sql_updates/create_candidates_view.sql
+++ b/data/sql_updates/create_candidates_view.sql
@@ -3,8 +3,8 @@ drop materialized view if exists ofec_candidates_mv_tmp;
 create materialized view ofec_candidates_mv_tmp as
 select
     row_number() over () as idx,
-    dimcand.cand_sk as candidate_key,
-    dimcand.cand_id as candidate_id,
+    dcp.cand_sk as candidate_key,
+    dcp.cand_id as candidate_id,
     max(csi_recent.cand_status) as candidate_status,
     expand_candidate_status(max(csi_recent.cand_status)) as candidate_status_full,
     max(dimoffice.office_district) as district,
@@ -19,7 +19,7 @@ select
     clean_party(max(dimparty.party_affiliation_desc)) as party_full,
     max(dimoffice.office_state) as state,
     max(candprops.cand_nm) as name
-from dimcand
+from dimcandproperties dcp
     -- Restrict to candidates with at least one non-F2Z filing
     inner join (
         select distinct cand_sk
@@ -49,11 +49,10 @@ from dimcand
         select distinct on (cand_sk) cand_sk, cand_nm from dimcandproperties
             order by cand_sk, candproperties_sk desc
     ) candprops using (cand_sk)
-    left join dimcandproperties dcp using (cand_sk)
     where dcp.election_yr >= :START_YEAR
 group by
-    dimcand.cand_sk,
-    dimcand.cand_id
+    dcp.cand_sk,
+    dcp.cand_id
 -- Candidate must have > 0 records after START_YEAR
 having count(dcp) > 0
 ;

--- a/data/sql_updates/create_committee_detail_view.sql
+++ b/data/sql_updates/create_committee_detail_view.sql
@@ -1,10 +1,10 @@
 drop view if exists ofec_committee_detail_vw;
 drop materialized view if exists ofec_committee_detail_mv_tmp;
 create materialized view ofec_committee_detail_mv_tmp as
-select distinct
+select distinct on (dcp.cmte_sk)
     row_number() over () as idx,
-    dimcmte.cmte_sk as committee_key,
-    dimcmte.cmte_id as committee_id,
+    dcp.cmte_sk as committee_key,
+    dcp.cmte_id as committee_id,
     dd.cmte_dsgn as designation,
     expand_committee_designation(dd.cmte_dsgn) as designation_full,
     dd.cmte_tp as committee_type,
@@ -68,7 +68,7 @@ select distinct
     cp_original.receipt_dt as first_file_date,
     cp_agg.cycles as cycles
 
-from dimcmte
+from dimcmteproperties dcp
     left join (
         select distinct on (cmte_sk) * from dimcmtetpdsgn
             order by cmte_sk, receipt_date desc

--- a/data/sql_updates/create_committee_history.sql
+++ b/data/sql_updates/create_committee_history.sql
@@ -46,10 +46,10 @@ select distinct on (dcp.cmte_sk, cycle)
     clean_party(p.party_affiliation_desc) as party_full,
     cycle_agg.cycles
 from dimcmteproperties dcp
-inner join dimcmtetpdsgn dd using (cmte_sk)
-left join dimparty p on dcp.cand_pty_affiliation = p.party_affiliation
-left join cycles on dcp.cmte_sk = cycles.cmte_sk and dcp.rpt_yr <= cycles.cycle
 left join cycle_agg on dcp.cmte_sk = cycle_agg.cmte_sk
+left join cycles on dcp.cmte_sk = cycles.cmte_sk and dcp.rpt_yr <= cycles.cycle
+left join dimparty p on dcp.cand_pty_affiliation = p.party_affiliation
+left join dimcmtetpdsgn dd on dcp.cmte_sk = dd.cmte_sk and extract(year from dd.receipt_date) <= cycles.cycle
 where array_length(cycle_agg.cycles, 1) > 0
 order by dcp.cmte_sk, cycle desc, dcp.rpt_yr desc, dd.receipt_date desc
 ;

--- a/data/sql_updates/create_committees_view.sql
+++ b/data/sql_updates/create_committees_view.sql
@@ -1,10 +1,10 @@
 drop view if exists ofec_committees_vw;
 drop materialized view if exists ofec_committees_mv_tmp;
 create materialized view ofec_committees_mv_tmp as
-select distinct
+select distinct on (dcp.cmte_sk)
     row_number() over () as idx,
-    dimcmte.cmte_sk as committee_key,
-    dimcmte.cmte_id as committee_id,
+    dcp.cmte_sk as committee_key,
+    dcp.cmte_id as committee_id,
     dd.cmte_dsgn as designation,
     expand_committee_designation(dd.cmte_dsgn) as designation_full,
     dd.cmte_tp as committee_type,
@@ -21,7 +21,7 @@ select distinct
     cp_most_recent.cmte_nm as name,
     candidates.candidate_ids,
     cp_agg.cycles
-from dimcmte
+from dimcmteproperties dcp
     left join (
         select distinct on (cmte_sk) * from dimcmtetpdsgn
             order by cmte_sk, receipt_date desc
@@ -52,7 +52,13 @@ from dimcmte
         group by cmte_sk
     ) cp_agg using (cmte_sk)
     left join dimparty p on cp_most_recent.cand_pty_affiliation = p.party_affiliation
-    left join (select cmte_sk, array_agg(distinct cand_id)::text[] as candidate_ids from dimlinkages dl group by cmte_sk) candidates on candidates.cmte_sk = dimcmte.cmte_sk
+    left join (
+        select
+            cmte_sk,
+            array_agg(distinct cand_id)::text[] as candidate_ids
+        from dimlinkages dl
+        group by cmte_sk
+    ) candidates on candidates.cmte_sk = dcp.cmte_sk
     -- Committee must have > 0 cycles after START_YEAR
     where array_length(cp_agg.cycles, 1) > 0
 ;

--- a/data/sql_updates/create_fulltext_table.sql
+++ b/data/sql_updates/create_fulltext_table.sql
@@ -1,29 +1,28 @@
 drop table if exists dimcand_fulltext;
 drop materialized view if exists ofec_candidate_fulltext_mv_tmp;
 create materialized view ofec_candidate_fulltext_mv_tmp as
-    select distinct on (c.cand_sk)
+    select distinct on (cand_sk)
         row_number() over () as idx,
-        c.cand_sk,
+        cand_sk,
         case
-            when p.cand_nm is not null then
-                setweight(to_tsvector(p.cand_nm), 'A') ||
-                setweight(to_tsvector(c.cand_id), 'B')
+            when cand_nm is not null then
+                setweight(to_tsvector(cand_nm), 'A') ||
+                setweight(to_tsvector(cand_id), 'B')
             else null::tsvector
             end
         as fulltxt
-    from dimcand c
-    left outer join dimcandproperties p on c.cand_sk = p.cand_sk
+    from dimcandproperties dcp
     inner join (
         select distinct cand_sk from dimcandproperties
         where form_tp != 'F2Z'
-    ) f2 on c.cand_sk = f2.cand_sk
+    ) f2 using (cand_sk)
     -- Use same joins as main candidate views to ensure same candidates
     -- present in all views
-    left join dimcandoffice co on c.cand_sk = co.cand_sk
+    left join dimcandoffice co using (cand_sk)
     inner join dimoffice using (office_sk)
     inner join dimparty using (party_sk)
-    where p.election_yr >= :START_YEAR
-    order by c.cand_sk, p.election_yr desc
+    where election_yr >= :START_YEAR
+    order by cand_sk, election_yr desc
 ;
 
 create unique index on ofec_candidate_fulltext_mv_tmp(idx);
@@ -32,18 +31,17 @@ create index on ofec_candidate_fulltext_mv_tmp using gin(fulltxt);
 drop table if exists dimcmte_fulltext;
 drop materialized view if exists ofec_committee_fulltext_mv_tmp;
 create materialized view ofec_committee_fulltext_mv_tmp as
-    select distinct on (c.cmte_sk)
+    select distinct on (cmte_sk)
         row_number() over () as idx,
-        c.cmte_sk,
+        cmte_sk,
         case
-            when p.cmte_nm is not null then
-                setweight(to_tsvector(p.cmte_nm), 'A') ||
-                setweight(to_tsvector(c.cmte_id), 'B')
+            when cmte_nm is not null then
+                setweight(to_tsvector(cmte_nm), 'A') ||
+                setweight(to_tsvector(cmte_id), 'B')
             else null::tsvector
             end
         as fulltxt
-    from dimcmte c
-    left join dimcmteproperties p using (cmte_sk)
+    from dimcmteproperties dcp
     left join (
         select
             cmte_sk,
@@ -59,7 +57,7 @@ create materialized view ofec_committee_fulltext_mv_tmp as
         group by cmte_sk
     ) cp_agg using (cmte_sk)
     where array_length(cp_agg.cycles, 1) > 0
-    order by c.cmte_sk, p.receipt_dt desc
+    order by cmte_sk, receipt_dt desc
 ;
 
 create unique index on ofec_committee_fulltext_mv_tmp(idx);
@@ -88,12 +86,11 @@ with
         where p.election_yr >= :START_YEAR
         order by c.cand_sk, p.election_yr desc
     ), ranked_cmte as (
-        select distinct on (c.cmte_sk)
-            p.cmte_nm as name,
-            to_tsvector(p.cmte_nm) as name_vec,
-            c.cmte_id
-        from dimcmte c
-        left join dimcmteproperties p using (cmte_sk)
+        select distinct on (cmte_sk)
+            cmte_nm as name,
+            to_tsvector(cmte_nm) as name_vec,
+            cmte_id
+        from dimcmteproperties dcp
         left join (
             select
                 cmte_sk,
@@ -109,7 +106,7 @@ with
             group by cmte_sk
         ) cp_agg using (cmte_sk)
         where array_length(cp_agg.cycles, 1) > 0
-        order by c.cmte_sk, p.receipt_dt desc
+        order by cmte_sk, receipt_dt desc
     )
     select
         row_number() over () as idx,

--- a/tests/candidate_tests.py
+++ b/tests/candidate_tests.py
@@ -10,10 +10,10 @@ from tests.common import ApiBaseTest
 from webservices import schemas
 from webservices.rest import db
 from webservices.rest import api
-from webservices.rest import CandidateList
-from webservices.rest import CandidateView
-from webservices.rest import CandidateSearch
-from webservices.rest import CandidateHistoryView
+from webservices.resources.candidates import CandidateList
+from webservices.resources.candidates import CandidateView
+from webservices.resources.candidates import CandidateSearch
+from webservices.resources.candidates import CandidateHistoryView
 
 
 fields = dict(

--- a/tests/committee_tests.py
+++ b/tests/committee_tests.py
@@ -11,9 +11,9 @@ from tests.common import ApiBaseTest
 from webservices import utils
 from webservices.rest import db
 from webservices.rest import api
-from webservices.rest import CommitteeList
-from webservices.rest import CommitteeView
-from webservices.rest import CandidateView
+from webservices.resources.committees import CommitteeList
+from webservices.resources.committees import CommitteeView
+from webservices.resources.candidates import CandidateView
 
 
 ## old, re-factored Committee tests ##

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -101,6 +101,14 @@ class CommitteeDetailFactory(BaseCommitteeFactory):
         paired_factory = lambda: CommitteeFactory
 
 
+class CommitteeHistoryFactory(BaseFactory):
+    class Meta:
+        model = models.CommitteeHistory
+    committee_key = factory.Sequence(lambda n: n + 1)
+    committee_id = factory.Sequence(lambda n: 'id{0}'.format(n))
+    cycle = 2016
+
+
 class CandidateCommitteeLinkFactory(BaseFactory):
     class Meta:
         model = models.CandidateCommitteeLink

--- a/tests/report_tests.py
+++ b/tests/report_tests.py
@@ -25,6 +25,10 @@ class TestReports(ApiBaseTest):
     def test_reports_by_committee_id(self):
         committee = factories.CommitteeFactory(committee_type='P')
         committee_id = committee.committee_id
+        history = factories.CommitteeHistoryFactory(
+            committee_id=committee_id,
+            committee_type='P',
+        )
         committee_report = factories.ReportsPresidentialFactory(committee_id=committee_id)
         other_report = factories.ReportsPresidentialFactory()
         results = self._results(api.url_for(ReportsView, committee_id=committee_id))
@@ -99,6 +103,10 @@ class TestReports(ApiBaseTest):
     def test_reports_sort(self):
         committee = factories.CommitteeFactory(committee_type='H')
         committee_id = committee.committee_id
+        history = factories.CommitteeHistoryFactory(
+            committee_id=committee_id,
+            committee_type='H',
+        )
         contributions = [0, 100]
         reports = [
             factories.ReportsHouseSenateFactory(committee_id=committee_id, net_contributions_period=contributions[0]),
@@ -110,6 +118,10 @@ class TestReports(ApiBaseTest):
     def test_reports_sort_default(self):
         committee = factories.CommitteeFactory(committee_type='H')
         committee_id = committee.committee_id
+        history = factories.CommitteeHistoryFactory(
+            committee_id=committee_id,
+            committee_type='H',
+        )
         dates = [
             datetime.datetime(2015, 7, 4),
             datetime.datetime(2015, 7, 5),

--- a/tests/report_tests.py
+++ b/tests/report_tests.py
@@ -6,7 +6,7 @@ from .common import ApiBaseTest
 from tests import factories
 
 from webservices.rest import api
-from webservices.rest import ReportsView
+from webservices.resources.reports import ReportsView
 
 
 class TestReports(ApiBaseTest):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,9 +12,9 @@ from webservices import rest
 from webservices import schemas
 from webservices.rest import api
 from webservices.rest import NameSearch
-from webservices.rest import TotalsView
-from webservices.rest import ReportsView
-from webservices.rest import CandidateList
+from webservices.resources.totals import TotalsView
+from webservices.resources.reports import ReportsView
+from webservices.resources.candidates import CandidateList
 
 
 class OverallTest(ApiBaseTest):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -114,6 +114,7 @@ class OverallTest(ApiBaseTest):
     def test_totals_house_senate(self):
         committee = factories.CommitteeFactory(committee_type='H')
         committee_id = committee.committee_id
+        factories.CommitteeHistoryFactory(committee_id=committee_id, committee_type='H')
         [
             factories.TotalsHouseSenateFactory(committee_id=committee_id, cycle=2008),
             factories.TotalsHouseSenateFactory(committee_id=committee_id, cycle=2012),
@@ -125,6 +126,10 @@ class OverallTest(ApiBaseTest):
 
     def _check_reports(self, committee_type, factory, schema):
         committee = factories.CommitteeFactory(committee_type=committee_type)
+        factories.CommitteeHistoryFactory(
+            committee_id=committee.committee_id,
+            committee_type=committee_type,
+        )
         end_dates = [datetime.datetime(2012, 1, 1), datetime.datetime(2008, 1, 1)]
         committee_id = committee.committee_id
         [
@@ -174,6 +179,7 @@ class OverallTest(ApiBaseTest):
     def test_total_cycle(self):
         committee = factories.CommitteeFactory(committee_type='P')
         committee_id = committee.committee_id
+        history = factories.CommitteeHistoryFactory(committee_id=committee_id, committee_type='P')
         receipts = 5
         totals = factories.TotalsPresidentialFactory(cycle=2012, committee_id=committee_id, receipts=receipts)
 

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -133,6 +133,13 @@ class CandidateView(Resource):
         return candidates.order_by(CandidateDetail.expire_date.desc())
 
 
+@spec.doc(
+    tags=['candidate'],
+    path_params=[
+        {'name': 'candidate_id', 'in': 'path', 'type': 'string'},
+        {'name': 'cycle', 'in': 'path', 'type': 'integer'},
+    ],
+)
 class CandidateHistoryView(Resource):
 
     @args.register_kwargs(args.paging)

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -125,6 +125,14 @@ class CommitteeView(Resource):
         return committees
 
 
+@spec.doc(
+    tags=['committee'],
+    path_params=[
+        {'name': 'committee_id', 'in': 'path', 'type': 'string'},
+        {'name': 'candidate_id', 'in': 'path', 'type': 'string'},
+        {'name': 'cycle', 'in': 'path', 'type': 'integer'},
+    ],
+)
 class CommitteeHistoryView(Resource):
 
     @args.register_kwargs(args.paging)

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -130,14 +130,25 @@ class CommitteeHistoryView(Resource):
     @args.register_kwargs(args.paging)
     @args.register_kwargs(args.make_sort_args(default=['-cycle']))
     @schemas.marshal_with(schemas.CommitteeHistoryPageSchema())
-    def get(self, committee_id, cycle=None, **kwargs):
-        query = self.get_committee(committee_id, cycle, kwargs)
+    def get(self, committee_id=None, candidate_id=None, cycle=None, **kwargs):
+        query = self.get_committee(committee_id, candidate_id, cycle, kwargs)
         return utils.fetch_page(query, kwargs)
 
-    def get_committee(self, committee_id, cycle, kwargs):
-        query = CommitteeHistory.query.filter(
-            CommitteeHistory.committee_id == committee_id
-        )
+    def get_committee(self, committee_id, candidate_id, cycle, kwargs):
+        query = CommitteeHistory.query
+
+        if committee_id:
+            query = query.filter(CommitteeHistory.committee_id == committee_id)
+
+        if candidate_id:
+            query = CommitteeHistory.query.join(
+                CandidateCommitteeLink,
+                CandidateCommitteeLink.committee_key == CommitteeHistory.committee_key,
+            ).filter(
+                CandidateCommitteeLink.candidate_id == candidate_id
+            )
+
         if cycle:
             query = query.filter(CommitteeHistory.cycle == cycle)
+
         return query

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -27,13 +27,14 @@ import sqlalchemy as sa
 from webservices import args
 from webservices import docs
 from webservices import spec
+from webservices import utils
 from webservices import schemas
 from webservices.common import models
 from webservices.common.models import db
-from webservices.resources.candidates import CandidateList, CandidateSearch, CandidateView, CandidateHistoryView
-from webservices.resources.totals import TotalsView
-from webservices.resources.reports import ReportsView
-from webservices.resources.committees import CommitteeList, CommitteeView, CommitteeHistoryView
+from webservices.resources import totals
+from webservices.resources import reports
+from webservices.resources import candidates
+from webservices.resources import committees
 
 from .json_encoding import TolerantJSONEncoder
 
@@ -135,33 +136,33 @@ class Help(restful.Resource):
 
 
 api.add_resource(Help, '/')
-api.add_resource(CandidateList, '/candidates')
-api.add_resource(CandidateSearch, '/candidates/search')
+api.add_resource(candidates.CandidateList, '/candidates')
+api.add_resource(candidates.CandidateSearch, '/candidates/search')
 api.add_resource(
-    CandidateView,
+    candidates.CandidateView,
     '/candidate/<string:candidate_id>',
     '/committee/<string:committee_id>/candidates',
 )
 api.add_resource(
-    CandidateHistoryView,
+    candidates.CandidateHistoryView,
     '/candidate/<string:candidate_id>/history/<int:cycle>',
     '/candidate/<string:candidate_id>/history',
 )
-api.add_resource(CommitteeList, '/committees')
+api.add_resource(committees.CommitteeList, '/committees')
 api.add_resource(
-    CommitteeView,
+    committees.CommitteeView,
     '/committee/<string:committee_id>',
     '/candidate/<string:candidate_id>/committees',
 )
 api.add_resource(
-    CommitteeHistoryView,
+    committees.CommitteeHistoryView,
     '/committee/<string:committee_id>/history/<int:cycle>',
     '/committee/<string:committee_id>/history',
     '/candidate/<candidate_id>/committees/history',
     '/candidate/<candidate_id>/committees/history/<int:cycle>',
 )
-api.add_resource(TotalsView, '/committee/<string:committee_id>/totals')
-api.add_resource(ReportsView, '/committee/<string:committee_id>/reports', '/reports/<string:committee_type>')
+api.add_resource(totals.TotalsView, '/committee/<string:committee_id>/totals')
+api.add_resource(reports.ReportsView, '/committee/<string:committee_id>/reports', '/reports/<string:committee_type>')
 api.add_resource(NameSearch, '/names')
 
 
@@ -191,7 +192,8 @@ def register_resource(resource, blueprint=None):
     for rule in rules:
         path = extract_path(rule.rule)
         path_params = [
-            each for each in resource_doc.get('path_params', [])
+            utils.extend({'required': True}, each)
+            for each in resource_doc.get('path_params', [])
             if each['name'] in rule.arguments
         ]
         for method in [method.lower() for method in resource.methods or []]:
@@ -208,13 +210,15 @@ def register_resource(resource, blueprint=None):
 
 
 register_resource(NameSearch, blueprint='v1')
-register_resource(CandidateView, blueprint='v1')
-register_resource(CandidateList, blueprint='v1')
-register_resource(CandidateSearch, blueprint='v1')
-register_resource(CommitteeView, blueprint='v1')
-register_resource(CommitteeList, blueprint='v1')
-register_resource(ReportsView, blueprint='v1')
-register_resource(TotalsView, blueprint='v1')
+register_resource(candidates.CandidateView, blueprint='v1')
+register_resource(candidates.CandidateList, blueprint='v1')
+register_resource(candidates.CandidateSearch, blueprint='v1')
+register_resource(candidates.CandidateHistoryView, blueprint='v1')
+register_resource(committees.CommitteeView, blueprint='v1')
+register_resource(committees.CommitteeList, blueprint='v1')
+register_resource(committees.CommitteeHistoryView, blueprint='v1')
+register_resource(reports.ReportsView, blueprint='v1')
+register_resource(totals.TotalsView, blueprint='v1')
 
 renderers = {
     'application/json': lambda data: jsonify(data),

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -157,6 +157,8 @@ api.add_resource(
     CommitteeHistoryView,
     '/committee/<string:committee_id>/history/<int:cycle>',
     '/committee/<string:committee_id>/history',
+    '/candidate/<candidate_id>/committees/history',
+    '/candidate/<candidate_id>/committees/history/<int:cycle>',
 )
 api.add_resource(TotalsView, '/committee/<string:committee_id>/totals')
 api.add_resource(ReportsView, '/committee/<string:committee_id>/reports', '/reports/<string:committee_type>')


### PR DESCRIPTION
Restoring Scott Brown's principal committee in previous election cycles turned out to be a bit more complicated than expected. As @LindsayYoung discovered, we were filtering committees for a given candidate that were *active* for a particular cycle, but still getting data for the most recent filings for those committees. This means that Scott Brown's joint committee, which used to be his principal committee, always showed up as a joint committee.

This patch exposes a new route to the committee history resource at `/candidate/<candidate_id>/committees/history/<cycle>`. This allows the webapp to fetch information about a candidate's committees at the currently selected cycle. The patch also modifies the reports and totals resources to look up committees in the committee history view by cycle, if cycle is provided.

[Resolves #780]