### PR TITLE
Add indexes on filings columns.

### DIFF
--- a/data/sql_updates/post_committees_create_filings_view.sql
+++ b/data/sql_updates/post_committees_create_filings_view.sql
@@ -59,3 +59,6 @@ create index on ofec_filings_vw_tmp (primary_general_indicator);
 create index on ofec_filings_vw_tmp (amendment_indicator);
 create index on ofec_filings_vw_tmp (report_type);
 create index on ofec_filings_vw_tmp (report_year);
+create index on ofec_filings_vw_tmp (total_receipts);
+create index on ofec_filings_vw_tmp (total_disbursements);
+create index on ofec_filings_vw_tmp (total_independent_expenditures);


### PR DESCRIPTION
We only permit sorting on indexed columns, since sorting on non-indexed
columns can be painfully slow. This patch adds indexes on columns on
which the webapp tries to sort filings data.