### PR TITLE
[dontmerge] Hotfix/cap per page

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -69,6 +69,8 @@ class OverallTest(ApiBaseTest):
     def test_invalid_per_page_param(self):
         results = self.app.get(api.url_for(CandidateList, per_page=-10))
         self.assertEquals(results.status_code, 422)
+        results = self.app.get(api.url_for(CandidateList, per_page=101))
+        self.assertEquals(results.status_code, 422)
         results = self.app.get(api.url_for(CandidateList, per_page=34.2))
         self.assertEquals(results.status_code, 422)
         results = self.app.get(api.url_for(CandidateList, per_page='dynamic-wombats'))

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -46,6 +46,12 @@ def _validate_natural(value):
 Natural = functools.partial(Arg, int, validate=_validate_natural)
 
 
+def _validate_per_page(value):
+    _validate_natural(value)
+    if value > 100:
+        raise webargs.ValidationError('Must be <= 100')
+
+
 Currency = functools.partial(Arg, float, use=lambda v: v.lstrip('$'))
 IString = functools.partial(Arg, str, use=lambda v: v.upper())
 
@@ -70,7 +76,7 @@ class Date(webargs.Arg):
 
 paging = {
     'page': Natural(default=1, description='For paginating through results, starting at page 1'),
-    'per_page': Natural(default=20, description='The number of results returned per page. Defaults to 20.'),
+    'per_page': Natural(default=20, validate=_validate_per_page, description='The number of results returned per page. Defaults to 20.'),
 }
 
 


### PR DESCRIPTION
Don't let users request unlimited records per page, which can lead to out of memory errors. h/t @LindsayYoung.