### PR TITLE
Upgrade to current CF stack.

### DIFF
--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -1,7 +1,7 @@
 ---
 path: .
 memory: 512M
-stack: lucid64
+stack: cflinuxfs2
 buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
 env:
   NEW_RELIC_CONFIG_FILE: newrelic.ini


### PR DESCRIPTION
Necessary to prevent buildpack compilation failures. Based on https://github.com/18F/foia-hub/pull/830.