### PR TITLE
Hide internal fields from Swagger output.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ gunicorn
 marshmallow>=2.0.0b2
 marshmallow-sqlalchemy>=0.2.0
 webargs>=0.13.0
-git+https://github.com/jmcarp/smore@check-base-path
+git+https://github.com/jmcarp/smore@respect-exclude
 
 nose>=1.3.6
 factory-boy>=2.5.2

--- a/tests/candidate_tests.py
+++ b/tests/candidate_tests.py
@@ -89,10 +89,6 @@ class CandidateFormatTest(ApiBaseTest):
         self.assertResultsEqual(result['incumbent_challenge'], candidate.incumbent_challenge)
         self.assertResultsEqual(result['candidate_status_full'], candidate.candidate_status_full)
 
-    def _results(self, qry):
-        response = self._response(qry)
-        return response['results']
-
     def test_candidates_search(self):
         principal_committee = factories.CommitteeFactory(designation='P')
         joint_committee = factories.CommitteeFactory(designation='J')

--- a/tests/committee_tests.py
+++ b/tests/committee_tests.py
@@ -18,9 +18,6 @@ from webservices.resources.candidates import CandidateView
 
 ## old, re-factored Committee tests ##
 class CommitteeFormatTest(ApiBaseTest):
-    def _results(self, qry):
-        response = self._response(qry)
-        return response['results']
 
     def test_committee_list_fields(self):
         committee = factories.CommitteeFactory(

--- a/tests/common.py
+++ b/tests/common.py
@@ -68,6 +68,10 @@ class ApiBaseTest(BaseTestCase):
         self.assertEqual(result['api_version'], __API_VERSION__)
         return result
 
+    def _results(self, qry):
+        response = self._response(qry)
+        return response['results']
+
     def assertResultsEqual(self, actual, expected, prefix=""):
         """This method provides some quick debugging info (rather than the
         cryptic "this 500 attribute dict is different than that one"). prefix

--- a/tests/report_tests.py
+++ b/tests/report_tests.py
@@ -11,10 +11,6 @@ from webservices.resources.reports import ReportsView
 
 class TestReports(ApiBaseTest):
 
-    def _results(self, qry):
-        response = self._response(qry)
-        return response['results']
-
     def _check_committee_ids(self, results, positives=None, negatives=None):
         ids = [each['committee_id'] for each in results]
         for positive in (positives or []):

--- a/tests/report_tests.py
+++ b/tests/report_tests.py
@@ -135,15 +135,17 @@ class TestReports(ApiBaseTest):
         self.assertEqual([each['coverage_end_date'] for each in results], dates_formatted[::-1])
 
     def test_reports_for_pdf_link(self):
+        number = 12345678901
         factories.ReportsPresidentialFactory(
             report_year=2016,
-            beginning_image_number=12345678901,
+            beginning_image_number=number,
         )
 
         results = self._results(
             api.url_for(
                 ReportsView,
                 committee_type='presidential',
+                beginning_image_number=number,
             )
         )
         self.assertEqual(
@@ -155,15 +157,17 @@ class TestReports(ApiBaseTest):
         """
         Old pdfs don't exist so we should not build links.
         """
+        number = 56789012345
         factories.ReportsPresidentialFactory(
             report_year=1990,
-            beginning_image_number=56789012345,
+            beginning_image_number=number,
         )
 
         results = self._results(
             api.url_for(
                 ReportsView,
                 committee_type='presidential',
+                beginning_image_number=number,
             )
         )
         self.assertIsNone(results[0]['pdf_url'])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,10 +24,6 @@ class OverallTest(ApiBaseTest):
         self.assertIn('api_version', response)
         self.assertIn('pagination', response)
 
-    def _results(self, qry):
-        response = self._response(qry)
-        return response['results']
-
     def test_full_text_search(self):
         candidate = factories.CandidateFactory(name='Josiah Bartlet')
         factories.CandidateSearchFactory(

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -172,10 +172,10 @@ make_reports_schema = functools.partial(make_schema, options={'exclude': ('idx',
 CommitteeReportsSchema = make_reports_schema(
     models.CommitteeReportsPresidential,
     class_name='CommitteeReportsSchema',
-    options={'fields': [
+    options={'exclude': [
         each.key for each in models.CommitteeReportsPresidential.__mapper__.iterate_properties
-        if hasattr(models.CommitteeReports, each.key)
-    ]}
+        if not hasattr(models.CommitteeReports, each.key)
+    ] + ['idx', 'report_key']}
 )
 CommitteeReportsPresidentialSchema = make_reports_schema(models.CommitteeReportsPresidential)
 CommitteeReportsHouseSenateSchema = make_reports_schema(models.CommitteeReportsHouseSenate)
@@ -193,10 +193,10 @@ register_schema(CommitteeReportsPageSchema)
 CommitteeTotalsSchema = make_schema(
     models.CommitteeTotalsPresidential,
     class_name='CommitteeTotalsSchema',
-    options={'fields': [
+    options={'exclude': [
         each.key for each in models.CommitteeTotalsPresidential.__mapper__.iterate_properties
-        if hasattr(models.CommitteeTotals, each.key)
-    ]}
+        if not hasattr(models.CommitteeTotals, each.key)
+    ] + ['idx']}
 )
 CommitteeTotalsPresidentialSchema = make_schema(models.CommitteeTotalsPresidential)
 CommitteeTotalsHouseSenateSchema = make_schema(models.CommitteeTotalsHouseSenate)

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -170,10 +170,8 @@ register_schema(CandidateHistoryPageSchema)
 
 make_reports_schema = functools.partial(
     make_schema,
-    options={
-        'exclude': ('idx', 'report_key'),
-        'additional': ('pdf_url', ),
-    }
+    fields={'pdf_url': ma.fields.Str()},
+    options={'exclude': ('idx', 'report_key')},
 )
 CommitteeReportsSchema = make_reports_schema(
     models.CommitteeReportsPresidential,


### PR DESCRIPTION
Smore ignores the `fields` and `additional` meta options of `Schema`
classes, but my fork respects the `exclude` option. This patch switches
to my fork of smore and relies on `exclude` instead of `fields` to
ensure that internal fields such as `idx` are excluded from Swagger
output.