### PR TITLE
adding demo key by default to make it easier to try out.

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -237,6 +237,7 @@ API_KEY_PARAM = {
     'required': True,
     'name': 'api_key',
     'description': docs.API_KEY_DESCRIPTION,
+    'default': 'DEMO_KEY',
 }
 
 


### PR DESCRIPTION
Adding a default key when none is supplied- should make the documentation more approachable. 

close #1066