### PR TITLE
Add caching headers from environment.

### DIFF
--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -8,3 +8,4 @@ env:
   PRODUCTION: True
   NEW_RELIC_APP_NAME: OpenFEC API (production)
   NEW_RELIC_ENV: development
+  FEC_CACHE_AGE: 3600

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -80,10 +80,18 @@ def limit_remote_addr():
 
 
 @app.after_request
-def after_request(response):
+def add_cors_headers(response):
     response.headers.add('Access-Control-Allow-Origin', '*')
     response.headers.add('Access-Control-Allow-Methods', 'GET')
     response.headers.add('Access-Control-Max-Age', '3000')
+    return response
+
+
+@app.after_request
+def add_caching_headers(response):
+    max_age = os.getenv('FEC_CACHE_AGE')
+    if max_age is not None:
+        response.headers.add('Cache-Control', 'public, max-age={}'.format(max_age))
     return response
 
 


### PR DESCRIPTION
Necessary to get caching through api.data.gov. Prerequisite to #889.

See http://apiumbrella.io/docs/caching/ for more information.