### PR TITLE
Expose control over null order.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,6 +52,17 @@ class TestSort(ApiBaseTest):
         query, columns = sorting.sort(models.Candidate.query, 'district', model=models.Candidate, hide_null=True)
         self.assertEqual(query.all(), candidates[:2])
 
+    def test_nulls_large(self):
+        candidates = [
+            factories.CandidateFactory(district='01'),
+            factories.CandidateFactory(district='02'),
+            factories.CandidateFactory(),
+        ]
+        query, columns = sorting.sort(models.Candidate.query, 'district', model=models.Candidate, nulls_large=False)
+        self.assertEqual(query.all(), candidates[-1:] + candidates[:2])
+        query, columns = sorting.sort(models.Candidate.query, '-district', model=models.Candidate, nulls_large=False)
+        self.assertEqual(query.all(), [candidates[1], candidates[0], candidates[2]])
+
 
 class TestFilter(ApiBaseTest):
 

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -120,7 +120,7 @@ class IndexValidator(OptionValidator):
         return not value or value in self.exclude
 
 
-def make_sort_args(default=None, multiple=True, validator=None, default_hide_null=False):
+def make_sort_args(default=None, multiple=True, validator=None, default_hide_null=False, default_nulls_large=True):
     return {
         'sort': Arg(
             str,
@@ -132,6 +132,10 @@ def make_sort_args(default=None, multiple=True, validator=None, default_hide_nul
         'sort_hide_null': Bool(
             default=default_hide_null,
             description='Hide null values on sorted column(s).'
+        ),
+        'sort_nulls_large': Bool(
+            default=default_nulls_large,
+            description='Treat null values as large on sorted column(s)',
         )
     }
 

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -121,7 +121,7 @@ class ElectionView(Resource):
 
     @args.register_kwargs(args.paging)
     @args.register_kwargs(args.elections)
-    @args.register_kwargs(args.make_sort_args(default=['-total_receipts']))
+    @args.register_kwargs(args.make_sort_args(default=['-total_receipts'], default_nulls_large=False))
     @schemas.marshal_with(schemas.ElectionPageSchema())
     def get(self, **kwargs):
         query = self._get_records(kwargs)

--- a/webservices/sorting.py
+++ b/webservices/sorting.py
@@ -1,23 +1,26 @@
 import sqlalchemy as sa
+from sqlalchemy.sql.expression import nullsfirst, nullslast
 
 from webservices.exceptions import ApiError
 
 
-def parse_option(option, model=None):
+def parse_option(option, model=None, nulls_large=True):
     """Parse sort option to SQLAlchemy order expression.
 
     :param str option: Column name, possibly prefixed with "-"
     :param model: Optional SQLAlchemy model to sort on
+    :param nulls_large: Treat null values as large
     :raises: ApiError if column not found on model
     """
     order = sa.desc if option.startswith('-') else sa.asc
+    nulls = nullsfirst if (nulls_large ^ (not option.startswith('-'))) else nullslast
     column = option.lstrip('-')
     if model:
         try:
             column = getattr(model, column)
         except AttributeError:
             raise ApiError('Field "{0}" not found'.format(column))
-    return column, order
+    return column, order, nulls
 
 
 def ensure_list(value):
@@ -28,7 +31,7 @@ def ensure_list(value):
     return []
 
 
-def sort(query, options, model, clear=False, hide_null=False):
+def sort(query, options, model, clear=False, hide_null=False, nulls_large=True):
     """Sort query using string-formatted columns.
 
     :param query: Original query
@@ -37,14 +40,15 @@ def sort(query, options, model, clear=False, hide_null=False):
     :param model: SQLAlchemy model
     :param clear: Clear existing sort conditions
     :param hide_null: Exclude null values on sorted column(s)
+    :param nulls_large: Treat null values as large on sorted column(s)
     """
     if clear:
         query = query.order_by(False)
     options = ensure_list(options)
     columns = []
     for option in options:
-        column, order = parse_option(option, model=model)
-        query = query.order_by(order(column))
+        column, order, nulls = parse_option(option, model=model, nulls_large=nulls_large)
+        query = query.order_by(nulls(order(column)))
         if hide_null:
             query = query.filter(column != None)  # noqa
         columns.append((column, order))

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -19,8 +19,8 @@ def check_cap(kwargs, cap):
 
 def fetch_page(query, kwargs, model=None, clear=False, count=None, cap=100):
     check_cap(kwargs, cap)
-    sort, hide_null = kwargs['sort'], kwargs['sort_hide_null']
-    query, _ = sorting.sort(query, sort, model=model, clear=clear, hide_null=hide_null)
+    sort, hide_null, nulls_large = kwargs['sort'], kwargs['sort_hide_null'], kwargs['sort_nulls_large']
+    query, _ = sorting.sort(query, sort, model=model, clear=clear, hide_null=hide_null, nulls_large=nulls_large)
     paginator = paging.SqlalchemyOffsetPaginator(query, kwargs['per_page'], count=count)
     return paginator.get_page(kwargs['page'])
 
@@ -28,8 +28,8 @@ def fetch_page(query, kwargs, model=None, clear=False, count=None, cap=100):
 def fetch_seek_page(query, kwargs, index_column, clear=False, count=None, cap=100):
     check_cap(kwargs, cap)
     model = index_column.class_
-    sort, hide_null = kwargs['sort'], kwargs['sort_hide_null']
-    query, sort_columns = sorting.sort(query, sort, model=model, clear=clear, hide_null=hide_null)
+    sort, hide_null, nulls_large = kwargs['sort'], kwargs['sort_hide_null'], kwargs['sort_nulls_large']
+    query, sort_columns = sorting.sort(query, sort, model=model, clear=clear, hide_null=hide_null, nulls_large=nulls_large)
     sort_column = sort_columns[0] if sort_columns else None
     paginator = paging.SqlalchemySeekPaginator(
         query,


### PR DESCRIPTION
Allow API consumers to specify whether null values are treated as small
or large when sorting using the `sort_nulls_large` parameter. Useful for
keeping candidates with small fundraising totals out of the top of the
election view endpoint.