### PR TITLE
Use `tuple_` expression for row value filters.

### DIFF
--- a/webservices/paging.py
+++ b/webservices/paging.py
@@ -161,7 +161,9 @@ class SqlalchemySeekPaginator(SqlalchemyMixin, SeekPaginator):
         if last_index is not None:
             lhs += (self.index_column, )
             rhs += (last_index, )
-        if any(rhs):
+        lhs = sa.tuple_(*lhs)
+        rhs = sa.tuple_(*rhs)
+        if rhs.clauses:
             filter = lhs > rhs if direction == sa.asc else lhs < rhs
             cursor = cursor.filter(filter)
         return cursor.order_by(direction(self.index_column)).limit(limit).all()


### PR DESCRIPTION
Seek pagination with multiple sort columns requires the use of SQL row
value comparisons (e.g. `(foo, bar) < (1, 2)`). This patch uses the
SQLAlchemy `tuple_` expression to use row values; plain Python `tuple`
objects don't translate to the correct query.

Fixes a sorting issue raised in fec-partners.