### PR TITLE
Feature/documentation tweaks

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -161,7 +161,7 @@ candidate_detail = {
     'office': Arg(str, multiple=True, enum=['', 'H', 'S', 'P'], description='Governmental office candidate runs for: House, Senate or President.'),
     'state': IString(multiple=True, description='U.S. State candidate or territory where a candidate runs for office.'),
     'party': IString(multiple=True, description='Three letter code for the party under which a candidate ran for office'),
-    'year': Arg(str, dest='election_year', description='See records pertaining to a particular year.'),
+    'year': Arg(str, dest='election_year', description='See records pertaining to a particular election year.'),
     'district': Arg(str, multiple=True, description='Two digit district number'),
     'candidate_status': IString(multiple=True, enum=['', 'C', 'F', 'N', 'P'], description='One letter code explaining if the candidate is:\n\
         - C present candidate\n\
@@ -181,7 +181,6 @@ candidate_list = {
 committee = {
     'year': Arg(int, multiple=True, description='A year that the committee was active- (After original registration date but before expiration date.)'),
     'cycle': Arg(int, multiple=True, description=docs.COMMITTEE_CYCLE),
-    'cycle': Arg(int, multiple=True, description='A two-year election cycle that the committee was active- (after original registration date but before expiration date.)'),
     'designation': IString(
         multiple=True, enum=['', 'A', 'J', 'P', 'U', 'B', 'D'],
         description='The one-letter designation code of the organization:\n\
@@ -241,9 +240,8 @@ filings = {
     'beginning_image_number': Arg(int, multiple=True, description=docs.BEGINNING_IMAGE_NUMBER),
     'report_type': IString(multiple=True, description='Report type'),
     'document_type': IString(multiple=True, description=docs.DOC_TYPE),
-    'report_year': Arg(int, multiple=True, description='Report year'),
     'beginning_image_number': Arg(int, multiple=True, description=docs.BEGINNING_IMAGE_NUMBER),
-    'report_year': Arg(int, multiple=True, description='Year that the report applies to'),
+    'report_year': Arg(int, multiple=True, description=docs.REPORT_YEAR),
     'min_receipt_date': Date(description='Minimum day the filing was received by the FEC'),
     'max_receipt_date': Date(description='Maximum day the filing was received by the FEC'),
     'form_type': IString(multiple=True, description='Form type'),
@@ -346,14 +344,14 @@ schedule_a_by_occupation = {
 
 schedule_a_by_contributor = {
     'cycle': Arg(int, multiple=True, description=docs.RECORD_CYCLE),
-    'year': Arg(int, multiple=True, description=docs.RECORD_CYCLE),
+    'year': Arg(int, multiple=True, description=docs.REPORT_YEAR),
     'contributor_id': IString(multiple=True, description=docs.COMMITTEE_ID),
 }
 
 
 schedule_a_by_contributor_type = {
     'cycle': Arg(int, multiple=True, description=docs.RECORD_CYCLE),
-    'year': Arg(int, multiple=True, description=docs.RECORD_CYCLE),
+    'year': Arg(int, multiple=True, description=docs.REPORT_YEAR),
     'individual': Bool(description='Restrict to individual donors'),
 }
 

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -218,6 +218,10 @@ Several different reporting structures exist, depending on the type of organizat
 submits financial information. To see an example of these reporting requirements,
 look at the summary and detailed summary pages of FEC Form 3, Form 3X, and Form 3P.
 '''
+REPORT_YEAR = '''
+Year that the record applies to. Sometimes records are amended in subsequent
+years so this can differ from underlying form's receipt date.
+'''
 
 TOTALS = '''
 This endpoint provides information about a committee's Form 3, Form 3X, or Form 3P financial reports,

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -234,9 +234,10 @@ is the next year — for example, in 2015, the current cycle is 2016.
 For presidential and Senate candidates, multiple two-year cycles exist between elections.
 '''
 
-SCHEDULE_A = '''
-Schedule A filings describe itemized receipts reported by a committee. This is where
-you can look for individual contributors.
+SCHEDULE_A_TAG = '''
+Schedule A records describe itemized receipts reported by a committee. This is where
+you can look for individual contributors. If you are interested in
+individual donors, `/schedules/schedule_a` will be the endpoint you use.
 
 Once a person gives more than a total of $200, the donations of that person must be
 reported by committees that file F3, F3X and F3P forms.
@@ -248,6 +249,12 @@ or `/totals` endpoints.
 When comparing the totals from reports to line items. the totals will not match unless you
 take out items where `"memoed_subtotal":true`. Memoed items are subtotals of receipts
 that are already accounted for in another schedule a line item.
+
+For the Schedule A aggregates, "memoed" items are not included to avoid double counting.
+
+'''
+
+SCHEDULE_A = SCHEDULE_A_TAG + '''
 
 Due to the large quantity of Schedule A filings, this endpoint is not paginated by
 page number. Instead, you can request the next page of results by adding the values in
@@ -274,10 +281,13 @@ Note: because the Schedule A data includes many records, counts for
 large result sets are approximate.
 '''
 
-SCHEDULE_B = '''
-Schedule B filings describe itemized disbursements that committees. This data
+SCHEDULE_B_TAG = '''
+Schedule B filings describe itemized disbursements. This data
 explains how committees and other filers spend their money. These figures are
-reported on F3, F3X and F3P forms.
+reported as part of forms F3, F3X and F3P.
+'''
+
+SCHEDULE_B = SCHEDULE_B_TAG + '''
 
 Due to the large quantity of Schedule B filings, this endpoint is not paginated by
 page number. Instead, you can request the next page of results by adding the values in
@@ -302,18 +312,6 @@ to the URL.
 
 Note: because the Schedule A data includes many records, counts for
 large result sets are approximate.
-'''
-
-# If we add schedules as a grouping
-SCHEDULES = '''
-Schedules come from particular sections on forms and contain detailed transactional data.
-
-Schedule A explains where contributions come from. If you are interested in
-individual donors, this will be the endpoint you use.
-
-For the Schedule A aggregates, "memoed" items are not included to avoid double counting.
-
-Schedule B explains how money is spent.
 '''
 
 SIZE_DESCRIPTION = '''

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -10,7 +10,7 @@ from webservices.common import models
 
 
 @spec.doc(
-    tags=['schedules'],
+    tags=['schedules/schedule_a'],
     path_params=[utils.committee_param],
 )
 class ScheduleAAggregateView(Resource):
@@ -32,7 +32,10 @@ class ScheduleAAggregateView(Resource):
         return query
 
 
-@spec.doc(description=docs.SIZE_DESCRIPTION)
+@spec.doc(
+    tags=['schedules/schedule_a'],
+    description=docs.SIZE_DESCRIPTION,
+)
 class ScheduleABySizeView(ScheduleAAggregateView):
 
     model = models.ScheduleABySize
@@ -54,6 +57,7 @@ class ScheduleABySizeView(ScheduleAAggregateView):
 
 
 @spec.doc(
+    tags=['schedules/schedule_a'],
     description=(
         'Schedule A receipts aggregated by contributor state. To avoid double counting, '
         'memoed items are not included.'
@@ -86,6 +90,7 @@ class ScheduleAByStateView(ScheduleAAggregateView):
 
 
 @spec.doc(
+    tags=['schedules/schedule_a'],
     description=(
         'Schedule A receipts aggregated by contributor zip code. To avoid double '
         'counting, memoed items are not included.'
@@ -112,6 +117,7 @@ class ScheduleAByZipView(ScheduleAAggregateView):
 
 
 @spec.doc(
+    tags=['schedules/schedule_a'],
     description=(
         'Schedule A receipts aggregated by contributor employer name. To avoid double '
         'counting, memoed items are not included.'
@@ -140,6 +146,7 @@ class ScheduleAByEmployerView(ScheduleAAggregateView):
 
 
 @spec.doc(
+    tags=['schedules/schedule_a'],
     description=(
         'Schedule A receipts aggregated by contributor occupation. To avoid double '
         'counting, memoed items are not included.'
@@ -168,6 +175,7 @@ class ScheduleAByOccupationView(ScheduleAAggregateView):
 
 
 @spec.doc(
+    tags=['schedules/schedule_a'],
     description=(
         'Schedule A receipts aggregated by contributor FEC ID, if applicable. To avoid '
         'double counting, memoed items are not included.'
@@ -194,6 +202,7 @@ class ScheduleAByContributorView(ScheduleAAggregateView):
 
 
 @spec.doc(
+    tags=['schedules/schedule_a'],
     description=(
         'Schedule A receipts aggregated by contributor type (individual or committee), if applicable. '
         'To avoid double counting, memoed items are not included.'
@@ -222,6 +231,7 @@ class ScheduleAByContributorTypeView(ScheduleAAggregateView):
 
 
 @spec.doc(
+    tags=['schedules/schedule_b'],
     description=(
         'Schedule B receipts aggregated by recipient name. To avoid '
         'double counting, memoed items are not included.'
@@ -248,6 +258,7 @@ class ScheduleBByRecipientView(ScheduleAAggregateView):
 
 
 @spec.doc(
+    tags=['schedules/schedule_b'],
     description=(
         'Schedule B receipts aggregated by recipient committee ID, if applicable. To avoid '
         'double counting, memoed items are not included.'

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -47,7 +47,7 @@ def candidate_aggregate(aggregate_model, label_columns, group_columns, kwargs):
 
 
 @spec.doc(
-    tags=['schedules'],
+    tags=['schedules/schedule_a'],
     description='Schedule A receipts aggregated by contribution size.',
 )
 class ScheduleABySizeCandidateView(Resource):
@@ -63,7 +63,7 @@ class ScheduleABySizeCandidateView(Resource):
 
 
 @spec.doc(
-    tags=['schedules'],
+    tags=['schedules/schedule_a'],
     description='Schedule A receipts aggregated by contributor state.',
 )
 class ScheduleAByStateCandidateView(Resource):
@@ -86,7 +86,7 @@ class ScheduleAByStateCandidateView(Resource):
 
 
 @spec.doc(
-    tags=['schedules'],
+    tags=['schedules/schedule_a'],
     description='Schedule A receipts aggregated by contributor type.',
 )
 class ScheduleAByContributorTypeCandidateView(Resource):

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -10,7 +10,7 @@ from webservices.common.views import ItemizedResource
 
 
 @spec.doc(
-    tags=['schedules'],
+    tags=['schedules/schedule_a'],
     description=docs.SCHEDULE_A,
 )
 class ScheduleAView(ItemizedResource):

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -9,7 +9,7 @@ from webservices.common.views import ItemizedResource
 
 
 @spec.doc(
-    tags=['schedules'],
+    tags=['schedules/schedule_b'],
     description=docs.SCHEDULE_B,
 )
 class ScheduleBView(ItemizedResource):

--- a/webservices/spec.py
+++ b/webservices/spec.py
@@ -43,8 +43,12 @@ spec = APISpec(
             'description': docs.FILINGS,
         },
         {
-            'name': 'schedules',
-            'description': docs.SCHEDULES,
+            'name': 'schedules/schedule_a',
+            'description': docs.SCHEDULE_A_TAG,
+        },
+        {
+            'name': 'schedules/schedule_b',
+            'description': docs.SCHEDULE_B_TAG,
         },
     ]
 )


### PR DESCRIPTION
 - Separate the year definition from the cycle definition. 
 - Breaks up schedule A and schedule B. 
It was hard to read the documentation with so much going on in `/schedules`.