### PR TITLE
Use BigInteger to avoid overflow on image numbers.

### DIFF
--- a/tests/report_tests.py
+++ b/tests/report_tests.py
@@ -135,36 +135,35 @@ class TestReports(ApiBaseTest):
         self.assertEqual([each['coverage_end_date'] for each in results], dates_formatted[::-1])
 
     def test_reports_for_pdf_link(self):
-        presidential_report_2016 = factories.ReportsPresidentialFactory(
+        factories.ReportsPresidentialFactory(
             report_year=2016,
             beginning_image_number=12345678901,
         )
 
-
-        results_pdf = self._results(
+        results = self._results(
             api.url_for(
                 ReportsView,
                 committee_type='presidential',
-                beginning_image_number=12345678901,
             )
         )
-        self.assertEqual(response_pdf[0]['pdf_url'], 'http://docquery.fec.gov/pdf/901/12345678901/12345678901.pdf')
+        self.assertEqual(
+            results[0]['pdf_url'],
+            'http://docquery.fec.gov/pdf/901/12345678901/12345678901.pdf',
+        )
 
     def test_no_pdf_link(self):
         """
         Old pdfs don't exist so we should not build links.
         """
-        presidential_report_1990 = factories.ReportsPresidentialFactory(
+        factories.ReportsPresidentialFactory(
             report_year=1990,
             beginning_image_number=56789012345,
         )
 
-        results_none = self._results(
+        results = self._results(
             api.url_for(
                 ReportsView,
                 committee_type='presidential',
-                beginning_image_number=56789012345,
             )
         )
-        self.assertEqual(response_none[0]['pdf_url'], 'null')
-
+        self.assertIsNone(results[0]['pdf_url'])

--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -224,7 +224,7 @@ class CommitteeReports(BaseModel):
     committee_id = db.Column(db.String(10))
     cycle = db.Column(db.Integer)
 
-    beginning_image_number = db.Column(db.Integer)
+    beginning_image_number = db.Column(db.BigInteger)
     cash_on_hand_beginning_period = db.Column(db.Integer)
     cash_on_hand_end_period = db.Column(db.Integer)
     coverage_end_date = db.Column(db.DateTime)


### PR DESCRIPTION
@LindsayYoung: This was kind of a subtle problem. In the tests, we're using `Integer` fields to store `beginning_image_number`, but the realistic number we provided here was too big. Switching to `BigInteger` fixes the issue. For some reason, Flask swallowed the `integer out of range` error we *should* have been getting and threw an interpretable error instead. And the issue would never come up outside of testing because the SQL scripts will intelligently detect the correct data type for us when we're importing real data.

`¯\_(ツ)_/¯`