### PR TITLE
Parse currency strings from query.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,13 @@
+import unittest
+
+from flask import request
+from webargs import flaskparser
+
 from tests import factories
 from tests.common import ApiBaseTest
 
+from webservices import args
+from webservices import rest
 from webservices import sorting
 from webservices.common import models
 
@@ -43,3 +50,11 @@ class TestSort(ApiBaseTest):
         self.assertEqual(query.all(), candidates)
         query, columns = sorting.sort(models.Candidate.query, 'district', model=models.Candidate, hide_null=True)
         self.assertEqual(query.all(), candidates[:2])
+
+
+class TestArgs(unittest.TestCase):
+
+    def test_currency(self):
+        with rest.app.test_request_context('?dollars=$24.50'):
+            parsed = flaskparser.parser.parse({'dollars': args.Currency()}, request)
+            self.assertEqual(parsed, {'dollars': 24.50})

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -46,6 +46,7 @@ def _validate_natural(value):
 Natural = functools.partial(Arg, int, validate=_validate_natural)
 
 
+Currency = functools.partial(Arg, float, use=lambda v: v.lstrip('$'))
 IString = functools.partial(Arg, str, use=lambda v: v.upper())
 
 
@@ -272,8 +273,8 @@ itemized = {
     'image_number': Arg(str, multiple=True, description='The image number of the page where the schedule item is reported'),
     'min_image_number': Arg(str),
     'max_image_number': Arg(str),
-    'min_amount': Arg(float, description='Filter for all amounts greater than a value.'),
-    'max_amount': Arg(float, description='Filter for all amounts less than a value.'),
+    'min_amount': Currency(description='Filter for all amounts greater than a value.'),
+    'max_amount': Currency(description='Filter for all amounts less than a value.'),
     'min_date': Date(),
     'max_date': Date(),
 }


### PR DESCRIPTION
Handle currency arguments like "$50". Useful for users who accidentally
use currency symbols, and for the webapp, which also prepends "$" to
currency values.