### PR TITLE
Join designation by form ID.

### DIFF
--- a/data/sql_updates/create_committee_history.sql
+++ b/data/sql_updates/create_committee_history.sql
@@ -110,11 +110,11 @@ from dimcmteproperties dcp
 left join cycle_agg on dcp.cmte_sk = cycle_agg.cmte_sk
 left join cycles on dcp.cmte_sk = cycles.cmte_sk and dcp.rpt_yr <= cycles.cycle
 left join dimparty p on dcp.cand_pty_affiliation = p.party_affiliation
-left join dimcmtetpdsgn dd on dcp.cmte_sk = dd.cmte_sk and extract(year from dd.receipt_date) <= cycles.cycle
+left join dimcmtetpdsgn dd using (form_sk)
 left join dcp_original on dcp.cmte_sk = dcp_original.cmte_sk
 left join candidate_agg on dcp.cmte_sk = candidate_agg.cmte_sk
 where max_cycle >= :START_YEAR
-order by dcp.cmte_sk, cycle desc, dcp.rpt_yr desc, dd.receipt_date desc
+order by dcp.cmte_sk, cycle desc, dcp.rpt_yr desc
 ;
 
 create unique index on ofec_committee_history_mv_tmp(idx);


### PR DESCRIPTION
Previously, the committee history view was built by joining
`dimcmteproperties` on `dimcmtetpdsgn` using date columns. Recently, the
`receipt_date` column on `dimcmtetpdsgn` appears to have been changed
such that nearly all values are `NULL`. This patch uses `form_sk` to
join the tables and preserve designation information.