### PR TITLE
Use consistent endpoints for candidate and committee history resources.

### DIFF
--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -155,7 +155,7 @@ class CommitteeHistoryView(Resource):
             query = query.filter(models.CommitteeHistory.committee_id == committee_id)
 
         if candidate_id:
-            query = models.CommitteeHistory.query.join(
+            query = query.join(
                 models.CandidateCommitteeLink,
                 models.CandidateCommitteeLink.committee_key == models.CommitteeHistory.committee_key,
             ).filter(

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -142,8 +142,10 @@ api.add_resource(
 )
 api.add_resource(
     candidates.CandidateHistoryView,
-    '/candidate/<string:candidate_id>/history/<int:cycle>',
     '/candidate/<string:candidate_id>/history',
+    '/candidate/<string:candidate_id>/history/<int:cycle>',
+    '/committee/<string:committee_id>/candidates/history',
+    '/committee/<string:committee_id>/candidates/history/<int:cycle>',
 )
 api.add_resource(committees.CommitteeList, '/committees')
 api.add_resource(
@@ -153,8 +155,8 @@ api.add_resource(
 )
 api.add_resource(
     committees.CommitteeHistoryView,
-    '/committee/<string:committee_id>/history/<int:cycle>',
     '/committee/<string:committee_id>/history',
+    '/committee/<string:committee_id>/history/<int:cycle>',
     '/candidate/<candidate_id>/committees/history',
     '/candidate/<candidate_id>/committees/history/<int:cycle>',
 )


### PR DESCRIPTION
For the webapp (and potentially other consumers of the API), we need to
be able to look up information about nested resources at a particular
time: e.g., information about all of a candidate's associated committees
in the 2011-2012 election cycle. We currently support these nested
history lookups for committee history, but not for candidate history,
exposing an edge case on the webapp where we can occasionally show the
wrong information for a candidate on her/his committee page. This patch
adds consistent endpoints for nested history resources.