### PR TITLE
Feature/resource wildcard search

### DIFF
--- a/tests/committee_tests.py
+++ b/tests/committee_tests.py
@@ -45,7 +45,7 @@ class CommitteeFormatTest(ApiBaseTest):
             cmte_sk=committee.committee_key,
             fulltxt=sa.func.to_tsvector(committee.name),
         )
-        results = self._results(api.url_for(CommitteeList, q='tomorrow'))
+        results = self._results(api.url_for(CommitteeList, q='better'))
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['committee_id'], committee.committee_id)
         self.assertNotEqual(results[0]['committee_id'], decoy_committee.committee_id)

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -30,7 +30,7 @@ class CandidateList(Resource):
     fulltext_query = '''
         SELECT cand_sk
         FROM   ofec_candidate_fulltext_mv
-        WHERE  fulltxt @@ to_tsquery(:findme)
+        WHERE  fulltxt @@ to_tsquery(:findme || ':*')
         ORDER BY ts_rank_cd(fulltxt, to_tsquery(:findme)) desc
    '''
 

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -40,7 +40,7 @@ class CommitteeList(Resource):
         SELECT cmte_sk
         FROM   ofec_committee_fulltext_mv
         WHERE  fulltxt @@ to_tsquery(:findme)
-        ORDER BY ts_rank_cd(fulltxt, to_tsquery(:findme)) desc
+        ORDER BY ts_rank_cd(fulltxt, to_tsquery(:findme || ':*')) desc
     '''
 
     @args.register_kwargs(args.paging)


### PR DESCRIPTION
Use wildcard search on candidates and committees.

Currently, typeahead search appends a wildcard (":*") to the search
term, such that searching for "Dan" matches "Danny" (but not "Aidan").
This patch adds a wildcard to full-text searches on the candidate and
committee endpoints for consistent results.

[Resolves #880]