### PR TITLE
Feature/handle duplicate receipts

### DIFF
--- a/data/functions/utils.sql
+++ b/data/functions/utils.sql
@@ -1,0 +1,33 @@
+create or replace function is_individual(amount numeric, receipt_type text, line_number text, memo_text text) returns bool as $$
+begin
+    return (
+        is_coded_individual(receipt_type) or
+        is_inferred_individual(amount, line_number, memo_text)
+    );
+end
+$$ language plpgsql immutable;
+
+
+create or replace function is_coded_individual(receipt_type text) returns bool as $$
+begin
+    return receipt_type is not null and receipt_type in ('15', '15E', '15J', '18J');
+end
+$$ language plpgsql immutable;
+
+
+create or replace function is_inferred_individual(amount numeric, line_number text, memo_text text) returns bool as $$
+begin
+    return (
+        amount is not null and amount < 200 and
+        line_number is not null and line_number in ('11AI', '12', '17', '17A', '18') and
+        not is_earmark(memo_text)
+    );
+end
+$$ language plpgsql immutable;
+
+
+create or replace function is_earmark(memo_text text) returns bool as $$
+begin
+    return memo_text is not null and memo_text ~* 'earmark|earmk|ermk';
+end
+$$ language plpgsql immutable;

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_employer.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_employer.sql
@@ -10,8 +10,7 @@ select
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
-and (memo_cd != 'X' or memo_cd is null)
-and line_num in ('11AI', '17A')
+and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
 group by cmte_id, cycle, employer
 ;
 
@@ -46,8 +45,7 @@ begin
             select * from old
         ) t
         where contb_receipt_amt is not null
-        and (memo_cd != 'X' or memo_cd is null)
-        and line_num in ('11AI', '17A')
+        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
         group by cmte_id, cycle, employer
     ),
     inc as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_occupation.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_occupation.sql
@@ -10,8 +10,7 @@ select
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
-and (memo_cd != 'X' or memo_cd is null)
-and line_num in ('11AI', '17A')
+and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
 group by cmte_id, cycle, occupation
 ;
 
@@ -46,8 +45,7 @@ begin
             select * from old
         ) t
         where contb_receipt_amt is not null
-        and (memo_cd != 'X' or memo_cd is null)
-        and line_num in ('11AI', '17A')
+        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
         group by cmte_id, cycle, occupation
     ),
     inc as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
@@ -22,8 +22,7 @@ select
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
-and (memo_cd != 'X' or memo_cd is null)
-and line_num in ('11AI', '17A')
+and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
 group by cmte_id, cycle, size
 ;
 
@@ -58,8 +57,7 @@ begin
             select * from old
         ) t
         where contb_receipt_amt is not null
-        and (memo_cd != 'X' or memo_cd is null)
-        and line_num in ('11AI', '17A')
+        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
         group by cmte_id, cycle, size
     ),
     inc as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_state.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_state.sql
@@ -10,8 +10,7 @@ select
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
-and (memo_cd != 'X' or memo_cd is null)
-and line_num in ('11AI', '17A')
+and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
 group by cmte_id, cycle, state
 ;
 
@@ -47,8 +46,7 @@ begin
             select * from old
         ) t
         where contb_receipt_amt is not null
-        and (memo_cd != 'X' or memo_cd is null)
-        and line_num in ('11AI', '17A')
+        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
         group by cmte_id, cycle, state
     ),
     inc as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_zip.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_zip.sql
@@ -12,8 +12,7 @@ select
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
-and (memo_cd != 'X' or memo_cd is null)
-and line_num in ('11AI', '17A')
+and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
 group by cmte_id, cycle, zip
 ;
 
@@ -52,8 +51,7 @@ begin
             select * from old
         ) t
         where contb_receipt_amt is not null
-        and (memo_cd != 'X' or memo_cd is null)
-        and line_num in ('11AI', '17A')
+        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
         group by cmte_id, cycle, zip
     ),
     inc as (

--- a/data/sql_setup/prepare_schedule_a.sql
+++ b/data/sql_setup/prepare_schedule_a.sql
@@ -7,6 +7,9 @@ create index on sched_a (contbr_id) where rpt_yr >= :START_YEAR_ITEMIZED;
 create index on sched_a (contbr_st) where rpt_yr >= :START_YEAR_ITEMIZED;
 create index on sched_a (contbr_city) where rpt_yr >= :START_YEAR_ITEMIZED;
 
+-- Create functional index on individual receipts
+create index on sched_a (is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text));
+
 -- Create composite indices on sortable columns
 create index on sched_a (contb_receipt_dt, sched_a_sk) where rpt_yr >= :START_YEAR_ITEMIZED;
 create index on sched_a (contb_receipt_amt, sched_a_sk) where rpt_yr >= :START_YEAR_ITEMIZED;

--- a/tests/common.py
+++ b/tests/common.py
@@ -50,6 +50,7 @@ class ApiBaseTest(BaseTestCase):
     def setUpClass(cls):
         super(ApiBaseTest, cls).setUpClass()
         manage.load_districts()
+        manage.update_functions()
         rest.db.create_all()
 
     def setUp(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -171,7 +171,7 @@ class TestViews(common.IntegrationTestCase):
             'report_year': 2015,
             'committee_id': 'C12345',
             'contribution_receipt_amount': 538,
-            'line_number': '11AI',
+            'receipt_type': '15J',
             item_key: value,
         })
         db.session.flush()
@@ -203,7 +203,7 @@ class TestViews(common.IntegrationTestCase):
             'report_year': 2015,
             'committee_id': existing.committee_id,
             'contribution_receipt_amount': 538,
-            'line_number': '11AI',
+            'receipt_type': '15J',
             item_key: getattr(existing, total_key),
         })
         db.session.flush()
@@ -235,7 +235,7 @@ class TestViews(common.IntegrationTestCase):
             committee_id=existing.committee_id,
             contributor_state=existing.state,
             contribution_receipt_amount=None,
-            line_number='11AI',
+            receipt_type='15J',
         )
         db.session.flush()
         db.session.execute('select update_aggregates()')
@@ -248,7 +248,7 @@ class TestViews(common.IntegrationTestCase):
             report_year=2015,
             committee_id='C12345',
             contribution_receipt_amount=538,
-            line_number='11AI',
+            receipt_type='15J',
         )
         db.session.flush()
         db.session.execute('select update_aggregates()')
@@ -281,7 +281,7 @@ class TestViews(common.IntegrationTestCase):
             report_year=2015,
             committee_id=existing.committee_id,
             contribution_receipt_amount=538,
-            line_number='11AI',
+            receipt_type='15J',
         )
         db.session.flush()
         db.session.execute('select update_aggregates()')
@@ -300,7 +300,7 @@ class TestViews(common.IntegrationTestCase):
             report_year=2015,
             committee_id=existing.committee_id,
             contribution_receipt_amount=75,
-            line_number='11AI',
+            receipt_type='15J',
         )
         # Create a committee and committee report
         dc = sa.Table('dimcmte', db.metadata, autoload=True, autoload_with=db.engine)

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -195,6 +195,26 @@ class TestItemized(ApiBaseTest):
             self.assertFalse(results[0]['memoed_subtotal'])
             self.assertTrue(results[1]['memoed_subtotal'])
 
+    def test_filter_individual_sched_a(self):
+        individuals = [
+            factories.ScheduleAFactory(receipt_type='15J'),
+            factories.ScheduleAFactory(line_number='12', contribution_receipt_amount=150),
+        ]
+        earmarks = [
+            factories.ScheduleAFactory(),
+            factories.ScheduleAFactory(line_number='12', contribution_receipt_amount=150, memo_text='earmark'),
+        ]
+        results = self._results(api.url_for(ScheduleAView))
+        self.assertEqual(
+            [each['sched_a_sk'] for each in results],
+            [each.sched_a_sk for each in individuals + earmarks],
+        )
+        results = self._results(api.url_for(ScheduleAView, is_individual='true'))
+        self.assertEqual(
+            [each['sched_a_sk'] for each in results],
+            [each.sched_a_sk for each in individuals],
+        )
+
     def test_amount_sched_a(self):
         [
             factories.ScheduleAFactory(contribution_receipt_amount=50),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -318,13 +318,6 @@ itemized = {
     'max_date': Date(description='Maximum date'),
 }
 
-contributor_type = Arg(
-    str,
-    multiple=True,
-    validate=lambda v: v in ['individual', 'committee'],
-    description='Filters individual or committee contributions based on line number.'
-)
-
 reporting_dates = {
     'due_date': Date(multiple=True, description='Date the filing is done.'),
     'report_year': Arg(int, multiple=True, description='Year of report.'),
@@ -361,7 +354,13 @@ schedule_a = {
     'last_contribution_receipt_date': Date(),
     'last_contribution_receipt_amount': Arg(float),
     'last_contributor_aggregate_ytd': Arg(float),
-    'contributor_type': contributor_type,
+    'is_individual': Bool(default=None, description='Restrict to non-earmarked individual contributions'),
+    'contributor_type': Arg(
+        str,
+        multiple=True,
+        validate=lambda v: v in ['individual', 'committee'],
+        description='Filters individual or committee contributions based on line number.'
+    ),
 }
 
 

--- a/webservices/common/models.py
+++ b/webservices/common/models.py
@@ -1,6 +1,6 @@
-from sqlalchemy.dialects.postgresql import ARRAY, TSVECTOR
-from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.dialects.postgresql import ARRAY, TSVECTOR
 
 from flask.ext.sqlalchemy import SQLAlchemy
 
@@ -674,9 +674,9 @@ class ScheduleA(BaseItemized):
     contributor_zip = db.Column('contbr_zip', db.String)
     contributor_employer = db.Column('contbr_employer', db.String)
     contributor_occupation = db.Column('contbr_occupation', db.String)
-    contributor_aggregate_ytd = db.Column('contb_aggregate_ytd', db.Float)
+    contributor_aggregate_ytd = db.Column('contb_aggregate_ytd', db.Numeric(30, 2))
     contribution_receipt_date = db.Column('contb_receipt_dt', db.Date)
-    contribution_receipt_amount = db.Column('contb_receipt_amt', db.Float)
+    contribution_receipt_amount = db.Column('contb_receipt_amt', db.Numeric(30, 2))
     receipt_type = db.Column('receipt_tp', db.String)
     receipt_type_full = db.Column('receipt_desc', db.String)
     election_type = db.Column('election_tp', db.String)

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -13,6 +13,7 @@ class ItemizedResource(Resource):
     year_column = None
     index_column = None
     filter_multi_fields = []
+    filter_match_fields = []
     filter_fulltext_fields = []
 
     def get(self, **kwargs):
@@ -26,6 +27,7 @@ class ItemizedResource(Resource):
         )
 
         query = filters.filter_multi(query, kwargs, self.filter_multi_fields)
+        query = filters.filter_match(query, kwargs, self.filter_match_fields)
         query = filters.filter_range(query, kwargs, self.filter_range_fields)
         query = self.filter_fulltext(query, kwargs)
 

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -9,6 +9,14 @@ from webservices.common import models
 from webservices.common.views import ItemizedResource
 
 
+is_individual = sa.func.is_individual(
+    models.ScheduleA.contribution_receipt_amount,
+    models.ScheduleA.receipt_type,
+    models.ScheduleA.line_number,
+    models.ScheduleA.memo_text,
+)
+
+
 @spec.doc(
     tags=['schedules/schedule_a'],
     description=docs.SCHEDULE_A,
@@ -34,15 +42,18 @@ class ScheduleAView(ItemizedResource):
         ('contributor_city', models.ScheduleA.contributor_city),
         ('contributor_state', models.ScheduleA.contributor_state),
     ]
-    filter_fulltext_fields = [
-        ('contributor_name', models.ScheduleASearch.contributor_name_text),
-        ('contributor_employer', models.ScheduleASearch.contributor_employer_text),
-        ('contributor_occupation', models.ScheduleASearch.contributor_occupation_text),
+    filter_match_fields = [
+        ('is_individual', is_individual),
     ]
     filter_range_fields = [
         (('min_date', 'max_date'), models.ScheduleA.contribution_receipt_date),
         (('min_amount', 'max_amount'), models.ScheduleA.contribution_receipt_amount),
         (('min_image_number', 'max_image_number'), models.ScheduleA.image_number),
+    ]
+    filter_fulltext_fields = [
+        ('contributor_name', models.ScheduleASearch.contributor_name_text),
+        ('contributor_employer', models.ScheduleASearch.contributor_employer_text),
+        ('contributor_occupation', models.ScheduleASearch.contributor_occupation_text),
     ]
 
     @args.register_kwargs(args.itemized)


### PR DESCRIPTION
Apply rules for identifying unique individual receipts, as described by @jwchumley and @paulclark2. There are a few issues to address before this can be merged (some copied from #1141):
* Is the value of the `memo_cd` column relevant for identifying unique receipts, or is `memo_text` adequate?
* I applied the rules to receipt aggregates from individual records (by size, state, zip, employer, and occupation), since that seemed like the right thing to do. Can you confirm that this is correct?
* Aggregates of disbursements are still restricted to non-memoed rows. Since that criterion wasn't appropriate for receipts, do we also need to change it for disbursements?