### PR TITLE
Feature/combined receipts by size

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -28,24 +28,15 @@ app.conf.update(
             'task': 'cron.refresh',
             'schedule': crontab(minute=0, hour=0),
         },
-        'update_aggregates': {
-            'task': 'cron.update_aggregates',
-            'schedule': crontab(minute=0, hour=0),
-        },
     }
 )
-
-
-@app.task
-def refresh():
-    with manage.app.test_request_context():
-        manage.refresh_materialized()
 
 
 @app.task
 def update_aggregates():
     with manage.app.test_request_context():
         manage.update_aggregates()
+        manage.refresh_materialized()
 
 
 if __name__ == '__main__':

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
@@ -1,9 +1,10 @@
 create or replace function contribution_size(value numeric) returns int as $$
 begin
     return case
-        when value < 500 then 200
-        when value < 1000 then 500
-        when value < 2000 then 1000
+        when abs(value) < 200 then 0
+        when abs(value) < 500 then 200
+        when abs(value) < 1000 then 500
+        when abs(value) < 2000 then 1000
         else 2000
     end;
 end
@@ -20,7 +21,6 @@ select
     count(contb_receipt_amt) as count
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
-and contb_receipt_amt > 200
 group by cmte_id, cycle, size
 ;
 

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
@@ -21,6 +21,7 @@ select
     count(contb_receipt_amt) as count
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
+and contb_receipt_amt is not null
 group by cmte_id, cycle, size
 ;
 
@@ -42,6 +43,7 @@ begin
             sum(contb_receipt_amt) as total,
             count(contb_receipt_amt) as count
         from ofec_sched_a_queue_new
+        where contb_receipt_amt is not null
         group by cmte_id, cycle, size
     ),
     old as (
@@ -52,6 +54,7 @@ begin
             -1 * sum(contb_receipt_amt) as total,
             -1 * count(contb_receipt_amt) as count
         from ofec_sched_a_queue_old
+        where contb_receipt_amt is not null
         group by cmte_id, cycle, size
     ),
     patch as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_state.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_state.sql
@@ -8,6 +8,7 @@ select
     count(contb_receipt_amt) as count
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
+and contb_receipt_amt is not null
 group by cmte_id, cycle, state
 ;
 
@@ -28,6 +29,7 @@ begin
             sum(contb_receipt_amt) as total,
             count(contb_receipt_amt) as count
         from ofec_sched_a_queue_new
+        where contb_receipt_amt is not null
         group by cmte_id, cycle, state
     ),
     old as (
@@ -38,6 +40,7 @@ begin
             -1 * sum(contb_receipt_amt) as total,
             -1 * count(contb_receipt_amt) as count
         from ofec_sched_a_queue_old
+        where contb_receipt_amt is not null
         group by cmte_id, cycle, state
     ),
     patch as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_zip.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_zip.sql
@@ -9,6 +9,7 @@ select
     count(contb_receipt_amt) as count
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
+and contb_receipt_amt is not null
 group by cmte_id, cycle, zip
 ;
 
@@ -30,6 +31,7 @@ begin
             sum(contb_receipt_amt) as total,
             count(contb_receipt_amt) as count
         from ofec_sched_a_queue_new
+        where contb_receipt_amt is not null
         group by cmte_id, cycle, zip
     ),
     old as (
@@ -40,6 +42,7 @@ begin
             -1 * sum(contb_receipt_amt) as total,
             -1 * count(contb_receipt_amt) as count
         from ofec_sched_a_queue_old
+        where contb_receipt_amt is not null
         group by cmte_id, cycle, zip
     ),
     patch as (

--- a/data/sql_setup/prepare_schedule_a.sql
+++ b/data/sql_setup/prepare_schedule_a.sql
@@ -40,36 +40,38 @@ create table ofec_sched_a_queue_old as select * from sched_a limit 0;
 
 -- Create trigger to maintain Schedule A queues
 create or replace function ofec_sched_a_update_queues() returns trigger as $$
+declare
+    start_year int = TG_ARGV[0]::int;
 begin
-  if tg_op = 'INSERT' then
-    if new.rpt_yr >= :START_YEAR_ITEMIZED then
-      insert into ofec_sched_a_queue_new
-      values (new.*)
-      ;
+    if tg_op = 'INSERT' then
+        if new.rpt_yr >= start_year then
+            insert into ofec_sched_a_queue_new
+            values (new.*)
+            ;
+        end if;
+        return new;
+    elsif tg_op = 'UPDATE' then
+        if new.rpt_yr >= start_year then
+            insert into ofec_sched_a_queue_new
+            values (new.*)
+            ;
+            insert into ofec_sched_a_queue_old
+            values (old.*)
+            ;
+        end if;
+        return new;
+    elsif tg_op = 'DELETE' then
+        if old.rpt_yr >= start_year then
+            insert into ofec_sched_a_queue_old
+            values (old.*)
+            ;
+        end if;
+        return old;
     end if;
-    return new;
-  elsif tg_op = 'UPDATE' then
-    if new.rpt_yr >= :START_YEAR_ITEMIZED then
-      insert into ofec_sched_a_queue_new
-      values (new.*)
-      ;
-      insert into ofec_sched_a_queue_old
-      values (old.*)
-      ;
-    end if;
-    return new;
-  elsif tg_op = 'DELETE' then
-    if old.rpt_yr >= :START_YEAR_ITEMIZED then
-      insert into ofec_sched_a_queue_old
-      values (old.*)
-      ;
-    end if;
-    return old;
-  end if;
 end
 $$ language plpgsql;
 
 drop trigger if exists ofec_sched_a_queue_trigger on sched_a;
 create trigger ofec_sched_a_queue_trigger before insert or update or delete
-    on sched_a for each row execute procedure ofec_sched_a_update_queues()
+    on sched_a for each row execute procedure ofec_sched_a_update_queues(:START_YEAR_ITEMIZED)
 ;

--- a/data/sql_updates/post_committees_create_filings_view.sql
+++ b/data/sql_updates/post_committees_create_filings_view.sql
@@ -49,12 +49,14 @@ where
     report_year >= :START_YEAR
 ;
 
-create index on public.ofec_filings_vw_tmp(committee_id);
-create index on public.ofec_filings_vw_tmp(candidate_id);
-create index on public.ofec_filings_vw_tmp(beginning_image_number);
-create index on public.ofec_filings_vw_tmp(receipt_date);
-create index on public.ofec_filings_vw_tmp(form_type);
-create index on public.ofec_filings_vw_tmp(primary_general_indicator);
-create index on public.ofec_filings_vw_tmp(amendment_indicator);
-create index on public.ofec_filings_vw_tmp(report_type);
-create index on public.ofec_filings_vw_tmp(report_year);
+create unique index on ofec_filings_vw_tmp (idx);
+
+create index on ofec_filings_vw_tmp (committee_id);
+create index on ofec_filings_vw_tmp (candidate_id);
+create index on ofec_filings_vw_tmp (beginning_image_number);
+create index on ofec_filings_vw_tmp (receipt_date);
+create index on ofec_filings_vw_tmp (form_type);
+create index on ofec_filings_vw_tmp (primary_general_indicator);
+create index on ofec_filings_vw_tmp (amendment_indicator);
+create index on ofec_filings_vw_tmp (report_type);
+create index on ofec_filings_vw_tmp (report_year);

--- a/data/sql_updates/post_totals_create_totals_unitemized.sql
+++ b/data/sql_updates/post_totals_create_totals_unitemized.sql
@@ -1,6 +1,6 @@
 -- Merge aggregated Schedule A receipts with committee totals views
-drop materialized view if exists ofec_sched_a_aggregate_size_merged_tmp;
-create materialized view ofec_sched_a_aggregate_size_merged_tmp as
+drop materialized view if exists ofec_sched_a_aggregate_size_merged_mv_tmp;
+create materialized view ofec_sched_a_aggregate_size_merged_mv_tmp as
 with grouped as (
     select
         committee_id as cmte_id,
@@ -9,7 +9,7 @@ with grouped as (
         individual_unitemized_contributions as total,
         0 as count
     from ofec_totals_pacs_parties_mv_tmp
-    where cycle >= 2011
+    where cycle >= :START_YEAR_ITEMIZED
     union all
     select
         committee_id as cmte_id,
@@ -18,7 +18,7 @@ with grouped as (
         individual_unitemized_contributions as total,
         0 as count
     from ofec_totals_presidential_mv_tmp
-    where cycle >= 2011
+    where cycle >= :START_YEAR_ITEMIZED
     union all
     select
         committee_id as cmte_id,
@@ -27,7 +27,7 @@ with grouped as (
         individual_unitemized_contributions as total,
         0 as count
     from ofec_totals_house_senate_mv_tmp
-    where cycle >= 2011
+    where cycle >= :START_YEAR_ITEMIZED
     union all
     select *
     from ofec_sched_a_aggregate_size
@@ -46,10 +46,10 @@ from grouped
 group by cmte_id, cycle, size
 ;
 
-create unique index on ofec_sched_a_aggregate_size_merged_tmp (idx);
+create unique index on ofec_sched_a_aggregate_size_merged_mv_tmp (idx);
 
-create index on ofec_sched_a_aggregate_size_merged_tmp (cmte_id);
-create index on ofec_sched_a_aggregate_size_merged_tmp (cycle);
-create index on ofec_sched_a_aggregate_size_merged_tmp (size);
-create index on ofec_sched_a_aggregate_size_merged_tmp (total);
-create index on ofec_sched_a_aggregate_size_merged_tmp (count);
+create index on ofec_sched_a_aggregate_size_merged_mv_tmp (cmte_id);
+create index on ofec_sched_a_aggregate_size_merged_mv_tmp (cycle);
+create index on ofec_sched_a_aggregate_size_merged_mv_tmp (size);
+create index on ofec_sched_a_aggregate_size_merged_mv_tmp (total);
+create index on ofec_sched_a_aggregate_size_merged_mv_tmp (count);

--- a/data/sql_updates/post_totals_create_totals_unitemized.sql
+++ b/data/sql_updates/post_totals_create_totals_unitemized.sql
@@ -1,0 +1,55 @@
+-- Merge aggregated Schedule A receipts with committee totals views
+drop materialized view if exists ofec_sched_a_aggregate_size_merged_tmp;
+create materialized view ofec_sched_a_aggregate_size_merged_tmp as
+with grouped as (
+    select
+        committee_id as cmte_id,
+        cycle as cycle,
+        0 as size,
+        individual_unitemized_contributions as total,
+        0 as count
+    from ofec_totals_pacs_parties_mv_tmp
+    where cycle >= 2011
+    union all
+    select
+        committee_id as cmte_id,
+        cycle as cycle,
+        0 as size,
+        individual_unitemized_contributions as total,
+        0 as count
+    from ofec_totals_presidential_mv_tmp
+    where cycle >= 2011
+    union all
+    select
+        committee_id as cmte_id,
+        cycle as cycle,
+        0 as size,
+        individual_unitemized_contributions as total,
+        0 as count
+    from ofec_totals_house_senate_mv_tmp
+    where cycle >= 2011
+    union all
+    select *
+    from ofec_sched_a_aggregate_size
+)
+select
+    row_number() over () as idx,
+    cmte_id,
+    cycle,
+    size,
+    sum(total) as total,
+    case
+        when size = 0 then null
+        else sum(count)
+    end as count
+from grouped
+group by cmte_id, cycle, size
+;
+
+create unique index on ofec_sched_a_aggregate_size_merged_tmp (idx);
+
+create index on ofec_sched_a_aggregate_size_merged_tmp (cmte_id);
+create index on ofec_sched_a_aggregate_size_merged_tmp (cycle);
+create index on ofec_sched_a_aggregate_size_merged_tmp (size);
+create index on ofec_sched_a_aggregate_size_merged_tmp (total);
+create index on ofec_sched_a_aggregate_size_merged_tmp (count);

--- a/manage.py
+++ b/manage.py
@@ -74,10 +74,14 @@ def update_schemas(processes=2):
     print("Starting DB refresh...")
     processes = int(processes)
     load_pacronyms()
-    execute_sql_folder('data/functions/', processes=processes)
     execute_sql_folder('data/sql_updates/', processes=processes)
     execute_sql_file('data/rename_temporary_views.sql')
     print("Finished DB refresh.")
+
+
+@manager.command
+def update_functions(processes=2):
+    execute_sql_folder('data/functions/', processes=processes)
 
 
 @manager.command

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -46,10 +46,11 @@ class TestViews(common.IntegrationTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestViews, cls).setUpClass()
-        manage.update_schemas(processes=1)
+        manage.update_functions(processes=1)
         manage.update_schedule_a()
         manage.update_schedule_b()
         manage.update_aggregates(processes=1)
+        manage.update_schemas(processes=1)
 
     def test_update_schemas(self):
         for model in db.Model._decl_class_registry.values():
@@ -263,6 +264,7 @@ class TestViews(common.IntegrationTestCase):
         )
         db.session.flush()
         db.session.execute('select update_aggregates()')
+        db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged')
         rows = models.ScheduleABySize.query.filter_by(
             cycle=2016,
             committee_id='C12345',
@@ -275,6 +277,7 @@ class TestViews(common.IntegrationTestCase):
         db.session.add(filing)
         db.session.flush()
         db.session.execute('select update_aggregates()')
+        db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged')
         db.session.refresh(rows[0])
         self.assertEqual(rows[0].total, 0)
         self.assertEqual(rows[0].count, 0)
@@ -293,6 +296,44 @@ class TestViews(common.IntegrationTestCase):
         )
         db.session.flush()
         db.session.execute('select update_aggregates()')
+        db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged')
         db.session.refresh(existing)
         self.assertEqual(existing.total, total + 538)
         self.assertEqual(existing.count, count + 1)
+
+    def test_update_aggregate_size_existing_merged(self):
+        existing = models.ScheduleABySize.query.filter_by(
+            size=0,
+            cycle=2016,
+        ).first()
+        total = existing.total
+        factories.ScheduleAFactory(
+            report_year=2015,
+            committee_id=existing.committee_id,
+            contributor_receipt_amount=75,
+        )
+        # Create a committee and committee report
+        dc = sa.Table('dimcmte', db.metadata, autoload=True, autoload_with=db.engine)
+        ins = dc.insert().values(
+            cmte_sk=7,
+            cmte_id=existing.committee_id,
+            load_date=datetime.datetime.now(),
+        )
+        db.session.execute(ins)
+        rep = sa.Table('facthousesenate_f3', db.metadata, autoload=True, autoload_with=db.engine)
+        ins = rep.insert().values(
+            cmte_sk=7,
+            indv_unitem_contb_per=20,
+            facthousesenate_f3_sk=3,
+            two_yr_period_sk=2016,
+            load_date=datetime.datetime.now(),
+        )
+        db.session.execute(ins)
+        db.session.flush()
+        db.session.execute('select update_aggregates()')
+        db.session.execute('refresh materialized view ofec_totals_house_senate_mv')
+        db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged')
+        db.session.refresh(existing)
+        # Updated total includes new Schedule A filing and new report
+        self.assertEqual(existing.total, total + 75 + 20)
+        self.assertEqual(existing.count, None)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -264,7 +264,7 @@ class TestViews(common.IntegrationTestCase):
         )
         db.session.flush()
         db.session.execute('select update_aggregates()')
-        db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged')
+        db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged_mv')
         rows = models.ScheduleABySize.query.filter_by(
             cycle=2016,
             committee_id='C12345',
@@ -277,7 +277,7 @@ class TestViews(common.IntegrationTestCase):
         db.session.add(filing)
         db.session.flush()
         db.session.execute('select update_aggregates()')
-        db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged')
+        db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged_mv')
         db.session.refresh(rows[0])
         self.assertEqual(rows[0].total, 0)
         self.assertEqual(rows[0].count, 0)
@@ -296,7 +296,7 @@ class TestViews(common.IntegrationTestCase):
         )
         db.session.flush()
         db.session.execute('select update_aggregates()')
-        db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged')
+        db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged_mv')
         db.session.refresh(existing)
         self.assertEqual(existing.total, total + 538)
         self.assertEqual(existing.count, count + 1)
@@ -332,7 +332,7 @@ class TestViews(common.IntegrationTestCase):
         db.session.flush()
         db.session.execute('select update_aggregates()')
         db.session.execute('refresh materialized view ofec_totals_house_senate_mv')
-        db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged')
+        db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged_mv')
         db.session.refresh(existing)
         # Updated total includes new Schedule A filing and new report
         self.assertEqual(existing.total, total + 75 + 20)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -213,6 +213,24 @@ class TestViews(common.IntegrationTestCase):
         self.assertEqual(existing.total, total + 538)
         self.assertEqual(existing.count, count + 1)
 
+    def test_update_aggregate_state_existing_null_amount(self):
+        existing = models.ScheduleAByState.query.filter_by(
+            cycle=2016,
+        ).first()
+        total = existing.total
+        count = existing.count
+        factories.ScheduleAFactory(
+            report_year=2015,
+            committee_id=existing.committee_id,
+            contributor_state=existing.state,
+            contributor_receipt_amount=None,
+        )
+        db.session.flush()
+        db.session.execute('select update_aggregates()')
+        db.session.refresh(existing)
+        self.assertEqual(existing.total, total)
+        self.assertEqual(existing.count, count)
+
     def test_update_aggregate_zip_create(self):
         filing = factories.ScheduleAFactory(
             report_year=2015,

--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -694,7 +694,7 @@ class BaseAggregate(db.Model):
 
 
 class ScheduleABySize(BaseAggregate):
-    __tablename__ = 'ofec_sched_a_aggregate_size'
+    __tablename__ = 'ofec_sched_a_aggregate_size_merged'
     size = db.Column(db.Integer, primary_key=True)
 
 

--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -694,7 +694,7 @@ class BaseAggregate(db.Model):
 
 
 class ScheduleABySize(BaseAggregate):
-    __tablename__ = 'ofec_sched_a_aggregate_size_merged'
+    __tablename__ = 'ofec_sched_a_aggregate_size_merged_mv'
     size = db.Column(db.Integer, primary_key=True)
 
 


### PR DESCRIPTION
Based on discussion in https://github.com/18F/openFEC-web-app/issues/316, the < $200 bin in the contributions by size aggregates should include both Schedule A receipts with absolute values < $200 and unitemized individual contribution totals from F3 filings. This patch adds a materialized view merging the summed Schedule A values and committee totals. This view is then used by the API resource.

Note: Merged aggregates are given a `count` of `NULL`, since we can't know how many individual contributions went into the aggregate. We will want to clarify this in the documentation.