### PR TITLE
Add more wildcards to search terms.

### DIFF
--- a/tests/committee_tests.py
+++ b/tests/committee_tests.py
@@ -45,7 +45,7 @@ class CommitteeFormatTest(ApiBaseTest):
             cmte_sk=committee.committee_key,
             fulltxt=sa.func.to_tsvector(committee.name),
         )
-        results = self._results(api.url_for(CommitteeList, q='better'))
+        results = self._results(api.url_for(CommitteeList, q='america'))
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['committee_id'], committee.committee_id)
         self.assertNotEqual(results[0]['committee_id'], decoy_committee.committee_id)

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -31,7 +31,7 @@ class CandidateList(Resource):
         SELECT cand_sk
         FROM   ofec_candidate_fulltext_mv
         WHERE  fulltxt @@ to_tsquery(:findme || ':*')
-        ORDER BY ts_rank_cd(fulltxt, to_tsquery(:findme)) desc
+        ORDER BY ts_rank_cd(fulltxt, to_tsquery(:findme || ':*')) desc
    '''
 
     @property

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -39,7 +39,7 @@ class CommitteeList(Resource):
     fulltext_query = '''
         SELECT cmte_sk
         FROM   ofec_committee_fulltext_mv
-        WHERE  fulltxt @@ to_tsquery(:findme)
+        WHERE  fulltxt @@ to_tsquery(:findme || ':*')
         ORDER BY ts_rank_cd(fulltxt, to_tsquery(:findme || ':*')) desc
     '''
 


### PR DESCRIPTION
Search wildcards were partly added in #882, but I missed one on the committees endpoint. This patch adds the missing wildcard and a regression test to go along with it.

h/t @LindsayYoung 