### PR TITLE
Feature/consolidate search

### DIFF
--- a/data/sql_updates/create_fulltext_table.sql
+++ b/data/sql_updates/create_fulltext_table.sql
@@ -3,7 +3,9 @@ drop materialized view if exists ofec_candidate_fulltext_mv_tmp;
 create materialized view ofec_candidate_fulltext_mv_tmp as
     select distinct on (cand_sk)
         row_number() over () as idx,
-        cand_sk,
+        cand_id as id,
+        cand_nm as name,
+        dof.office_tp as office_sought,
         case
             when cand_nm is not null then
                 setweight(to_tsvector(cand_nm), 'A') ||
@@ -19,8 +21,8 @@ create materialized view ofec_candidate_fulltext_mv_tmp as
     -- Use same joins as main candidate views to ensure same candidates
     -- present in all views
     left join dimcandoffice co using (cand_sk)
-    inner join dimoffice using (office_sk)
-    inner join dimparty using (party_sk)
+    inner join dimoffice dof using (office_sk)
+    inner join dimparty dp using (party_sk)
     where election_yr >= :START_YEAR
     order by cand_sk, election_yr desc
 ;
@@ -28,12 +30,14 @@ create materialized view ofec_candidate_fulltext_mv_tmp as
 create unique index on ofec_candidate_fulltext_mv_tmp(idx);
 create index on ofec_candidate_fulltext_mv_tmp using gin(fulltxt);
 
+
 drop table if exists dimcmte_fulltext;
 drop materialized view if exists ofec_committee_fulltext_mv_tmp;
 create materialized view ofec_committee_fulltext_mv_tmp as
     select distinct on (cmte_sk)
         row_number() over () as idx,
-        cmte_sk,
+        cmte_id as id,
+        cmte_nm as name,
         case
             when cmte_nm is not null then
                 setweight(to_tsvector(cmte_nm), 'A') ||
@@ -64,72 +68,3 @@ create materialized view ofec_committee_fulltext_mv_tmp as
 
 create unique index on ofec_committee_fulltext_mv_tmp(idx);
 create index on ofec_committee_fulltext_mv_tmp using gin(fulltxt);
-
-drop table if exists name_search_fulltext;
-drop materialized view if exists ofec_candidate_committee_fulltext_mv_tmp;
-create materialized view ofec_candidate_committee_fulltext_mv_tmp as
-with
-    ranked_cand as (
-        select distinct on (c.cand_sk)
-            p.cand_nm as name,
-            to_tsvector(p.cand_nm) as name_vec,
-            c.cand_id,
-            null::text as cmte_id,
-            o.office_tp as office_sought
-        from dimcand c
-        join dimcandproperties p on (p.cand_sk = c.cand_sk)
-        join dimcandoffice co on (co.cand_sk = c.cand_sk)
-        join dimoffice o on (co.office_sk = o.office_sk)
-        join dimparty using (party_sk)
-        inner join (
-            select distinct cand_sk from dimcandproperties
-            where form_tp != 'F2Z'
-        ) f2 on c.cand_sk = f2.cand_sk
-        where p.election_yr >= :START_YEAR
-        order by c.cand_sk, p.election_yr desc
-    ), ranked_cmte as (
-        select distinct on (cmte_sk)
-            cmte_nm as name,
-            to_tsvector(cmte_nm) as name_vec,
-            cmte_id
-        from dimcmteproperties dcp
-        left join (
-            select
-                cmte_sk,
-                array_agg(distinct(rpt_yr + rpt_yr % 2))::int[] as cycles
-            from (
-                select cmte_sk, rpt_yr from factpacsandparties_f3x
-                union all
-                select cmte_sk, rpt_yr from factpresidential_f3p
-                union all
-                select cmte_sk, rpt_yr from facthousesenate_f3
-                union all
-                select cmte_sk, rpt_yr from dimcmteproperties
-            ) years
-            where rpt_yr >= :START_YEAR
-            group by cmte_sk
-        ) cp_agg using (cmte_sk)
-        where array_length(cp_agg.cycles, 1) > 0
-        order by cmte_sk, receipt_dt desc
-    )
-    select
-        row_number() over () as idx,
-        name,
-        name_vec,
-        cand_id,
-        cmte_id,
-        office_sought
-    from ranked_cand
-    union
-    select
-        row_number() over () + (select count(*) from ranked_cand) as idx,
-        name,
-        name_vec,
-        null as cand_id,
-        cmte_id,
-        null as office_sought
-    from ranked_cmte
-;
-
-create unique index on ofec_candidate_committee_fulltext_mv_tmp(idx);
-create index on ofec_candidate_committee_fulltext_mv_tmp using gin(name_vec);

--- a/tests/candidate_tests.py
+++ b/tests/candidate_tests.py
@@ -139,9 +139,9 @@ class CandidateFormatTest(ApiBaseTest):
 
     def test_fulltext_match(self):
         danielle = factories.CandidateFactory(name='Danielle')
-        factories.CandidateSearchFactory(cand_sk=danielle.candidate_key, fulltxt=sa.func.to_tsvector('Danielle'))
+        factories.CandidateSearchFactory(id=danielle.candidate_id, fulltxt=sa.func.to_tsvector('Danielle'))
         dana = factories.CandidateFactory(name='Dana')
-        factories.CandidateSearchFactory(cand_sk=dana.candidate_key, fulltxt=sa.func.to_tsvector('Dana'))
+        factories.CandidateSearchFactory(id=dana.candidate_id, fulltxt=sa.func.to_tsvector('Dana'))
         rest.db.session.flush()
         results = self._results(api.url_for(CandidateList, q='danielle'))
         self.assertEqual(len(results), 1)

--- a/tests/committee_tests.py
+++ b/tests/committee_tests.py
@@ -42,7 +42,7 @@ class CommitteeFormatTest(ApiBaseTest):
         committee = factories.CommitteeFactory(name='Americans for a Better Tomorrow, Tomorrow')
         decoy_committee = factories.CommitteeFactory()
         factories.CommitteeSearchFactory(
-            cmte_sk=committee.committee_key,
+            id=committee.committee_id,
             fulltxt=sa.func.to_tsvector(committee.name),
         )
         results = self._results(api.url_for(CommitteeList, q='america'))

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -11,23 +11,16 @@ class BaseFactory(SQLAlchemyModelFactory):
         sqlalchemy_session = db.session
 
 
-class NameSearchFactory(BaseFactory):
-    class Meta:
-        model = models.NameSearch
-    cand_id = factory.Sequence(lambda n: n)
-    cmte_id = factory.Sequence(lambda n: n)
-
-
 class CandidateSearchFactory(BaseFactory):
     class Meta:
         model = models.CandidateSearch
-    cand_sk = factory.Sequence(lambda n: n)
+    id = factory.Sequence(lambda n: n)
 
 
 class CommitteeSearchFactory(BaseFactory):
     class Meta:
         model = models.CommitteeSearch
-    cmte_sk = factory.Sequence(lambda n: n)
+    id = factory.Sequence(lambda n: n)
 
 
 class PairedOptions(SQLAlchemyOptions):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,8 @@ from tests.common import ApiBaseTest
 from webservices import rest
 from webservices import schemas
 from webservices.rest import api
-from webservices.rest import NameSearch
+from webservices.rest import CandidateNameSearch
+from webservices.rest import CommitteeNameSearch
 from webservices.resources.totals import TotalsView
 from webservices.resources.reports import ReportsView
 from webservices.resources.candidates import CandidateList
@@ -31,7 +32,7 @@ class OverallTest(ApiBaseTest):
     def test_full_text_search(self):
         candidate = factories.CandidateFactory(name='Josiah Bartlet')
         factories.CandidateSearchFactory(
-            cand_sk=candidate.candidate_key,
+            id=candidate.candidate_id,
             fulltxt=sa.func.to_tsvector('Josiah Bartlet'),
         )
         rest.db.session.flush()
@@ -42,7 +43,7 @@ class OverallTest(ApiBaseTest):
     def test_full_text_search_with_whitespace(self):
         candidate = factories.CandidateFactory(name='Josiah Bartlet')
         factories.CandidateSearchFactory(
-            cand_sk=candidate.candidate_key,
+            id=candidate.candidate_id,
             fulltxt=sa.func.to_tsvector('Josiah Bartlet'),
         )
         rest.db.session.flush()
@@ -187,62 +188,34 @@ class OverallTest(ApiBaseTest):
         self.assertEqual(results[0]['receipts'], totals.receipts)
 
     # Typeahead name search
-    def test_typeahead_name_search(self):
+    def test_typeahead_candidate_search(self):
         [
-            factories.NameSearchFactory(
+            factories.CandidateSearchFactory(
                 name='Bartlet {0}'.format(idx),
-                name_vec=sa.func.to_tsvector('Bartlet for America {0}'.format(idx)),
+                fulltxt=sa.func.to_tsvector('Bartlet for America {0}'.format(idx)),
             )
             for idx in range(30)
         ]
         rest.db.session.flush()
-        results = self._results(api.url_for(NameSearch, q='bartlet'))
+        results = self._results(api.url_for(CandidateNameSearch, q='bartlet'))
         self.assertEqual(len(results), 20)
-        cand_ids = [r['candidate_id'] for r in results if r['candidate_id']]
-        self.assertEqual(len(cand_ids), len(set(cand_ids)))
+        ids = [r['id'] for r in results if r['id']]
+        self.assertEqual(len(ids), len(set(ids)))
         for each in results:
             self.assertIn('bartlet', each['name'].lower())
 
-    def test_typeahead_search_by_resource_bad_resource(self):
-        res = self.app.get(api.url_for(NameSearch, q='bartlet', type='twizzler'))
-        self.assertEqual(res.status_code, 400)
-
-    def test_typeahead_search_by_resource(self):
-        # Create Bartlet candidate records
+    def test_typeahead_committee_search(self):
         [
-            factories.NameSearchFactory(
-                name='Jed Bartlet {0}'.format(idx),
-                name_vec=sa.func.to_tsvector('Jed Bartlet {0}'.format(idx)),
-                cmte_id=None,
-            )
-            for idx in range(5)
-        ]
-        # Create Bartlet committee records
-        [
-            factories.NameSearchFactory(
+            factories.CommitteeSearchFactory(
                 name='Bartlet {0}'.format(idx),
-                name_vec=sa.func.to_tsvector('Bartlet for America {0}'.format(idx)),
-                cand_id=None,
+                fulltxt=sa.func.to_tsvector('Bartlet for America {0}'.format(idx)),
             )
-            for idx in range(5)
+            for idx in range(30)
         ]
-        # Create decoy Ritchie records
-        [
-            factories.NameSearchFactory(
-                name='Ritchie {0}'.format(idx),
-                name_vec=sa.func.to_tsvector('Friends of Ritchie {0}'.format(idx)),
-            )
-            for idx in range(5)
-        ]
-
-        res = self._results(api.url_for(NameSearch, q='bartlet', type='candidate'))
-        self.assertEqual(len(res), 5)
-        self.assertTrue(all('bartlet' in each['name'].lower() for each in res))
-        self.assertTrue(all(each['candidate_id'] is not None for each in res))
-        self.assertTrue(all(each['committee_id'] is None for each in res))
-
-        res = self._results(api.url_for(NameSearch, q='bartlet', type='committee'))
-        self.assertEqual(len(res), 5)
-        self.assertTrue(all('bartlet' in each['name'].lower() for each in res))
-        self.assertTrue(all(each['committee_id'] is not None for each in res))
-        self.assertTrue(all(each['candidate_id'] is None for each in res))
+        rest.db.session.flush()
+        results = self._results(api.url_for(CommitteeNameSearch, q='bartlet'))
+        self.assertEqual(len(results), 20)
+        ids = [r['id'] for r in results if r['id']]
+        self.assertEqual(len(ids), len(set(ids)))
+        for each in results:
+            self.assertIn('bartlet', each['name'].lower())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -83,7 +83,6 @@ class TestViews(common.IntegrationTestCase):
             models.CommitteeDetail.query.count(),
             models.CommitteeHistory.query.distinct(models.CommitteeHistory.committee_id).count(),
             models.CommitteeSearch.query.count(),
-            models.NameSearch.query.filter(models.NameSearch.cmte_id != None).count(),
         ]
         assert len(set(counts)) == 1
 
@@ -93,7 +92,6 @@ class TestViews(common.IntegrationTestCase):
             models.CandidateDetail.query.count(),
             models.CandidateHistory.query.distinct(models.CandidateHistory.candidate_id).count(),
             models.CandidateSearch.query.count(),
-            models.NameSearch.query.filter(models.NameSearch.cand_id != None).count(),
         ]
         assert len(set(counts)) == 1
 

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -59,13 +59,6 @@ def one_of(value, options):
 
 names = {
     'q': Arg(str, required=True, description='Name (candidate or committee) to search for'),
-    'type': Arg(
-        str,
-        use=lambda v: v.lower(),
-        validate=functools.partial(one_of, options=['candidate', 'committee']),
-        description='Resource type to search for. May be "candidate" or "committee"; if '
-        'not specified, search both resources.',
-    ),
 }
 
 

--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -10,27 +10,20 @@ class BaseModel(db.Model):
     idx = db.Column(db.Integer, primary_key=True)
 
 
-class NameSearch(BaseModel):
-    __tablename__ = 'ofec_candidate_committee_fulltext_mv'
-
-    cand_id = db.Column(db.Integer, nullable=True)
-    cmte_id = db.Column(db.Integer, nullable=True)
-    name = db.Column(db.String)
-    office_sought = db.Column(db.String)
-    name_vec = db.Column(TSVECTOR)
-
-
 class CandidateSearch(BaseModel):
     __tablename__ = 'ofec_candidate_fulltext_mv'
 
-    cand_sk = db.Column(db.Integer)
+    id = db.Column(db.String)
+    name = db.Column(db.String)
+    office_sought = db.Column(db.String)
     fulltxt = db.Column(TSVECTOR)
 
 
 class CommitteeSearch(BaseModel):
     __tablename__ = 'ofec_committee_fulltext_mv'
 
-    cmte_sk = db.Column(db.Integer)
+    id = db.Column(db.String)
+    name = db.Column(db.String)
     fulltxt = db.Column(TSVECTOR)
 
 

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -6,8 +6,8 @@ from webservices import docs
 from webservices import spec
 from webservices import utils
 from webservices import schemas
+from webservices.common import models
 from webservices.common.util import filter_query
-from webservices.common.models import db, Candidate, CandidateDetail, CandidateHistory, CandidateCommitteeLink
 
 
 filter_fields = {
@@ -27,16 +27,9 @@ filter_fields = {
 )
 class CandidateList(Resource):
 
-    fulltext_query = '''
-        SELECT cand_sk
-        FROM   ofec_candidate_fulltext_mv
-        WHERE  fulltxt @@ to_tsquery(:findme || ':*')
-        ORDER BY ts_rank_cd(fulltxt, to_tsquery(:findme || ':*')) desc
-   '''
-
     @property
     def query(self):
-        return Candidate.query
+        return models.Candidate.query
 
     @args.register_kwargs(args.paging)
     @args.register_kwargs(args.candidate_list)
@@ -45,28 +38,30 @@ class CandidateList(Resource):
     @schemas.marshal_with(schemas.CandidatePageSchema())
     def get(self, **kwargs):
         query = self.get_candidates(kwargs)
-        return utils.fetch_page(query, kwargs, model=Candidate)
+        return utils.fetch_page(query, kwargs, model=models.Candidate)
 
     def get_candidates(self, kwargs):
 
         candidates = self.query
 
         if kwargs.get('q'):
-            findme = ' & '.join(kwargs['q'].split())
-            candidates = candidates.filter(
-                Candidate.candidate_key.in_(
-                    db.session.query('cand_sk').from_statement(sa.text(self.fulltext_query)).params(findme=findme)
-                )
+            candidates = utils.search_text(
+                candidates.join(
+                    models.CandidateSearch,
+                    models.Candidate.candidate_key == models.CandidateSearch.cand_sk,
+                ),
+                models.CandidateSearch.fulltxt,
+                kwargs['q'],
             )
 
-        candidates = filter_query(Candidate, candidates, filter_fields, kwargs)
+        candidates = filter_query(models.Candidate, candidates, filter_fields, kwargs)
 
         if kwargs.get('name'):
-            candidates = candidates.filter(Candidate.name.ilike('%{}%'.format(kwargs['name'])))
+            candidates = candidates.filter(models.Candidate.name.ilike('%{}%'.format(kwargs['name'])))
 
         # TODO(jmcarp) Reintroduce year filter pending accurate `load_date` and `expire_date` values
         if kwargs['cycle']:
-            candidates = candidates.filter(Candidate.cycles.overlap(kwargs['cycle']))
+            candidates = candidates.filter(models.Candidate.cycles.overlap(kwargs['cycle']))
 
         return candidates
 
@@ -80,8 +75,8 @@ class CandidateSearch(CandidateList):
     @property
     def query(self):
         # Eagerly load principal committees to avoid extra queries
-        return Candidate.query.options(
-            sa.orm.subqueryload(Candidate.principal_committees)
+        return models.Candidate.query.options(
+            sa.orm.subqueryload(models.Candidate.principal_committees)
         )
 
     @args.register_kwargs(args.paging)
@@ -91,7 +86,7 @@ class CandidateSearch(CandidateList):
     @schemas.marshal_with(schemas.CandidateSearchPageSchema())
     def get(self, **kwargs):
         query = self.get_candidates(kwargs)
-        return utils.fetch_page(query, kwargs, model=Candidate)
+        return utils.fetch_page(query, kwargs, model=models.Candidate)
 
 
 @spec.doc(
@@ -110,25 +105,25 @@ class CandidateView(Resource):
     @schemas.marshal_with(schemas.CandidateDetailPageSchema())
     def get(self, candidate_id=None, committee_id=None, **kwargs):
         query = self.get_candidate(kwargs, candidate_id, committee_id)
-        return utils.fetch_page(query, kwargs, model=CandidateDetail)
+        return utils.fetch_page(query, kwargs, model=models.CandidateDetail)
 
     def get_candidate(self, kwargs, candidate_id=None, committee_id=None):
         if candidate_id is not None:
-            candidates = CandidateDetail.query
+            candidates = models.CandidateDetail.query
             candidates = candidates.filter_by(candidate_id=candidate_id)
 
         if committee_id is not None:
-            candidates = CandidateDetail.query.join(
-                CandidateCommitteeLink
+            candidates = models.CandidateDetail.query.join(
+                models.CandidateCommitteeLink
             ).filter(
-                CandidateCommitteeLink.committee_id == committee_id
+                models.CandidateCommitteeLink.committee_id == committee_id
             )
 
-        candidates = filter_query(CandidateDetail, candidates, filter_fields, kwargs)
+        candidates = filter_query(models.CandidateDetail, candidates, filter_fields, kwargs)
 
         # TODO(jmcarp) Reintroduce year filter pending accurate `load_date` and `expire_date` values
         if kwargs['cycle']:
-            candidates = candidates.filter(CandidateDetail.cycles.overlap(kwargs['cycle']))
+            candidates = candidates.filter(models.CandidateDetail.cycles.overlap(kwargs['cycle']))
 
         return candidates
 
@@ -150,7 +145,7 @@ class CandidateHistoryView(Resource):
         return utils.fetch_page(query, kwargs)
 
     def get_candidate(self, candidate_id, cycle, kwargs):
-        query = CandidateHistory.query.filter(CandidateHistory.candidate_id == candidate_id)
+        query = models.CandidateHistory.query.filter(models.CandidateHistory.candidate_id == candidate_id)
         if cycle:
-            query = query.filter(CandidateHistory.two_year_period == cycle)
+            query = query.filter(models.CandidateHistory.two_year_period == cycle)
         return query

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -48,7 +48,7 @@ class CandidateList(Resource):
             candidates = utils.search_text(
                 candidates.join(
                     models.CandidateSearch,
-                    models.Candidate.candidate_key == models.CandidateSearch.cand_sk,
+                    models.Candidate.candidate_id == models.CandidateSearch.id,
                 ),
                 models.CandidateSearch.fulltxt,
                 kwargs['q'],

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -1,5 +1,4 @@
-from sqlalchemy import extract
-from sqlalchemy.sql import text, or_, and_
+import sqlalchemy as sa
 from flask.ext.restful import Resource
 
 from webservices import args
@@ -7,8 +6,8 @@ from webservices import docs
 from webservices import spec
 from webservices import utils
 from webservices import schemas
+from webservices.common import models
 from webservices.common.util import filter_query
-from webservices.common.models import db, Committee, CandidateCommitteeLink, CommitteeDetail, CommitteeHistory
 
 
 list_filter_fields = {'committee_id', 'designation', 'organization_type', 'state', 'party', 'committee_type'}
@@ -17,13 +16,13 @@ detail_filter_fields = {'designation', 'organization_type', 'committee_type'}
 
 def filter_year(model, query, years):
     return query.filter(
-        or_(*[
-            and_(
-                or_(
-                    extract('year', model.last_file_date) >= year,
+        sa.or_(*[
+            sa.and_(
+                sa.or_(
+                    sa.extract('year', model.last_file_date) >= year,
                     model.last_file_date == None,
                 ),
-                extract('year', model.first_file_date) <= year,
+                sa.extract('year', model.first_file_date) <= year,
             )
             for year in years
         ])
@@ -36,13 +35,6 @@ def filter_year(model, query, years):
 )
 class CommitteeList(Resource):
 
-    fulltext_query = '''
-        SELECT cmte_sk
-        FROM   ofec_committee_fulltext_mv
-        WHERE  fulltxt @@ to_tsquery(:findme || ':*')
-        ORDER BY ts_rank_cd(fulltxt, to_tsquery(:findme || ':*')) desc
-    '''
-
     @args.register_kwargs(args.paging)
     @args.register_kwargs(args.committee)
     @args.register_kwargs(args.committee_list)
@@ -54,31 +46,33 @@ class CommitteeList(Resource):
 
     def get_committees(self, kwargs):
 
-        committees = Committee.query
+        committees = models.Committee.query
 
         if kwargs['candidate_id']:
             committees = committees.filter(
-                Committee.candidate_ids.overlap(kwargs['candidate_id'])
+                models.Committee.candidate_ids.overlap(kwargs['candidate_id'])
             )
 
         if kwargs.get('q'):
-            findme = ' & '.join(kwargs['q'].split())
-            committees = committees.filter(
-                Committee.committee_key.in_(
-                    db.session.query('cmte_sk').from_statement(text(self.fulltext_query)).params(findme=findme)
-                )
+            committees = utils.search_text(
+                committees.join(
+                    models.CommitteeSearch,
+                    models.Committee.committee_key == models.CommitteeSearch.cmte_sk,
+                ),
+                models.CommitteeSearch.fulltxt,
+                kwargs['q'],
             )
 
         if kwargs.get('name'):
-            committees = committees.filter(Committee.name.ilike('%{}%'.format(kwargs['name'])))
+            committees = committees.filter(models.Committee.name.ilike('%{}%'.format(kwargs['name'])))
 
-        committees = filter_query(Committee, committees, list_filter_fields, kwargs)
+        committees = filter_query(models.Committee, committees, list_filter_fields, kwargs)
 
         if kwargs['year']:
-            committees = filter_year(Committee, committees, kwargs['year'])
+            committees = filter_year(models.Committee, committees, kwargs['year'])
 
         if kwargs['cycle']:
-            committees = committees.filter(Committee.cycles.overlap(kwargs['cycle']))
+            committees = committees.filter(models.Committee.cycles.overlap(kwargs['cycle']))
 
         return committees
 
@@ -102,25 +96,25 @@ class CommitteeView(Resource):
 
     def get_committee(self, kwargs, committee_id, candidate_id):
 
-        committees = CommitteeDetail.query
+        committees = models.CommitteeDetail.query
 
         if committee_id is not None:
             committees = committees.filter_by(committee_id=committee_id)
 
         if candidate_id is not None:
-            committees = CommitteeDetail.query.join(
-                CandidateCommitteeLink
+            committees = models.CommitteeDetail.query.join(
+                models.CandidateCommitteeLink
             ).filter(
-                CandidateCommitteeLink.candidate_id == candidate_id
+                models.CandidateCommitteeLink.candidate_id == candidate_id
             )
 
-        committees = filter_query(CommitteeDetail, committees, detail_filter_fields, kwargs)
+        committees = filter_query(models.CommitteeDetail, committees, detail_filter_fields, kwargs)
 
         if kwargs['year']:
-            committees = filter_year(CommitteeDetail, committees, kwargs['year'])
+            committees = filter_year(models.CommitteeDetail, committees, kwargs['year'])
 
         if kwargs['cycle']:
-            committees = committees.filter(CommitteeDetail.cycles.overlap(kwargs['cycle']))
+            committees = committees.filter(models.CommitteeDetail.cycles.overlap(kwargs['cycle']))
 
         return committees
 
@@ -143,20 +137,20 @@ class CommitteeHistoryView(Resource):
         return utils.fetch_page(query, kwargs)
 
     def get_committee(self, committee_id, candidate_id, cycle, kwargs):
-        query = CommitteeHistory.query
+        query = models.CommitteeHistory.query
 
         if committee_id:
-            query = query.filter(CommitteeHistory.committee_id == committee_id)
+            query = query.filter(models.CommitteeHistory.committee_id == committee_id)
 
         if candidate_id:
-            query = CommitteeHistory.query.join(
-                CandidateCommitteeLink,
-                CandidateCommitteeLink.committee_key == CommitteeHistory.committee_key,
+            query = models.CommitteeHistory.query.join(
+                models.CandidateCommitteeLink,
+                models.CandidateCommitteeLink.committee_key == models.CommitteeHistory.committee_key,
             ).filter(
-                CandidateCommitteeLink.candidate_id == candidate_id
+                models.CandidateCommitteeLink.candidate_id == candidate_id
             )
 
         if cycle:
-            query = query.filter(CommitteeHistory.cycle == cycle)
+            query = query.filter(models.CommitteeHistory.cycle == cycle)
 
         return query

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -57,7 +57,7 @@ class CommitteeList(Resource):
             committees = utils.search_text(
                 committees.join(
                     models.CommitteeSearch,
-                    models.Committee.committee_key == models.CommitteeSearch.cmte_sk,
+                    models.Committee.committee_id == models.CommitteeSearch.id,
                 ),
                 models.CommitteeSearch.fulltxt,
                 kwargs['q'],

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -104,23 +104,39 @@ class ApiSchema(ma.Schema):
         return ret
 
 
-class NameSearchSchema(ma.Schema):
-    candidate_id = ma.fields.String(attribute='cand_id')
-    committee_id = ma.fields.String(attribute='cmte_id')
+class BaseSearchSchema(ma.Schema):
+    id = ma.fields.String()
     name = ma.fields.String()
+
+
+class CandidateSearchSchema(BaseSearchSchema):
     office_sought = ma.fields.String()
 
 
-class NameSearchListSchema(ApiSchema):
+class CommitteeSearchSchema(BaseSearchSchema):
+    pass
+
+
+class CandidateSearchListSchema(ApiSchema):
     results = ma.fields.Nested(
-        NameSearchSchema,
-        ref='#/definitions/NameSearch',
+        CandidateSearchSchema,
+        ref='#/definitions/CandidateSearch',
         many=True,
     )
 
 
-register_schema(NameSearchSchema)
-register_schema(NameSearchListSchema)
+class CommitteeSearchListSchema(ApiSchema):
+    results = ma.fields.Nested(
+        CandidateSearchSchema,
+        ref='#/definitions/CommtteeSearch',
+        many=True,
+    )
+
+
+register_schema(CandidateSearchSchema)
+register_schema(CandidateSearchListSchema)
+register_schema(CommitteeSearchSchema)
+register_schema(CommitteeSearchListSchema)
 
 
 make_committee_schema = functools.partial(make_schema, options={'exclude': ('idx', 'committee_key')})

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -1,3 +1,5 @@
+import sqlalchemy as sa
+
 from webservices import paging
 from webservices import sorting
 
@@ -13,3 +15,18 @@ def extend(*dicts):
     for each in dicts:
         ret.update(each)
     return ret
+
+
+def search_text(query, column, text):
+    vector = ' & '.join(text.split())
+    vector = sa.func.concat(vector, ':*')
+    return query.filter(
+        column.match(vector)
+    ).order_by(
+        sa.desc(
+            sa.func.ts_rank_cd(
+                column,
+                sa.func.to_tsquery(vector)
+            )
+        )
+    )


### PR DESCRIPTION
Remove name fulltext view.

The name fulltext view is more or less the candidate and committee
fulltext views concatenated together. We don't need to build these rows
twice; the separate candidate and committee fulltext views are adequate
as they are. This patch deletes the combined view and the logic used to
handle the complexities of using a single view to store two different
kinds of rows.

Important: should be merged at the same time as corresponding webapp issue https://github.com/18F/openFEC-web-app/pull/224.