### PR TITLE
Feature/fix data types

### DIFF
--- a/tests/committee_tests.py
+++ b/tests/committee_tests.py
@@ -20,7 +20,7 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_list_fields(self):
         committee = factories.CommitteeFactory(
-            first_file_date=datetime.datetime(1982, 12, 31),
+            first_file_date=datetime.date(1982, 12, 31),
             committee_type='P',
             treasurer_name='Robert J. Lipshutz',
             party='DEM',
@@ -29,7 +29,7 @@ class CommitteeFormatTest(ApiBaseTest):
         result = response['results'][0]
         # main fields
         # original registration date doesn't make sense in this example, need to look into this more
-        self.assertEqual(result['first_file_date'], isoformat(committee.first_file_date))
+        self.assertEqual(result['first_file_date'], committee.first_file_date.isoformat())
         self.assertEqual(result['committee_type'], committee.committee_type)
         self.assertEqual(result['treasurer_name'], committee.treasurer_name)
         self.assertEqual(result['party'], committee.party)
@@ -69,7 +69,7 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_detail_fields(self):
         committee = factories.CommitteeDetailFactory(
-            first_file_date=datetime.datetime(1982, 12, 31),
+            first_file_date=datetime.date(1982, 12, 31),
             committee_type='P',
             treasurer_name='Robert J. Lipshutz',
             party='DEM',
@@ -81,7 +81,7 @@ class CommitteeFormatTest(ApiBaseTest):
         response = self._response(api.url_for(CommitteeView, committee_id=committee.committee_id))
         result = response['results'][0]
         # main fields
-        self.assertEqual(result['first_file_date'], isoformat(committee.first_file_date))
+        self.assertEqual(result['first_file_date'], committee.first_file_date.isoformat())
         self.assertEqual(result['committee_type'], committee.committee_type)
         self.assertEqual(result['treasurer_name'], committee.treasurer_name)
         self.assertEqual(result['party'], committee.party)
@@ -183,8 +183,8 @@ class CommitteeFormatTest(ApiBaseTest):
     def test_committee_year_filter_skips_null_first_file_date(self):
         # Build fixtures
         dates = [
-            datetime.datetime(2012, 1, 1),
-            datetime.datetime(2015, 1, 1),
+            datetime.date(2012, 1, 1),
+            datetime.date(2015, 1, 1),
         ]
         [
             factories.CommitteeFactory(first_file_date=None, last_file_date=None),
@@ -266,15 +266,15 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_date_filters(self):
         [
-            factories.CommitteeFactory(first_file_date=datetime.datetime(2015, 1, 1)),
-            factories.CommitteeFactory(first_file_date=datetime.datetime(2015, 2, 1)),
-            factories.CommitteeFactory(first_file_date=datetime.datetime(2015, 3, 1)),
-            factories.CommitteeFactory(first_file_date=datetime.datetime(2015, 4, 1)),
+            factories.CommitteeFactory(first_file_date=datetime.date(2015, 1, 1)),
+            factories.CommitteeFactory(first_file_date=datetime.date(2015, 2, 1)),
+            factories.CommitteeFactory(first_file_date=datetime.date(2015, 3, 1)),
+            factories.CommitteeFactory(first_file_date=datetime.date(2015, 4, 1)),
         ]
         results = self._results(api.url_for(CommitteeList, min_first_file_date='02/01/2015'))
-        self.assertTrue(all(each['first_file_date'] >= isoformat(datetime.datetime(2015, 2, 1)) for each in results))
+        self.assertTrue(all(each['first_file_date'] >= datetime.date(2015, 2, 1).isoformat() for each in results))
         results = self._results(api.url_for(CommitteeList, max_first_file_date='02/03/2015'))
-        self.assertTrue(all(each['first_file_date'] <= isoformat(datetime.datetime(2015, 3, 1)) for each in results))
+        self.assertTrue(all(each['first_file_date'] <= datetime.date(2015, 3, 1).isoformat() for each in results))
         results = self._results(
             api.url_for(
                 CommitteeList,
@@ -284,9 +284,9 @@ class CommitteeFormatTest(ApiBaseTest):
         )
         self.assertTrue(
             all(
-                isoformat(datetime.datetime(2015, 2, 1))
+                datetime.date(2015, 2, 1).isoformat()
                 <= each['first_file_date']
-                <= isoformat(datetime.datetime(2015, 3, 1))
+                <= datetime.date(2015, 3, 1).isoformat()
                 for each in results
             )
         )

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -5,9 +5,9 @@ import sqlalchemy as sa
 from tests import factories
 from tests.common import ApiBaseTest
 
-from webservices import schemas
-from webservices.rest import db
 from webservices.rest import api
+from webservices.schemas import ScheduleASchema
+from webservices.schemas import ScheduleBSchema
 from webservices.resources.sched_a import ScheduleAView
 from webservices.resources.sched_b import ScheduleBView
 from webservices.resources.sched_e import ScheduleEView
@@ -16,14 +16,15 @@ from webservices.resources.sched_e import ScheduleEView
 class TestItemized(ApiBaseTest):
 
     def test_fields(self):
-        [
-            factories.ScheduleAFactory(report_year=2014, contributor_receipt_date=datetime.datetime(2014, 1, 1)),
-            factories.ScheduleAFactory(report_year=2012, contributor_receipt_date=datetime.datetime(2012, 1, 1)),
-            factories.ScheduleAFactory(report_year=1986, contributor_receipt_date=datetime.datetime(1986, 1, 1)),
+        params = [
+            (factories.ScheduleAFactory, ScheduleAView, ScheduleASchema),
+            (factories.ScheduleBFactory, ScheduleBView, ScheduleBSchema),
         ]
-        results = self._results(api.url_for(ScheduleAView))
-        for result in results:
-            assert result.keys() == schemas.ScheduleASchema().fields.keys()
+        for factory, resource, schema in params:
+            factory()
+            results = self._results(api.url_for(resource))
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0].keys(), schema().fields.keys())
 
     def test_sorting(self):
         [

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -5,6 +5,7 @@ import sqlalchemy as sa
 from tests import factories
 from tests.common import ApiBaseTest
 
+from webservices import schemas
 from webservices.rest import db
 from webservices.rest import api
 from webservices.resources.sched_a import ScheduleAView
@@ -14,13 +15,22 @@ from webservices.resources.sched_e import ScheduleEView
 
 class TestItemized(ApiBaseTest):
 
+    def test_fields(self):
+        [
+            factories.ScheduleAFactory(report_year=2014, contributor_receipt_date=datetime.datetime(2014, 1, 1)),
+            factories.ScheduleAFactory(report_year=2012, contributor_receipt_date=datetime.datetime(2012, 1, 1)),
+            factories.ScheduleAFactory(report_year=1986, contributor_receipt_date=datetime.datetime(1986, 1, 1)),
+        ]
+        results = self._results(api.url_for(ScheduleAView))
+        for result in results:
+            assert result.keys() == schemas.ScheduleASchema().fields.keys()
+
     def test_sorting(self):
         [
             factories.ScheduleAFactory(report_year=2014, contributor_receipt_date=datetime.datetime(2014, 1, 1)),
             factories.ScheduleAFactory(report_year=2012, contributor_receipt_date=datetime.datetime(2012, 1, 1)),
             factories.ScheduleAFactory(report_year=1986, contributor_receipt_date=datetime.datetime(1986, 1, 1)),
         ]
-        db.session.flush()
         response = self._response(api.url_for(ScheduleAView, sort='contributor_receipt_date'))
         self.assertEqual(
             [each['report_year'] for each in response['results']],

--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -1,4 +1,3 @@
-import re
 from flask.ext.sqlalchemy import SQLAlchemy
 from sqlalchemy.dialects.postgresql import ARRAY, TSVECTOR
 from sqlalchemy.ext.declarative import declared_attr
@@ -135,8 +134,8 @@ class BaseConcreteCommittee(BaseCommittee):
 class Committee(BaseConcreteCommittee):
     __table_args__ = {'extend_existing': True}
 
-    first_file_date = db.Column(db.DateTime)
-    last_file_date = db.Column(db.DateTime)
+    first_file_date = db.Column(db.Date)
+    last_file_date = db.Column(db.Date)
 
 
 class CommitteeHistory(BaseCommittee):
@@ -153,8 +152,8 @@ class CommitteeHistory(BaseCommittee):
 class CommitteeDetail(BaseConcreteCommittee):
     __table_args__ = {'extend_existing': True}
 
-    first_file_date = db.Column(db.DateTime)
-    last_file_date = db.Column(db.DateTime)
+    first_file_date = db.Column(db.Date)
+    last_file_date = db.Column(db.Date)
     filing_frequency = db.Column(db.String(1))
     email = db.Column(db.String(50))
     fax = db.Column(db.String(10))
@@ -165,7 +164,7 @@ class CommitteeDetail(BaseConcreteCommittee):
     lobbyist_registrant_pac = db.Column(db.String(1))
     party_type = db.Column(db.String(3))
     party_type_full = db.Column(db.String(15))
-    qualifying_date = db.Column(db.DateTime())
+    qualifying_date = db.Column(db.Date())
     street_1 = db.Column(db.String(50))
     street_2 = db.Column(db.String(50))
     city = db.Column(db.String(50))
@@ -674,7 +673,7 @@ class ScheduleA(BaseItemized):
     contributor_employer = db.Column('contbr_employer', db.String)
     contributor_occupation = db.Column('contbr_occupation', db.String)
     contributor_aggregate_ytd = db.Column('contb_aggregate_ytd', db.Float)
-    contributor_receipt_date = db.Column('contb_receipt_dt', db.DateTime)
+    contributor_receipt_date = db.Column('contb_receipt_dt', db.Date)
     contributor_receipt_amount = db.Column('contb_receipt_amt', db.Float)
     receipt_type = db.Column('receipt_tp', db.String)
     receipt_type_full = db.Column('receipt_desc', db.String)
@@ -686,7 +685,7 @@ class ScheduleA(BaseItemized):
     record_number = db.Column('record_num', db.Integer)
     report_primary_general = db.Column('rpt_pgi', db.String)
     form_type_full = db.Column('form_tp_cd', db.String)
-    receipt_date = db.Column('receipt_dt', db.DateTime)
+    receipt_date = db.Column('receipt_dt', db.Date)
     increased_limit = db.Column(db.String)
     load_date = db.Column(db.DateTime)
     update_date = db.Column(db.DateTime)
@@ -792,7 +791,7 @@ class ScheduleB(BaseItemized):
     recipient_zip = db.Column(db.String)
     disbursement_type = db.Column('disb_tp', db.String)
     disbursement_description = db.Column('disb_desc', db.String)
-    disbursement_date = db.Column('disb_dt', db.DateTime)
+    disbursement_date = db.Column('disb_dt', db.Date)
     disbursement_amount = db.Column('disb_amt', db.Float)
     back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
     back_reference_schedule_id = db.Column('back_ref_sched_id', db.String)
@@ -801,7 +800,7 @@ class ScheduleB(BaseItemized):
     election_type_full = db.Column('election_tp_desc', db.String)
     record_number = db.Column('record_num', db.Integer)
     report_primary_general = db.Column('rpt_pgi', db.String)
-    receipt_date = db.Column('receipt_dt', db.DateTime)
+    receipt_date = db.Column('receipt_dt', db.Date)
     beneficiary_committee_name = db.Column('benef_cmte_nm', db.String)
     semi_annual_bundled_refund = db.Column('semi_an_bundled_refund', db.Float)
     load_date = db.Column(db.DateTime)
@@ -863,7 +862,7 @@ class ScheduleE(BaseItemized):
     notary_commission_expiration_date = db.Column('notary_commission_exprtn_dt', db.Date)
     back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
     back_reference_schedule_name = db.Column('back_ref_sched_nm', db.String)
-    receipt_date = db.Column('receipt_dt', db.DateTime)
+    receipt_date = db.Column('receipt_dt', db.Date)
     record_number = db.Column('record_num', db.Integer)
     report_primary_general = db.Column('rpt_pgi', db.String)
     office_total_ytd = db.Column('cal_ytd_ofc_sought', db.Float)


### PR DESCRIPTION
Several columns were set as `DateTime` types but should have been
`Date`, causing the corresponding fields to be lost on serialization.
This patch fixes the incorrect data types and adds a regression test.