### PR TITLE
Feature/ie totals

### DIFF
--- a/data/sql_updates/crate_totals_ie_only_view.sql
+++ b/data/sql_updates/crate_totals_ie_only_view.sql
@@ -1,0 +1,25 @@
+drop materialized view if exists ofec_totals_ie_only_mv_tmp;
+create materialized view ofec_totals_ie_only_mv_tmp as
+select
+    row_number() over () as idx,
+    cmte_id as committee_id,
+    two_yr_period_sk as cycle,
+    min(start_date.dw_date) as coverage_start_date,
+    max(end_date.dw_date) as coverage_end_date,
+    sum(ttl_indt_contb) as total_independent_contributions,
+    sum(ttl_indt_exp) as total_independent_expenditures
+from
+    dimcmte c
+    inner join factindpexpcontb_f5 ief5 on indv_org_sk = c.cmte_sk
+    left join dimdates start_date on cvg_start_dt_sk = start_date.date_sk and cvg_start_dt_sk != 1
+    left join dimdates end_date on cvg_end_dt_sk = end_date.date_sk and cvg_end_dt_sk != 1
+where
+    two_yr_period_sk >= :START_YEAR
+    and ief5.expire_date is null
+group by committee_id, cycle
+;
+
+create unique index on ofec_totals_ie_only_mv_tmp(idx);
+
+create index on ofec_totals_ie_only_mv_tmp(cycle);
+create index on ofec_totals_ie_only_mv_tmp(committee_id);

--- a/tests/committee_tests.py
+++ b/tests/committee_tests.py
@@ -14,6 +14,7 @@ from webservices.rest import api
 from webservices.resources.committees import CommitteeList
 from webservices.resources.committees import CommitteeView
 from webservices.resources.candidates import CandidateView
+from webservices.resources.totals import TotalsView
 
 
 ## old, re-factored Committee tests ##

--- a/tests/common.py
+++ b/tests/common.py
@@ -22,6 +22,7 @@ class BaseTestCase(unittest.TestCase):
     def setUpClass(cls):
         rest.app.config['TESTING'] = True
         rest.app.config['SQLALCHEMY_DATABASE_URI'] = TEST_CONN
+        rest.app.config['PRESERVE_CONTEXT_ON_EXCEPTION'] = False
         cls.app = rest.app.test_client()
         cls.app_context = rest.app.app_context()
         cls.app_context.push()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -89,6 +89,10 @@ class TotalsPacPartyFactory(BaseTotalsFactory):
     class Meta:
         model = models.CommitteeTotalsPacParty
 
+class TotalsIEOnlyFactory(BaseFactory):
+    class Meta:
+        model = models.CommitteeTotalsIEOnly
+
 
 class BaseReportsFactory(BaseFactory):
     committee_id = factory.LazyAttribute(lambda o: CommitteeFactory().committee_id)

--- a/tests/totals_tests.py
+++ b/tests/totals_tests.py
@@ -152,20 +152,24 @@ class TestTotals(ApiBaseTest):
 
 
 
-    # def test_ie_totals(self):
-    #     committee_id = 'C8675312'
-    #     ie_fields = {
-    #         'committee_id': committee_id,
-    #         'cycle': 2014,
-    #         # 'coverage_start_date': None,
-    #         # 'coverage_end_date': None,
-    #         'total_independent_contributions': 1,
-    #         'total_independent_expenditures': 2,
-    #     }
+    def test_ie_totals(self):
+        committee_id = 'C8675312'
+        history = factories.CommitteeHistoryFactory(
+            committee_id=committee_id,
+            committee_type='I',
+        )
+        ie_fields = {
+            'committee_id': committee_id,
+            'cycle': 2014,
+            'coverage_start_date': None,
+            'coverage_end_date': None,
+            'total_independent_contributions': 1,
+            'total_independent_expenditures': 2,
+        }
 
-    #     committee_total = factories.TotalsIEOnlyFactory(
-    #         **ie_fields
-    #     )
-    #     results = self._results(api.url_for(TotalsView, committee_id=committee_id))
+        committee_total = factories.TotalsIEOnlyFactory(
+            **ie_fields
+        )
+        results = self._results(api.url_for(TotalsView, committee_id=committee_id))
 
-    #     self.assertEqual(results[0], fields)
+        self.assertEqual(results[0], ie_fields)

--- a/tests/totals_tests.py
+++ b/tests/totals_tests.py
@@ -151,18 +151,21 @@ class TestTotals(ApiBaseTest):
         self.assertEqual(results[0], fields)
 
 
-# not working
+
     # def test_ie_totals(self):
-    #     committee_id = 'C8675310'
-    #     ie_total = factories.TotalsIEOnlyFactory(
-    #         committee_id=committee_id,
-    #         cycle =2014,
-    #         coverage_start_date=isoformat(datetime.datetime(2014, 1, 1)),
-    #         coverage_end_date=isoformat(datetime.datetime(2014, 3, 31)),
-    #         total_independent_contributions=300,
-    #         total_independent_expenditures=20,
+    #     committee_id = 'C8675312'
+    #     ie_fields = {
+    #         'committee_id': committee_id,
+    #         'cycle': 2014,
+    #         # 'coverage_start_date': None,
+    #         # 'coverage_end_date': None,
+    #         'total_independent_contributions': 1,
+    #         'total_independent_expenditures': 2,
+    #     }
+
+    #     committee_total = factories.TotalsIEOnlyFactory(
+    #         **ie_fields
     #     )
     #     results = self._results(api.url_for(TotalsView, committee_id=committee_id))
-    #     self.assertTrue(results, ie_total)
 
-
+    #     self.assertEqual(results[0], fields)

--- a/tests/totals_tests.py
+++ b/tests/totals_tests.py
@@ -9,15 +9,34 @@ from webservices.rest import db
 from webservices.rest import api
 from webservices.resources.totals import TotalsView
 
+def merge_dicts(x, y):
+    z = x.copy()
+    z.update(y)
+    return z
+
+shared_fields =  {
+    'offsets_to_operating_expenditures': 112,
+    'political_party_committee_contributions': 113,
+    'other_disbursements': 114,
+    'other_political_committee_contributions': 115,
+    'individual_itemized_contributions': 116,
+    'individual_unitemized_contributions': 117,
+    'operating_expenditures': 118,
+    'disbursements': 119,
+    'contributions': 120,
+    'contribution_refunds': 121,
+    'individual_contributions': 122,
+    'refunded_individual_contributions': 123,
+    'refunded_other_political_committee_contributions': 124,
+    'refunded_political_party_committee_contributions': 125,
+    'receipts': 126,
+    'coverage_start_date': None,
+    'coverage_end_date': None,
+    'net_contributions': 127,
+    'net_operating_expenditures': 128,
+}
 
 class TestTotals(ApiBaseTest):
-
-    def _check_committee_ids(self, results, positives=None, negatives=None):
-        ids = [each['committee_id'] for each in results]
-        for positive in (positives or []):
-            self.assertIn(positive.committee_id, ids)
-        for negative in (negatives or []):
-            self.assertNotIn(negative.committee_id, ids)
 
     def test_Presidential_totals(self):
         committee_id = 'C8675309'
@@ -25,29 +44,36 @@ class TestTotals(ApiBaseTest):
             committee_id=committee_id,
             committee_type='P',
         )
+        presidential_fields = {
+            'committee_id': 'C8675309',
+            'cycle': 2016,
+            'candidate_contribution': 1,
+            'exempt_legal_accounting_disbursement': 2,
+            'federal_funds': 3,
+            'fundraising_disbursements': 4,
+            'loan_repayments_made': 16,
+            'loans_received': 5,
+            'loans_received_from_candidate': 6,
+            'offsets_to_fundraising_expenditures': 7,
+            'offsets_to_legal_accounting': 8,
+            'total_offsets_to_operating_expenditures': 9,
+            'other_loans_received': 10,
+            'other_receipts': 11,
+            'repayments_loans_made_by_candidate': 12,
+            'repayments_other_loans': 13,
+            'transfers_from_affiliated_committee': 14,
+            'transfers_to_other_authorized_committee': 15,
+
+        }
+
+        fields = merge_dicts(shared_fields, presidential_fields)
+
         committee_total = factories.TotalsPresidentialFactory(
-            committee_id=committee_id,
-            cycle =2016,
-            # fields unique to presidential
-            candidate_contribution = 1,
-            exempt_legal_accounting_disbursement = 2,
-            federal_funds = 3,
-            fundraising_disbursements = 4,
-            loan_repayments_made = 16,
-            loans_received = 5,
-            loans_received_from_candidate = 6,
-            offsets_to_fundraising_expenditures = 7,
-            offsets_to_legal_accounting = 8,
-            total_offsets_to_operating_expenditures = 9,
-            other_loans_received = 10,
-            other_receipts = 11,
-            repayments_loans_made_by_candidate = 12,
-            repayments_other_loans = 13,
-            transfers_from_affiliated_committee = 14,
-            transfers_to_other_authorized_committee = 15,
+            **fields
         )
         results = self._results(api.url_for(TotalsView, committee_id=committee_id))
-        self._check_committee_ids(results, [committee_total])
+
+        self.assertEqual(results[0], fields)
 
     def test_House_Senate_totals(self):
         committee_id = 'C8675310'
@@ -55,23 +81,30 @@ class TestTotals(ApiBaseTest):
             committee_id=committee_id,
             committee_type='S',
         )
+
+        house_senate_fields = {
+            'committee_id': committee_id,
+            'cycle': 2016,
+            'all_other_loans': 1,
+            'candidate_contribution': 2,
+            'loan_repayments': 3,
+            'loan_repayments_candidate_loans': 4,
+            'loan_repayments_other_loans': 5,
+            'loans': 6,
+            'loans_made_by_candidate': 7,
+            'other_receipts': 8,
+            'transfers_from_other_authorized_committee': 9,
+            'transfers_to_other_authorized_committee': 10,
+        }
+        fields = merge_dicts(house_senate_fields, shared_fields)
+
         committee_total = factories.TotalsHouseSenateFactory(
-            committee_id=committee_id,
-            cycle =2016,
-            # fields unique to House and Senate
-            all_other_loans = 1,
-            candidate_contribution = 2,
-            loan_repayments = 3,
-            loan_repayments_candidate_loans = 4,
-            loan_repayments_other_loans = 5,
-            loans = 6,
-            loans_made_by_candidate = 7,
-            other_receipts = 8,
-            transfers_from_other_authorized_committee = 9,
-            transfers_to_other_authorized_committee = 10,
+            **fields
         )
         results = self._results(api.url_for(TotalsView, committee_id=committee_id))
-        self._check_committee_ids(results, [committee_total])
+
+        self.assertEqual(results[0], fields)
+
 
     def test_Pac_Party_totals(self):
         committee_id = 'C8675311'
@@ -79,39 +112,57 @@ class TestTotals(ApiBaseTest):
             committee_id=committee_id,
             committee_type='Q',
         )
+        pac_party_fields = {
+            'committee_id': committee_id,
+            'cycle': 2016,
+            'all_loans_received': 1,
+            'allocated_federal_election_levin_share': 2,
+            'coordinated_expenditures_by_party_committee': 3,
+            'fed_candidate_committee_contributions': 4,
+            'fed_candidate_contribution_refunds': 5,
+            'fed_disbursements': 6,
+            'fed_election_activity': 7,
+            'fed_operating_expenditures': 8,
+            'fed_receipts': 9,
+            'independent_expenditures': 10,
+            'loan_repayments_made': 11,
+            'loan_repayments_received': 12,
+            'loans_made': 13,
+            'non_allocated_fed_election_activity': 14,
+            'nonfed_transfers': 15,
+            'other_fed_operating_expenditures': 16,
+            'other_fed_receipts': 17,
+            'shared_fed_activity': 18,
+            'shared_fed_activity_nonfed': 19,
+            'shared_fed_operating_expenditures': 20,
+            'shared_nonfed_operating_expenditures': 21,
+            'transfers_from_affiliated_party': 22,
+            'transfers_from_nonfed_account': 23,
+            'transfers_from_nonfed_levin': 24,
+            'transfers_to_affiliated_committee': 25,
+        }
+        fields = merge_dicts(pac_party_fields, shared_fields)
+
         committee_total = factories.TotalsPacPartyFactory(
-            committee_id=committee_id,
-            cycle =2016,
-            # fields unique to PACs and Parties
-            all_loans_received = 1,
-            allocated_federal_election_levin_share = 2,
-            coordinated_expenditures_by_party_committee = 3,
-            fed_candidate_committee_contributions = 4,
-            fed_candidate_contribution_refunds = 5,
-            fed_disbursements = 6,
-            fed_election_activity = 7,
-            fed_operating_expenditures = 8,
-            fed_receipts = 9,
-            independent_expenditures = 10,
-            loan_repayments_made = 11,
-            loan_repayments_received = 12,
-            loans_made = 13,
-            non_allocated_fed_election_activity = 14,
-            nonfed_transfers = 15,
-            other_fed_operating_expenditures = 16,
-            other_fed_receipts = 17,
-            shared_fed_activity = 18,
-            shared_fed_activity_nonfed = 19,
-            shared_fed_operating_expenditures = 20,
-            shared_nonfed_operating_expenditures = 21,
-            transfers_from_affiliated_party = 22,
-            transfers_from_nonfed_account = 23,
-            transfers_from_nonfed_levin = 24,
-            transfers_to_affiliated_committee = 25,
+            **fields
         )
         results = self._results(api.url_for(TotalsView, committee_id=committee_id))
-        self._check_committee_ids(results, [committee_total])
+
+        self.assertEqual(results[0], fields)
 
 
+# not working
+    # def test_ie_totals(self):
+    #     committee_id = 'C8675310'
+    #     ie_total = factories.TotalsIEOnlyFactory(
+    #         committee_id=committee_id,
+    #         cycle =2014,
+    #         coverage_start_date=isoformat(datetime.datetime(2014, 1, 1)),
+    #         coverage_end_date=isoformat(datetime.datetime(2014, 3, 31)),
+    #         total_independent_contributions=300,
+    #         total_independent_expenditures=20,
+    #     )
+    #     results = self._results(api.url_for(TotalsView, committee_id=committee_id))
+    #     self.assertTrue(results, ie_total)
 
 

--- a/tests/totals_tests.py
+++ b/tests/totals_tests.py
@@ -1,0 +1,117 @@
+import datetime
+
+from marshmallow.utils import isoformat
+
+from .common import ApiBaseTest
+from tests import factories
+
+from webservices.rest import db
+from webservices.rest import api
+from webservices.resources.totals import TotalsView
+
+
+class TestTotals(ApiBaseTest):
+
+    def _check_committee_ids(self, results, positives=None, negatives=None):
+        ids = [each['committee_id'] for each in results]
+        for positive in (positives or []):
+            self.assertIn(positive.committee_id, ids)
+        for negative in (negatives or []):
+            self.assertNotIn(negative.committee_id, ids)
+
+    def test_Presidential_totals(self):
+        committee_id = 'C8675309'
+        history = factories.CommitteeHistoryFactory(
+            committee_id=committee_id,
+            committee_type='P',
+        )
+        committee_total = factories.TotalsPresidentialFactory(
+            committee_id=committee_id,
+            cycle =2016,
+            # fields unique to presidential
+            candidate_contribution = 1,
+            exempt_legal_accounting_disbursement = 2,
+            federal_funds = 3,
+            fundraising_disbursements = 4,
+            loan_repayments_made = 16,
+            loans_received = 5,
+            loans_received_from_candidate = 6,
+            offsets_to_fundraising_expenditures = 7,
+            offsets_to_legal_accounting = 8,
+            total_offsets_to_operating_expenditures = 9,
+            other_loans_received = 10,
+            other_receipts = 11,
+            repayments_loans_made_by_candidate = 12,
+            repayments_other_loans = 13,
+            transfers_from_affiliated_committee = 14,
+            transfers_to_other_authorized_committee = 15,
+        )
+        results = self._results(api.url_for(TotalsView, committee_id=committee_id))
+        self._check_committee_ids(results, [committee_total])
+
+    def test_House_Senate_totals(self):
+        committee_id = 'C8675310'
+        history = factories.CommitteeHistoryFactory(
+            committee_id=committee_id,
+            committee_type='S',
+        )
+        committee_total = factories.TotalsHouseSenateFactory(
+            committee_id=committee_id,
+            cycle =2016,
+            # fields unique to House and Senate
+            all_other_loans = 1,
+            candidate_contribution = 2,
+            loan_repayments = 3,
+            loan_repayments_candidate_loans = 4,
+            loan_repayments_other_loans = 5,
+            loans = 6,
+            loans_made_by_candidate = 7,
+            other_receipts = 8,
+            transfers_from_other_authorized_committee = 9,
+            transfers_to_other_authorized_committee = 10,
+        )
+        results = self._results(api.url_for(TotalsView, committee_id=committee_id))
+        self._check_committee_ids(results, [committee_total])
+
+    def test_Pac_Party_totals(self):
+        committee_id = 'C8675311'
+        history = factories.CommitteeHistoryFactory(
+            committee_id=committee_id,
+            committee_type='Q',
+        )
+        committee_total = factories.TotalsPacPartyFactory(
+            committee_id=committee_id,
+            cycle =2016,
+            # fields unique to PACs and Parties
+            all_loans_received = 1,
+            allocated_federal_election_levin_share = 2,
+            coordinated_expenditures_by_party_committee = 3,
+            fed_candidate_committee_contributions = 4,
+            fed_candidate_contribution_refunds = 5,
+            fed_disbursements = 6,
+            fed_election_activity = 7,
+            fed_operating_expenditures = 8,
+            fed_receipts = 9,
+            independent_expenditures = 10,
+            loan_repayments_made = 11,
+            loan_repayments_received = 12,
+            loans_made = 13,
+            non_allocated_fed_election_activity = 14,
+            nonfed_transfers = 15,
+            other_fed_operating_expenditures = 16,
+            other_fed_receipts = 17,
+            shared_fed_activity = 18,
+            shared_fed_activity_nonfed = 19,
+            shared_fed_operating_expenditures = 20,
+            shared_nonfed_operating_expenditures = 21,
+            transfers_from_affiliated_party = 22,
+            transfers_from_nonfed_account = 23,
+            transfers_from_nonfed_levin = 24,
+            transfers_to_affiliated_committee = 25,
+        )
+        results = self._results(api.url_for(TotalsView, committee_id=committee_id))
+        self._check_committee_ids(results, [committee_total])
+
+
+
+

--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -556,3 +556,15 @@ class CommitteeTotalsHouseSenate(CommitteeTotals):
     other_receipts = db.Column(db.Integer)
     transfers_from_other_authorized_committee = db.Column(db.Integer)
     transfers_to_other_authorized_committee = db.Column(db.Integer)
+
+
+class CommitteeTotalsIEOnly(BaseModel):
+    __tablename__ = 'ofec_totals_ie_only_mv'
+
+    committee_id = db.Column(db.String)
+    cycle = db.Column(db.Integer)
+    coverage_start_date = db.Column(db.DateTime)
+    coverage_end_date = db.Column(db.DateTime)
+    total_independent_contributions = db.Column(db.Integer)
+    total_independent_expenditures = db.Column(db.Integer)
+

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -13,6 +13,8 @@ totals_schema_map = {
     'P': (models.CommitteeTotalsPresidential, schemas.CommitteeTotalsPresidentialPageSchema),
     'H': (models.CommitteeTotalsHouseSenate, schemas.CommitteeTotalsHouseSenatePageSchema),
     'S': (models.CommitteeTotalsHouseSenate, schemas.CommitteeTotalsHouseSenatePageSchema),
+    'I': (models.CommitteeTotalsIEOnly, schemas.
+        CommitteeTotalsIEOnlyPageSchema)
 }
 default_schemas = (models.CommitteeTotalsPacParty, schemas.CommitteeTotalsPacPartyPageSchema)
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -233,3 +233,8 @@ CommitteeTotalsPacPartyPageSchema = make_page_schema(CommitteeTotalsPacPartySche
 
 register_schema(CommitteeTotalsSchema)
 register_schema(CommitteeTotalsPageSchema)
+
+CommitteeTotalsIEOnlySchema = make_schema(
+    models.CommitteeTotalsIEOnly,
+)
+CommitteeTotalsIEOnlyPageSchema =make_page_schema(CommitteeTotalsIEOnlySchema)


### PR DESCRIPTION
Totals for the form 5-only filers. 

Also added tests for all the totals endpoints.

['PRESERVE_CONTEXT_ON_EXCEPTION' = False](https://github.com/18F/openFEC/compare/feature/ie-totals?expand=1#diff-572606b9b77c96a18b4bf3eefabc6b25R25) makes debugging better. Just wanted to make sure if there was a reason we were not using it before

[fixes #938]