### PR TITLE
Fix filtering on filings view.

### DIFF
--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -1,7 +1,5 @@
 import datetime
 
-from marshmallow.utils import isoformat
-
 from webservices.rest import api
 from webservices.resources.filings import FilingsView, FilingsList
 
@@ -14,7 +12,7 @@ class TestFilings(ApiBaseTest):
     def test_committee_filings(self):
         """ Check filing returns with a specified committee id"""
         committee_id = 'C8675309'
-        filing = factories.FilingsFactory(committee_id=committee_id)
+        factories.FilingsFactory(committee_id=committee_id)
 
         results = self._results(api.url_for(FilingsView, committee_id=committee_id))
         self.assertEqual(results[0]['committee_id'], committee_id)
@@ -28,30 +26,30 @@ class TestFilings(ApiBaseTest):
 
     def test_filings(self):
         """ Check filings returns in general endpoint"""
-        filing_1 = factories.FilingsFactory(committee_id='C001')
-        filing_2 = factories.FilingsFactory(committee_id='C002')
+        factories.FilingsFactory(committee_id='C001')
+        factories.FilingsFactory(committee_id='C002')
 
         results = self._results(api.url_for(FilingsList))
         self.assertEqual(len(results), 2)
 
     def test_filter_date(self):
         [
-            factories.FilingsFactory(receipt_date=datetime.datetime(2012, 1, 1)),
-            factories.FilingsFactory(receipt_date=datetime.datetime(2013, 1, 1)),
-            factories.FilingsFactory(receipt_date=datetime.datetime(2014, 1, 1)),
-            factories.FilingsFactory(receipt_date=datetime.datetime(2015, 1, 1)),
+            factories.FilingsFactory(receipt_date=datetime.date(2012, 1, 1)),
+            factories.FilingsFactory(receipt_date=datetime.date(2013, 1, 1)),
+            factories.FilingsFactory(receipt_date=datetime.date(2014, 1, 1)),
+            factories.FilingsFactory(receipt_date=datetime.date(2015, 1, 1)),
         ]
-        min_date = datetime.datetime(2013, 1, 1)
+        min_date = datetime.date(2013, 1, 1)
         results = self._results(api.url_for(FilingsList, min_receipt_date=min_date))
-        self.assertTrue(all(each for each in results if each['receipt_date'] >= isoformat(min_date)))
-        max_date = datetime.datetime(2014, 1, 1)
+        self.assertTrue(all(each for each in results if each['receipt_date'] >= min_date.isoformat()))
+        max_date = datetime.date(2014, 1, 1)
         results = self._results(api.url_for(FilingsList, max_receipt_date=max_date))
-        self.assertTrue(all(each for each in results if each['receipt_date'] <= isoformat(max_date)))
+        self.assertTrue(all(each for each in results if each['receipt_date'] <= max_date.isoformat()))
         results = self._results(api.url_for(FilingsList, min_receipt_date=min_date, max_receipt_date=max_date))
         self.assertTrue(
             all(
                 each for each in results
-                if isoformat(min_date) <= each['receipt_date'] <= isoformat(max_date)
+                if min_date.isoformat() <= each['receipt_date'] <= max_date.isoformat()
             )
         )
 
@@ -110,7 +108,7 @@ class TestFilings(ApiBaseTest):
 
     def test_regex(self):
         """ Getting rid of extra text that comes in the tables."""
-        filing = factories.FilingsFactory(
+        factories.FilingsFactory(
             report_type_full='report {more information than we want}',
             committee_id='C007',
             report_year=2004,

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -255,8 +255,6 @@ committee_list = {
 }
 
 filings = {
-    'committee_id': IString(multiple=True, description=docs.COMMITTEE_ID),
-    'candidate_id': IString(multiple=True, description=docs.CANDIDATE_ID),
     'report_type': IString(multiple=True, description='Report type'),
     'document_type': IString(multiple=True, description=docs.DOC_TYPE),
     'beginning_image_number': Arg(int, multiple=True, description=docs.BEGINNING_IMAGE_NUMBER),
@@ -264,7 +262,7 @@ filings = {
     'min_receipt_date': Date(description='Minimum day the filing was received by the FEC'),
     'max_receipt_date': Date(description='Maximum day the filing was received by the FEC'),
     'form_type': IString(multiple=True, description='Form type'),
-    'primary_general_indicator': IString(multiple=True, description='Primary Gereral or Special election indicator.'),
+    'primary_general_indicator': IString(multiple=True, description='Primary General or Special election indicator.'),
     'amendment_indicator': IString(multiple=True, description='''
         -N   new\n\
         -A   amendment\n\
@@ -460,6 +458,11 @@ schedule_a_candidate_aggregate = {
     'cycle': Arg(int, multiple=True, required=True, description=docs.RECORD_CYCLE),
 }
 
+
+entities = {
+    'committee_id': IString(multiple=True, description=docs.COMMITTEE_ID),
+    'candidate_id': IString(multiple=True, description=docs.CANDIDATE_ID),
+}
 
 schedule_e = {
     'committee_id': IString(multiple=True, description=docs.COMMITTEE_ID),

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -8,57 +8,46 @@ from webservices import utils
 from webservices import schemas
 from webservices.common import counts
 from webservices.common import models
-from webservices.common.util import filter_query
-
-
-fields = {
-    'committee_id',
-    'candidate_id',
-    'beginning_image_number',
-    'report_type',
-    'document_type',
-    'report_year',
-    'receipt_date',
-    'form_type',
-    'primary_general_indicator',
-    'amendment_indicator',
-}
-
-range_fields = [
-    (('min_receipt_date', 'max_receipt_date'), models.Filings.receipt_date),
-]
 
 
 @spec.doc(
     tags=['filings'],
     description=docs.FILINGS,
-    path_params=[utils.committee_param, utils.candidate_param],
+    path_params=[
+        utils.extend(utils.committee_param, {'name': 'committee_id'}),
+        utils.extend(utils.candidate_param, {'name': 'candidate_id'}),
+    ],
 )
-class FilingsView(Resource):
+class BaseFilings(Resource):
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(
-        args.make_sort_args(
-            default=['-receipt_date'],
-            validator=args.IndexValidator(models.Filings),
-        )
-    )
-    @schemas.marshal_with(schemas.FilingsPageSchema())
-    def get(self, committee_id=None, candidate_id=None, **kwargs):
-        query = models.Filings.query
-        if committee_id:
-            query = query.filter(models.Filings.committee_id == committee_id)
-        if candidate_id:
-            query = query.filter(models.Filings.candidate_id == candidate_id)
+    range_fields = [
+        (('min_receipt_date', 'max_receipt_date'), models.Filings.receipt_date),
+    ]
+
+    multi_fields = [
+        ('beginning_image_number', models.Filings.beginning_image_number),
+        ('report_type', models.Filings.report_type),
+        ('document_type', models.Filings.document_type),
+        ('report_year', models.Filings.report_year),
+        ('form_type', models.Filings.form_type),
+        ('primary_general_indicator', models.Filings.primary_general_indicator),
+        ('amendment_indicator', models.Filings.amendment_indicator),
+    ]
+
+    def get(self, **kwargs):
+        query = self._build_query(**kwargs)
         count = counts.count_estimate(query, models.db.session, threshold=5000)
         return utils.fetch_page(query, kwargs, model=models.Filings, count=count)
 
+    def _build_query(self, **kwargs):
+        query = models.Filings.query
+        query = query.options(sa.orm.joinedload(models.Filings.committee))
+        query = utils.filter_multi(query, kwargs, self.multi_fields)
+        query = utils.filter_range(query, kwargs, self.range_fields)
+        return query
 
-@spec.doc(
-    tags=['filings'],
-    description=docs.FILINGS,
-)
-class FilingsList(Resource):
+
+class FilingsView(BaseFilings):
 
     @args.register_kwargs(args.paging)
     @args.register_kwargs(args.filings)
@@ -70,9 +59,33 @@ class FilingsList(Resource):
     )
     @schemas.marshal_with(schemas.FilingsPageSchema())
     def get(self, **kwargs):
-        query = models.Filings.query
-        query = query.options(sa.orm.joinedload(models.Filings.committee))
-        query = filter_query(models.Filings, query, fields, kwargs)
-        query = utils.filter_range(query, kwargs, range_fields)
-        count = counts.count_estimate(query, models.db.session, threshold=5000)
-        return utils.fetch_page(query, kwargs, model=models.Filings, count=count)
+        return super().get(**kwargs)
+
+    def _build_query(self, committee_id=None, candidate_id=None, **kwargs):
+        query = super()._build_query(**kwargs)
+        if committee_id:
+            query = query.filter(models.Filings.committee_id == committee_id)
+        if candidate_id:
+            query = query.filter(models.Filings.candidate_id == candidate_id)
+        return query
+
+
+class FilingsList(BaseFilings):
+
+    multi_fields = BaseFilings.multi_fields + [
+        ('committee_id', models.Filings.committee_id),
+        ('candidate_id', models.Filings.candidate_id),
+    ]
+
+    @args.register_kwargs(args.paging)
+    @args.register_kwargs(args.filings)
+    @args.register_kwargs(args.entities)
+    @args.register_kwargs(
+        args.make_sort_args(
+            default=['-receipt_date'],
+            validator=args.IndexValidator(models.Filings),
+        )
+    )
+    @schemas.marshal_with(schemas.FilingsPageSchema())
+    def get(self, **kwargs):
+        return super().get(**kwargs)

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -213,8 +213,8 @@ api.add_resource(
 
 api.add_resource(
     filings.FilingsView,
-    '/committee/<string:committee_id>/filings/',
-    '/candidate/<string:candidate_id>/filings/',
+    '/committee/<committee_id>/filings/',
+    '/candidate/<candidate_id>/filings/',
 )
 api.add_resource(filings.FilingsList, '/filings/')
 


### PR DESCRIPTION
Currently, the filings view mounted as a sub-resource of a candidate or
committee does no filtering, which breaks the filter widget on the
committee and candidate filings pages. This patch adds filtering on
filings sub-resources and merges the two filings resources into a single
class.

Note: To make this play nicely with Swagger, the path parameters for
committee and candidate IDs are prefixed with "path_". This is a hack
but has no effect on the behavior of the API, so I think it's
acceptable.