### PR TITLE
Feature/recipient aggregate

### DIFF
--- a/data/functions/aggregates.sql
+++ b/data/functions/aggregates.sql
@@ -7,6 +7,9 @@ begin
     perform ofec_sched_a_update_aggregate_employer();
     perform ofec_sched_a_update_aggregate_occupation();
 
+    perform ofec_sched_b_update_aggregate_recipient();
+    perform ofec_sched_b_update_aggregate_recipient_id();
+
     -- Update full-text tables in place
     perform ofec_sched_a_update_fulltext();
     perform ofec_sched_b_update_fulltext();

--- a/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient.sql
@@ -1,0 +1,66 @@
+-- Create initial aggregate
+drop table if exists ofec_sched_b_aggregate_recipient;
+create table ofec_sched_b_aggregate_recipient as
+select
+    cmte_id,
+    rpt_yr + rpt_yr % 2 as cycle,
+    recipient_nm as recipient_name,
+    sum(disb_amt) as total,
+    count(disb_amt) as count
+from sched_b
+where rpt_yr >= :START_YEAR_ITEMIZED
+and disb_amt is not null
+and (memo_cd != 'X' or memo_cd is null)
+group by cmte_id, cycle, recipient_name
+;
+
+-- Create indices on aggregate
+create index on ofec_sched_b_aggregate_recipient (cmte_id);
+create index on ofec_sched_b_aggregate_recipient (cycle);
+create index on ofec_sched_b_aggregate_recipient (recipient_name);
+create index on ofec_sched_b_aggregate_recipient (total);
+create index on ofec_sched_b_aggregate_recipient (count);
+
+-- Create update function
+create or replace function ofec_sched_b_update_aggregate_recipient() returns void as $$
+begin
+    with new as (
+        select 1 as multiplier, *
+        from ofec_sched_b_queue_new
+    ),
+    old as (
+        select -1 as multiplier, *
+        from ofec_sched_b_queue_old
+    ),
+    patch as (
+        select
+            cmte_id,
+            rpt_yr + rpt_yr % 2 as cycle,
+            recipient_nm as recipient_name,
+            sum(disb_amt * multiplier) as total,
+            sum(multiplier) as count
+        from (
+            select * from new
+            union all
+            select * from old
+        ) t
+        where disb_amt is not null
+        and (memo_cd != 'X' or memo_cd is null)
+        group by cmte_id, cycle, recipient_name
+    ),
+    inc as (
+        update ofec_sched_b_aggregate_recipient ag
+        set
+            total = ag.total + patch.total,
+            count = ag.count + patch.count
+        from patch
+        where (ag.cmte_id, ag.cycle, ag.recipient_name) = (patch.cmte_id, patch.cycle, patch.recipient_name)
+    )
+    insert into ofec_sched_b_aggregate_recipient (
+        select patch.* from patch
+        left join ofec_sched_b_aggregate_recipient ag using (cmte_id, cycle, recipient_name)
+        where ag.cmte_id is null
+    )
+    ;
+end
+$$ language plpgsql;

--- a/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient_committee.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient_committee.sql
@@ -5,6 +5,7 @@ select
     cmte_id,
     rpt_yr + rpt_yr % 2 as cycle,
     recipient_cmte_id,
+    max(recipient_nm) as recipient_nm,
     sum(disb_amt) as total,
     count(disb_amt) as count
 from sched_b
@@ -38,6 +39,7 @@ begin
             cmte_id,
             rpt_yr + rpt_yr % 2 as cycle,
             recipient_cmte_id,
+            max(recipient_nm) as recipient_nm,
             sum(disb_amt * multiplier) as total,
             sum(multiplier) as count
         from (

--- a/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient_committee.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient_committee.sql
@@ -1,0 +1,68 @@
+-- Create initial aggregate
+drop table if exists ofec_sched_b_aggregate_recipient_id;
+create table ofec_sched_b_aggregate_recipient_id as
+select
+    cmte_id,
+    rpt_yr + rpt_yr % 2 as cycle,
+    recipient_cmte_id,
+    sum(disb_amt) as total,
+    count(disb_amt) as count
+from sched_b
+where rpt_yr >= :START_YEAR_ITEMIZED
+and disb_amt is not null
+and (memo_cd != 'X' or memo_cd is null)
+and recipient_cmte_id is not null
+group by cmte_id, cycle, recipient_cmte_id
+;
+
+-- Create indices on aggregate
+create index on ofec_sched_b_aggregate_recipient_id (cmte_id);
+create index on ofec_sched_b_aggregate_recipient_id (cycle);
+create index on ofec_sched_b_aggregate_recipient_id (recipient_cmte_id);
+create index on ofec_sched_b_aggregate_recipient_id (total);
+create index on ofec_sched_b_aggregate_recipient_id (count);
+
+-- Create update function
+create or replace function ofec_sched_b_update_aggregate_recipient_id() returns void as $$
+begin
+    with new as (
+        select 1 as multiplier, *
+        from ofec_sched_b_queue_new
+    ),
+    old as (
+        select -1 as multiplier, *
+        from ofec_sched_b_queue_old
+    ),
+    patch as (
+        select
+            cmte_id,
+            rpt_yr + rpt_yr % 2 as cycle,
+            recipient_cmte_id,
+            sum(disb_amt * multiplier) as total,
+            sum(multiplier) as count
+        from (
+            select * from new
+            union all
+            select * from old
+        ) t
+        where disb_amt is not null
+        and (memo_cd != 'X' or memo_cd is null)
+        and recipient_cmte_id is not null
+        group by cmte_id, cycle, recipient_cmte_id
+    ),
+    inc as (
+        update ofec_sched_b_aggregate_recipient_id ag
+        set
+            total = ag.total + patch.total,
+            count = ag.count + patch.count
+        from patch
+        where (ag.cmte_id, ag.cycle, ag.recipient_cmte_id) = (patch.cmte_id, patch.cycle, patch.recipient_cmte_id)
+    )
+    insert into ofec_sched_b_aggregate_recipient_id (
+        select patch.* from patch
+        left join ofec_sched_b_aggregate_recipient_id ag using (cmte_id, cycle, recipient_cmte_id)
+        where ag.cmte_id is null
+    )
+    ;
+end
+$$ language plpgsql;

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -348,7 +348,7 @@ schedule_a_by_contributor = {
 
 schedule_b_by_recipient = {
     'cycle': Arg(int, multiple=True, description=docs.RECORD_CYCLE),
-    'recipient': Arg(str, multiple=True, description='Recipient name'),
+    'recipient_name': Arg(str, multiple=True, description='Recipient name'),
 }
 
 

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -346,6 +346,18 @@ schedule_a_by_contributor = {
 }
 
 
+schedule_b_by_recipient = {
+    'cycle': Arg(int, multiple=True, description=docs.RECORD_CYCLE),
+    'recipient': Arg(str, multiple=True, description='Recipient name'),
+}
+
+
+schedule_b_by_recipient_id = {
+    'cycle': Arg(int, multiple=True, description=docs.RECORD_CYCLE),
+    'recipient_id': Arg(str, multiple=True, description='Recipient Committee ID'),
+}
+
+
 schedule_b = {
     'committee_id': Arg(str, multiple=True, description=docs.COMMITTEE_ID),
     'recipient_committee_id': Arg(str, multiple=True, description='The FEC identifier should be represented here the contributor is registered with the FEC'),

--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -722,6 +722,17 @@ class ScheduleAByOccupation(BaseAggregate):
     occupation = db.Column(db.String, primary_key=True)
 
 
+class ScheduleBByRecipient(BaseAggregate):
+    __tablename__ = 'ofec_sched_b_aggregate_recipient'
+    recipient_name = db.Column('recipient_nm', db.String, primary_key=True)
+
+
+class ScheduleBByRecipientID(BaseAggregate):
+    __tablename__ = 'ofec_sched_b_aggregate_recipient_id'
+    recipient_id = db.Column('recipient_cmte_id', db.String, primary_key=True)
+    recipient_name = db.Column('recipient_nm', db.String)
+
+
 class ScheduleAByContributor(db.Model):
     __tablename__ = 'ofec_sched_a_aggregate_contributor_mv'
 

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -232,7 +232,7 @@ class ScheduleBByRecipientIDView(ScheduleAAggregateView):
     ]
 
     @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.schedule_b_by_recipient)
+    @args.register_kwargs(args.schedule_b_by_recipient_id)
     @args.register_kwargs(
         args.make_sort_args(
             validator=args.IndexValidator(models.ScheduleBByRecipientID)

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -189,3 +189,55 @@ class ScheduleAByContributorView(ScheduleAAggregateView):
     @schemas.marshal_with(schemas.ScheduleAByContributorPageSchema())
     def get(self, committee_id=None, **kwargs):
         return super(ScheduleAByContributorView, self).get(committee_id=committee_id, **kwargs)
+
+
+@spec.doc(
+    description=(
+        'Schedule B receipts aggregated by recipient name. To avoid '
+        'double counting, memoed items are not included.'
+    )
+)
+class ScheduleBByRecipientView(ScheduleAAggregateView):
+
+    model = models.ScheduleBByRecipient
+    fields = [
+        ('cycle', models.ScheduleBByRecipient.cycle),
+        ('recipient_name', models.ScheduleBByRecipient.recipient_name),
+    ]
+
+    @args.register_kwargs(args.paging)
+    @args.register_kwargs(args.schedule_b_by_recipient)
+    @args.register_kwargs(
+        args.make_sort_args(
+            validator=args.IndexValidator(models.ScheduleBByRecipient)
+        )
+    )
+    @schemas.marshal_with(schemas.ScheduleBByRecipientPageSchema())
+    def get(self, committee_id=None, **kwargs):
+        return super().get(committee_id=committee_id, **kwargs)
+
+
+@spec.doc(
+    description=(
+        'Schedule B receipts aggregated by recipient committee ID, if applicable. To avoid '
+        'double counting, memoed items are not included.'
+    )
+)
+class ScheduleBByRecipientIDView(ScheduleAAggregateView):
+
+    model = models.ScheduleBByRecipientID
+    fields = [
+        ('cycle', models.ScheduleBByRecipientID.cycle),
+        ('recipient_id', models.ScheduleBByRecipientID.recipient_id),
+    ]
+
+    @args.register_kwargs(args.paging)
+    @args.register_kwargs(args.schedule_b_by_recipient)
+    @args.register_kwargs(
+        args.make_sort_args(
+            validator=args.IndexValidator(models.ScheduleBByRecipientID)
+        )
+    )
+    @schemas.marshal_with(schemas.ScheduleBByRecipientIDPageSchema())
+    def get(self, committee_id=None, **kwargs):
+        return super().get(committee_id=committee_id, **kwargs)

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -181,36 +181,24 @@ api.add_resource(CandidateNameSearch, '/names/candidates')
 api.add_resource(CommitteeNameSearch, '/names/committees')
 api.add_resource(sched_a.ScheduleAView, '/schedules/schedule_a')
 api.add_resource(sched_b.ScheduleBView, '/schedules/schedule_b')
-api.add_resource(
-    aggregates.ScheduleABySizeView,
-    '/schedules/schedule_a/by_size',
-    '/committee/<committee_id>/schedules/schedule_a/by_size',
-)
-api.add_resource(
-    aggregates.ScheduleAByStateView,
-    '/schedules/schedule_a/by_state',
-    '/committee/<committee_id>/schedules/schedule_a/by_state',
-)
-api.add_resource(
-    aggregates.ScheduleAByZipView,
-    '/schedules/schedule_a/by_zip',
-    '/committee/<committee_id>/schedules/schedule_a/by_zip',
-)
-api.add_resource(
-    aggregates.ScheduleAByEmployerView,
-    '/schedules/schedule_a/by_employer',
-    '/committee/<committee_id>/schedules/schedule_a/by_employer',
-)
-api.add_resource(
-    aggregates.ScheduleAByOccupationView,
-    '/schedules/schedule_a/by_occupation',
-    '/committee/<committee_id>/schedules/schedule_a/by_occupation',
-)
-api.add_resource(
-    aggregates.ScheduleAByContributorView,
-    '/schedules/schedule_a/by_contributor',
-    '/committee/<committee_id>/schedules/schedule_a/by_contributor',
-)
+
+def add_aggregate_resource(api, view, schedule, label):
+    api.add_resource(
+        view,
+        '/schedules/schedule_{schedule}/by_{label}'.format(**locals()),
+        '/committee/<committee_id>/schedules/schedule_{schedule}/by_{label}'.format(**locals()),
+    )
+
+add_aggregate_resource(api, aggregates.ScheduleABySizeView, 'a', 'size')
+add_aggregate_resource(api, aggregates.ScheduleAByStateView, 'a', 'state')
+add_aggregate_resource(api, aggregates.ScheduleAByZipView, 'a', 'zip')
+add_aggregate_resource(api, aggregates.ScheduleAByEmployerView, 'a', 'employer')
+add_aggregate_resource(api, aggregates.ScheduleAByOccupationView, 'a', 'occupation')
+add_aggregate_resource(api, aggregates.ScheduleAByContributorView, 'a', 'contributor')
+
+add_aggregate_resource(api, aggregates.ScheduleBByRecipientView, 'b', 'recipient')
+add_aggregate_resource(api, aggregates.ScheduleBByRecipientIDView, 'b', 'recipient_id')
+
 api.add_resource(filings.FilingsView, '/committee/<string:committee_id>/filings')
 api.add_resource(filings.FilingsList, '/filings')
 
@@ -288,6 +276,8 @@ register_resource(aggregates.ScheduleAByZipView, blueprint='v1')
 register_resource(aggregates.ScheduleAByEmployerView, blueprint='v1')
 register_resource(aggregates.ScheduleAByOccupationView, blueprint='v1')
 register_resource(aggregates.ScheduleAByContributorView, blueprint='v1')
+register_resource(aggregates.ScheduleBByRecipientView, blueprint='v1')
+register_resource(aggregates.ScheduleBByRecipientIDView, blueprint='v1')
 register_resource(filings.FilingsView, blueprint='v1')
 register_resource(filings.FilingsList, blueprint='v1')
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -272,6 +272,8 @@ augment_models(
     models.ScheduleAByEmployer,
     models.ScheduleAByOccupation,
     models.ScheduleAByContributor,
+    models.ScheduleBByRecipient,
+    models.ScheduleBByRecipientID,
 )
 
 ScheduleBSchema = make_schema(


### PR DESCRIPTION
This patch adds two new aggregates on the Schedule B data:
* Aggregate disbursements by recipient name (raw text)
* Aggregate disbursements by recipient committee ID (if not null)

Question: The aggregate by recipient committee ID (obviously) only includes disbursements for which a recipient committee ID is provided. Should the aggregate by recipient name exclude disbursements that *do* have a committee ID? I'm asking because if we include all disbursements in both aggregates, we'll likely see disbursements with recipient committee IDs showing up in both aggregates, which could make the two tables look a little redundant when viewed side by side.

Ping @LindsayYoung @noahmanger