### PR TITLE
Direct swagger-ui to combine query arguments correctly.

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -5,7 +5,6 @@ from smore import swagger
 from flask.ext.restful import abort
 
 import webargs
-from webargs import Arg
 from webargs.core import text_type
 from webargs.flaskparser import FlaskParser
 
@@ -13,6 +12,9 @@ from webservices import docs
 
 
 logger = logging.getLogger(__name__)
+
+
+Arg = functools.partial(webargs.Arg, collectionFormat='multi')
 
 
 class FlaskRestParser(FlaskParser):


### PR DESCRIPTION
Since all of our request parsing assumes that list parameters are repeated (e.g. `foo=bar&foo=baz`), set `collectionFormat='multi'` as the default on the `Arg` constructor.

This is at least a partial fix to #980; not sure if anything else needs to happen here.