### PR TITLE
Restrict most aggregates to individual contributions.

### DIFF
--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_employer.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_employer.sql
@@ -11,6 +11,7 @@ from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
 and (memo_cd != 'X' or memo_cd is null)
+and line_num in ('11AI', '17A')
 group by cmte_id, cycle, employer
 ;
 
@@ -25,33 +26,29 @@ create index on ofec_sched_a_aggregate_employer (count);
 create or replace function ofec_sched_a_update_aggregate_employer() returns void as $$
 begin
     with new as (
-        select
-            cmte_id,
-            rpt_yr + rpt_yr % 2 as cycle,
-            contbr_employer as employer,
-            sum(contb_receipt_amt) as total,
-            count(contb_receipt_amt) as count
+        select 1 as multiplier, *
         from ofec_sched_a_queue_new
-        where contb_receipt_amt is not null
-        and (memo_cd != 'X' or memo_cd is null)
-        group by cmte_id, cycle, employer
     ),
     old as (
+        select -1 as multiplier, *
+        from ofec_sched_a_queue_old
+    ),
+    patch as (
         select
             cmte_id,
             rpt_yr + rpt_yr % 2 as cycle,
             contbr_employer as employer,
-            -1 * sum(contb_receipt_amt) as total,
-            -1 * count(contb_receipt_amt) as count
-        from ofec_sched_a_queue_old
+            sum(contb_receipt_amt * multiplier) as total,
+            sum(multiplier) as count
+        from (
+            select * from new
+            union all
+            select * from old
+        ) t
         where contb_receipt_amt is not null
         and (memo_cd != 'X' or memo_cd is null)
+        and line_num in ('11AI', '17A')
         group by cmte_id, cycle, employer
-    ),
-    patch as (
-      select * from new
-      union all
-      select * from old
     ),
     inc as (
         update ofec_sched_a_aggregate_employer ag

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_occupation.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_occupation.sql
@@ -11,6 +11,7 @@ from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
 and (memo_cd != 'X' or memo_cd is null)
+and line_num in ('11AI', '17A')
 group by cmte_id, cycle, occupation
 ;
 
@@ -25,33 +26,29 @@ create index on ofec_sched_a_aggregate_occupation (count);
 create or replace function ofec_sched_a_update_aggregate_occupation() returns void as $$
 begin
     with new as (
-        select
-            cmte_id,
-            rpt_yr + rpt_yr % 2 as cycle,
-            contbr_occupation as occupation,
-            sum(contb_receipt_amt) as total,
-            count(contb_receipt_amt) as count
+        select 1 as multiplier, *
         from ofec_sched_a_queue_new
-        where contb_receipt_amt is not null
-        and (memo_cd != 'X' or memo_cd is null)
-        group by cmte_id, cycle, occupation
     ),
     old as (
+        select -1 as multiplier, *
+        from ofec_sched_a_queue_old
+    ),
+    patch as (
         select
             cmte_id,
             rpt_yr + rpt_yr % 2 as cycle,
             contbr_occupation as occupation,
-            -1 * sum(contb_receipt_amt) as total,
-            -1 * count(contb_receipt_amt) as count
-        from ofec_sched_a_queue_old
+            sum(contb_receipt_amt * multiplier) as total,
+            sum(multiplier) as count
+        from (
+            select * from new
+            union all
+            select * from old
+        ) t
         where contb_receipt_amt is not null
         and (memo_cd != 'X' or memo_cd is null)
+        and line_num in ('11AI', '17A')
         group by cmte_id, cycle, occupation
-    ),
-    patch as (
-      select * from new
-      union all
-      select * from old
     ),
     inc as (
         update ofec_sched_a_aggregate_occupation ag

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
@@ -23,6 +23,7 @@ from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
 and (memo_cd != 'X' or memo_cd is null)
+and line_num in ('11AI', '17A')
 group by cmte_id, cycle, size
 ;
 
@@ -37,33 +38,29 @@ create index on ofec_sched_a_aggregate_size (count);
 create or replace function ofec_sched_a_update_aggregate_size() returns void as $$
 begin
     with new as (
-        select
-            cmte_id,
-            rpt_yr + rpt_yr % 2 as cycle,
-            contribution_size(contb_receipt_amt) as size,
-            sum(contb_receipt_amt) as total,
-            count(contb_receipt_amt) as count
+        select 1 as multiplier, *
         from ofec_sched_a_queue_new
-        where contb_receipt_amt is not null
-        and (memo_cd != 'X' or memo_cd is null)
-        group by cmte_id, cycle, size
     ),
     old as (
+        select -1 as multiplier, *
+        from ofec_sched_a_queue_old
+    ),
+    patch as (
         select
             cmte_id,
             rpt_yr + rpt_yr % 2 as cycle,
             contribution_size(contb_receipt_amt) as size,
-            -1 * sum(contb_receipt_amt) as total,
-            -1 * count(contb_receipt_amt) as count
-        from ofec_sched_a_queue_old
+            sum(contb_receipt_amt * multiplier) as total,
+            sum(multiplier) as count
+        from (
+            select * from new
+            union all
+            select * from old
+        ) t
         where contb_receipt_amt is not null
         and (memo_cd != 'X' or memo_cd is null)
+        and line_num in ('11AI', '17A')
         group by cmte_id, cycle, size
-    ),
-    patch as (
-        select * from new
-        union all
-        select * from old
     ),
     inc as (
         update ofec_sched_a_aggregate_size ag

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_state.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_state.sql
@@ -11,6 +11,7 @@ from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
 and (memo_cd != 'X' or memo_cd is null)
+and line_num in ('11AI', '17A')
 group by cmte_id, cycle, state
 ;
 
@@ -25,35 +26,30 @@ create index on ofec_sched_a_aggregate_state (count);
 create or replace function ofec_sched_a_update_aggregate_state() returns void as $$
 begin
     with new as (
-        select
-            cmte_id,
-            rpt_yr + rpt_yr % 2 as cycle,
-            contbr_st as state,
-            expand_state(contbr_st) as state_full,
-            sum(contb_receipt_amt) as total,
-            count(contb_receipt_amt) as count
+        select 1 as multiplier, *
         from ofec_sched_a_queue_new
-        where contb_receipt_amt is not null
-        and (memo_cd != 'X' or memo_cd is null)
-        group by cmte_id, cycle, state
     ),
     old as (
+        select -1 as multiplier, *
+        from ofec_sched_a_queue_old
+    ),
+    patch as (
         select
             cmte_id,
             rpt_yr + rpt_yr % 2 as cycle,
             contbr_st as state,
             expand_state(contbr_st) as state_full,
-            -1 * sum(contb_receipt_amt) as total,
-            -1 * count(contb_receipt_amt) as count
-        from ofec_sched_a_queue_old
+            sum(contb_receipt_amt * multiplier) as total,
+            sum(multiplier) as count
+        from (
+            select * from new
+            union all
+            select * from old
+        ) t
         where contb_receipt_amt is not null
         and (memo_cd != 'X' or memo_cd is null)
+        and line_num in ('11AI', '17A')
         group by cmte_id, cycle, state
-    ),
-    patch as (
-        select * from new
-        union all
-        select * from old
     ),
     inc as (
         update ofec_sched_a_aggregate_state ag

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_zip.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_zip.sql
@@ -13,6 +13,7 @@ from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
 and (memo_cd != 'X' or memo_cd is null)
+and line_num in ('11AI', '17A')
 group by cmte_id, cycle, zip
 ;
 
@@ -29,37 +30,31 @@ create index on ofec_sched_a_aggregate_zip (count);
 create or replace function ofec_sched_a_update_aggregate_zip() returns void as $$
 begin
     with new as (
-        select
-            cmte_id,
-            rpt_yr + rpt_yr % 2 as cycle,
-            contbr_zip as zip,
-            max(contbr_st) as state,
-            expand_state(max(contbr_st)) as state_full,
-            sum(contb_receipt_amt) as total,
-            count(contb_receipt_amt) as count
+        select 1 as multiplier, *
         from ofec_sched_a_queue_new
-        where contb_receipt_amt is not null
-        and (memo_cd != 'X' or memo_cd is null)
-        group by cmte_id, cycle, zip
     ),
     old as (
+        select -1 as multiplier, *
+        from ofec_sched_a_queue_old
+    ),
+    patch as (
         select
             cmte_id,
             rpt_yr + rpt_yr % 2 as cycle,
             contbr_zip as zip,
             max(contbr_st) as state,
             expand_state(max(contbr_st)) as state_full,
-            -1 * sum(contb_receipt_amt) as total,
-            -1 * count(contb_receipt_amt) as count
-        from ofec_sched_a_queue_old
+            sum(contb_receipt_amt * multiplier) as total,
+            sum(multiplier) as count
+        from (
+            select * from new
+            union all
+            select * from old
+        ) t
         where contb_receipt_amt is not null
         and (memo_cd != 'X' or memo_cd is null)
+        and line_num in ('11AI', '17A')
         group by cmte_id, cycle, zip
-    ),
-    patch as (
-      select * from new
-      union all
-      select * from old
     ),
     inc as (
         update ofec_sched_a_aggregate_zip ag

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -171,6 +171,7 @@ class TestViews(common.IntegrationTestCase):
             'report_year': 2015,
             'committee_id': 'C12345',
             'contributor_receipt_amount': 538,
+            'line_number': '11AI',
             item_key: value,
         })
         db.session.flush()
@@ -188,8 +189,8 @@ class TestViews(common.IntegrationTestCase):
         db.session.flush()
         db.session.execute('select update_aggregates()')
         db.session.refresh(rows[0])
-        self.assertEqual(rows[0].total, 0)
-        self.assertEqual(rows[0].count, 0)
+        self.assertEqual(rows[0].total, 53)
+        self.assertEqual(rows[0].count, 1)
 
     def _check_update_aggregate_existing(self, item_key, total_key, total_model):
         existing = total_model.query.filter(
@@ -202,6 +203,7 @@ class TestViews(common.IntegrationTestCase):
             'report_year': 2015,
             'committee_id': existing.committee_id,
             'contributor_receipt_amount': 538,
+            'line_number': '11AI',
             item_key: getattr(existing, total_key),
         })
         db.session.flush()
@@ -233,6 +235,7 @@ class TestViews(common.IntegrationTestCase):
             committee_id=existing.committee_id,
             contributor_state=existing.state,
             contributor_receipt_amount=None,
+            line_number='11AI',
         )
         db.session.flush()
         db.session.execute('select update_aggregates()')
@@ -245,6 +248,7 @@ class TestViews(common.IntegrationTestCase):
             report_year=2015,
             committee_id='C12345',
             contributor_receipt_amount=538,
+            line_number='11AI',
         )
         db.session.flush()
         db.session.execute('select update_aggregates()')
@@ -277,6 +281,7 @@ class TestViews(common.IntegrationTestCase):
             report_year=2015,
             committee_id=existing.committee_id,
             contributor_receipt_amount=538,
+            line_number='11AI',
         )
         db.session.flush()
         db.session.execute('select update_aggregates()')
@@ -295,6 +300,7 @@ class TestViews(common.IntegrationTestCase):
             report_year=2015,
             committee_id=existing.committee_id,
             contributor_receipt_amount=75,
+            line_number='11AI',
         )
         # Create a committee and committee report
         dc = sa.Table('dimcmte', db.metadata, autoload=True, autoload_with=db.engine)
@@ -319,5 +325,5 @@ class TestViews(common.IntegrationTestCase):
         db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged_mv')
         db.session.refresh(existing)
         # Updated total includes new Schedule A filing and new report
-        self.assertEqual(existing.total, total + 75 + 20)
+        self.assertAlmostEqual(existing.total, total + 75 + 20)
         self.assertEqual(existing.count, None)


### PR DESCRIPTION
See discussion in https://github.com/18F/openFEC-web-app/issues/339 for
motivation.

This restricts aggregates to contributions from individuals for the following:
* Schedule A by state
* Schedule A by zip
* Schedule A by employer
* Schedule A by occupation
* Schedule A by contribution size

Schedule A aggregates by contributor type are unchanged; ditto for Schedule B aggregates.

This also incorporates a few fixes from #1067.

Ping @LindsayYoung 