### PR TITLE
Use Flask-CORS for more robust CORS configuration.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 psycopg2==2.6
+Flask-Cors==2.1.0
 Flask-RESTful==0.3.3
 Flask-SQLAlchemy==2.0
 newrelic==2.52.0.40

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -16,6 +16,7 @@ from flask import render_template
 from flask import Flask
 from flask import Blueprint
 
+from flask.ext import cors
 from flask.ext import restful
 
 from webservices import args
@@ -58,6 +59,7 @@ app.debug = True
 app.config['SQLALCHEMY_DATABASE_URI'] = sqla_conn_string()
 # app.config['SQLALCHEMY_ECHO'] = True
 db.init_app(app)
+cors.CORS(app)
 
 
 v1 = Blueprint('v1', __name__, url_prefix='/v1')
@@ -95,14 +97,6 @@ def limit_remote_addr():
         else:
             if api_data_route not in trusted_proxies:
                 abort(403)
-
-
-@app.after_request
-def add_cors_headers(response):
-    response.headers.add('Access-Control-Allow-Origin', '*')
-    response.headers.add('Access-Control-Allow-Methods', 'GET')
-    response.headers.add('Access-Control-Max-Age', '3000')
-    return response
 
 
 @app.after_request


### PR DESCRIPTION
The API currently uses the `Access-Control-Allow-Origin` header, but not
the `Access-Control-Allow-Headers` header. This leads to CORS errors
when using Safari, which sends the `Accept-Encoding` header with its
`OPTIONS` requests. Rather than allowing the `Accept-Encoding` header,
this patch switches to Flask-CORS for CORS configuration, which has
better defaults and is easier to configure than settings CORS headers
manually.

Thanks @onezerojeremy and @noahmanger for help with debugging.

[Resolves https://github.com/18F/openFEC-web-app/issues/462]