### PR TITLE
Use <= 200 for first contribution size bucket.

### DIFF
--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
@@ -1,7 +1,7 @@
 create or replace function contribution_size(value numeric) returns int as $$
 begin
     return case
-        when abs(value) < 200 then 0
+        when abs(value) <= 200 then 0
         when abs(value) < 500 then 200
         when abs(value) < 1000 then 500
         when abs(value) < 2000 then 1000


### PR DESCRIPTION
To match FEC reporting rules.

@LindsayYoung: Think we should keep the rest of the buckets as they are, or also change to `<=` for consistency?