### PR TITLE
order candidate records to get the most recent

### DIFF
--- a/data/sql_updates/create_candidate_history_view.sql
+++ b/data/sql_updates/create_candidate_history_view.sql
@@ -85,7 +85,8 @@ order by
     cycle desc,
     dcp.election_yr desc,
     dsi.election_yr desc,
-    co.cand_election_yr desc
+    co.cand_election_yr desc,
+    dcp.form_sk desc
 ;
 
 create unique index on ofec_candidate_history_mv_tmp(idx);


### PR DESCRIPTION
Using report key as a proxy for when the report was received. Would like to use receipt date in the future. Fixes #987