### PR TITLE
Fix error on empty elections.

### DIFF
--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -111,6 +111,10 @@ class TestElections(ApiBaseTest):
         response = self.app.get(api.url_for(ElectionView, office='house', cycle=2012, state='NY', district='01'))
         self.assertEquals(response.status_code, 200)
 
+    def test_empty_query(self):
+        results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='ZZ', per_page=0))
+        self.assertEqual(len(results), 0)
+
     def test_elections(self):
         results = self._results(api.url_for(ElectionView, office='house', cycle=2012, state='NY', district='07'))
         self.assertEqual(len(results), 1)

--- a/webservices/paging.py
+++ b/webservices/paging.py
@@ -90,7 +90,9 @@ class BasePaginator(object):
 
     @property
     def pages(self):
-        return int(math.ceil(self.count / self.per_page))
+        if self.per_page:
+            return int(math.ceil(self.count / self.per_page))
+        return 0
 
     @abc.abstractmethod
     def _count(self):


### PR DESCRIPTION
* Catch zero division error on empty query sets with no per-page cap
* Add regression test

h/t @noahmanger for finding the error