### PR TITLE
Use most recent designation row.

### DIFF
--- a/data/sql_updates/create_committee_history.sql
+++ b/data/sql_updates/create_committee_history.sql
@@ -33,6 +33,11 @@ with
         where form_tp = 'F1'
         group by cmte_sk
     ),
+    dsgn as (
+        select dcp.receipt_dt, dd.* from dimcmteproperties dcp
+        join dimcmtetpdsgn dd using (form_sk)
+        order by dcp.receipt_dt desc
+    ),
     candidate_agg as (
         select
             cmte_sk,
@@ -110,7 +115,7 @@ from dimcmteproperties dcp
 left join cycle_agg on dcp.cmte_sk = cycle_agg.cmte_sk
 left join cycles on dcp.cmte_sk = cycles.cmte_sk and dcp.rpt_yr <= cycles.cycle
 left join dimparty p on dcp.cand_pty_affiliation = p.party_affiliation
-left join dimcmtetpdsgn dd using (form_sk)
+left join dsgn dd on dcp.cmte_sk = dd.cmte_sk and extract(year from dd.receipt_date) <= cycles.cycle
 left join dcp_original on dcp.cmte_sk = dcp_original.cmte_sk
 left join candidate_agg on dcp.cmte_sk = candidate_agg.cmte_sk
 where max_cycle >= :START_YEAR


### PR DESCRIPTION
In #1107, we changed the join between dimcmteproperties and
dimcmtetpdsgn to use the form_sk column. This works for most records but
causes problems with missing designation records. This patch joins
dimcmteproperties on the most recent tuple from a separate join of
dimcmteproperties and dimcmtetpdsgn.

Note: If the receipt_date column is repopulated in dimcmtetpdsgn, we can
revert to the logic we were using pre-#1107.