### PR TITLE
Allow specification of included and excluded report types.

### DIFF
--- a/data/sql_updates/create_reports_house_senate_view.sql
+++ b/data/sql_updates/create_reports_house_senate_view.sql
@@ -103,3 +103,4 @@ create unique index on ofec_reports_house_senate_mv_tmp(idx);
 
 create index on ofec_reports_house_senate_mv_tmp(cycle);
 create index on ofec_reports_house_senate_mv_tmp(committee_id);
+create index on ofec_reports_house_senate_mv_tmp(report_type);

--- a/data/sql_updates/create_reports_pacs_parties_view.sql
+++ b/data/sql_updates/create_reports_pacs_parties_view.sql
@@ -125,3 +125,4 @@ create unique index on ofec_reports_pacs_parties_mv_tmp(idx);
 
 create index on ofec_reports_pacs_parties_mv_tmp(cycle);
 create index on ofec_reports_pacs_parties_mv_tmp(committee_id);
+create index on ofec_reports_pacs_parties_mv_tmp(report_type);

--- a/data/sql_updates/create_reports_presidential_view.sql
+++ b/data/sql_updates/create_reports_presidential_view.sql
@@ -104,3 +104,4 @@ create unique index on ofec_reports_presidential_mv_tmp(idx);
 
 create index on ofec_reports_presidential_mv_tmp(cycle);
 create index on ofec_reports_presidential_mv_tmp(committee_id);
+create index on ofec_reports_presidential_mv_tmp(report_type);

--- a/tests/report_tests.py
+++ b/tests/report_tests.py
@@ -133,3 +133,33 @@ class TestReports(ApiBaseTest):
         ]
         results = self._results(api.url_for(ReportsView, committee_id=committee_id))
         self.assertEqual([each['coverage_end_date'] for each in results], dates_formatted[::-1])
+
+    def test_report_type_include(self):
+        committee = factories.CommitteeFactory(committee_type='H')
+        committee_id = committee.committee_id
+        factories.CommitteeHistoryFactory(
+            committee_id=committee_id,
+            committee_type='H',
+        )
+        [
+            factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='Q2'),
+            factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='M3'),
+            factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='TER'),
+        ]
+        results = self._results(api.url_for(ReportsView, committee_id=committee_id, type=['Q2', 'M3']))
+        self.assertTrue(all(each['report_type'] in ['Q2', 'M3'] for each in results))
+
+    def test_report_type_exclude(self):
+        committee = factories.CommitteeFactory(committee_type='H')
+        committee_id = committee.committee_id
+        factories.CommitteeHistoryFactory(
+            committee_id=committee_id,
+            committee_type='H',
+        )
+        [
+            factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='Q2'),
+            factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='M3'),
+            factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='TER'),
+        ]
+        results = self._results(api.url_for(ReportsView, committee_id=committee_id, type=['-M3']))
+        self.assertTrue(all(each['report_type'] in ['Q2', 'TER'] for each in results))

--- a/tests/report_tests.py
+++ b/tests/report_tests.py
@@ -146,7 +146,7 @@ class TestReports(ApiBaseTest):
             factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='M3'),
             factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='TER'),
         ]
-        results = self._results(api.url_for(ReportsView, committee_id=committee_id, type=['Q2', 'M3']))
+        results = self._results(api.url_for(ReportsView, committee_id=committee_id, report_type=['Q2', 'M3']))
         self.assertTrue(all(each['report_type'] in ['Q2', 'M3'] for each in results))
 
     def test_report_type_exclude(self):
@@ -161,5 +161,5 @@ class TestReports(ApiBaseTest):
             factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='M3'),
             factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='TER'),
         ]
-        results = self._results(api.url_for(ReportsView, committee_id=committee_id, type=['-M3']))
+        results = self._results(api.url_for(ReportsView, committee_id=committee_id, report_type=['-M3']))
         self.assertTrue(all(each['report_type'] in ['Q2', 'TER'] for each in results))

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -108,6 +108,7 @@ committee_list = {
 reports = {
     'year': Arg(int, multiple=True, description='Year in which a candidate runs for office'),
     'cycle': Arg(int, multiple=True, description='Two-year election cycle in which a candidate runs for office'),
+    'type': Arg(str, multiple=True, description='Report type; prefix with "-" to exclude'),
 }
 
 

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -108,7 +108,7 @@ committee_list = {
 reports = {
     'year': Arg(int, multiple=True, description='Year in which a candidate runs for office'),
     'cycle': Arg(int, multiple=True, description='Two-year election cycle in which a candidate runs for office'),
-    'type': Arg(str, multiple=True, description='Report type; prefix with "-" to exclude'),
+    'report_type': Arg(str, multiple=True, description='Report type; prefix with "-" to exclude'),
 }
 
 

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -70,8 +70,8 @@ class ReportsView(Resource):
         if kwargs['cycle']:
             reports = reports.filter(reports_class.cycle.in_(kwargs['cycle']))
 
-        if kwargs['type']:
-            include, exclude = parse_types(kwargs['type'])
+        if kwargs['report_type']:
+            include, exclude = parse_types(kwargs['report_type'])
             if include:
                 reports = reports.filter(reports_class.report_type.in_(include))
             elif exclude:

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -24,6 +24,17 @@ reports_type_map = {
 }
 
 
+def parse_types(types):
+    include, exclude = [], []
+    for each in types:
+        target = exclude if each.startswith('-') else include
+        each = each.lstrip('-')
+        target.append(each)
+    if include and exclude:
+        include = [each for each in include if each not in exclude]
+    return include, exclude
+
+
 @spec.doc(
     tags=['financial'],
     description=docs.REPORTS,
@@ -58,6 +69,13 @@ class ReportsView(Resource):
             reports = reports.filter(reports_class.report_year.in_(kwargs['year']))
         if kwargs['cycle']:
             reports = reports.filter(reports_class.cycle.in_(kwargs['cycle']))
+
+        if kwargs['type']:
+            include, exclude = parse_types(kwargs['type'])
+            if include:
+                reports = reports.filter(reports_class.report_type.in_(include))
+            elif exclude:
+                reports = reports.filter(sa.not_(reports_class.report_type.in_(exclude)))
 
         return reports, reports_schema
 


### PR DESCRIPTION
Allow API consumers to specify report types in reports endpoints. This can be used to either include or exclude reports by type:

* `/committee/<committee_id>/reports?type=Q1&type=Q2`
* `/committee/<committee_id>/reports?type=-TER`

Partial fix for #881 based on feedback from @dcpcc1967 and @jwchumley.