### PR TITLE
Include F1 filings in filings endpoint.

### DIFF
--- a/data/functions/individual.sql
+++ b/data/functions/individual.sql
@@ -1,0 +1,36 @@
+create or replace function is_individual(amount numeric, receipt_type text, line_number text, memo_code text, memo_text text) returns bool as $$
+begin
+    return (
+        is_coded_individual(receipt_type) or
+        is_inferred_individual(amount, line_number, memo_code, memo_text)
+    );
+end
+$$ language plpgsql immutable;
+
+
+create or replace function is_coded_individual(receipt_type text) returns bool as $$
+begin
+    return receipt_type is not null and receipt_type in ('15', '15E', '15J', '18J');
+end
+$$ language plpgsql immutable;
+
+
+create or replace function is_inferred_individual(amount numeric, line_number text, memo_code text, memo_text text) returns bool as $$
+begin
+    return (
+        amount is not null and amount < 200 and
+        line_number is not null and line_number in ('11AI', '12', '17', '17A', '18') and
+        not is_earmark(memo_code, memo_text)
+    );
+end
+$$ language plpgsql immutable;
+
+
+create or replace function is_earmark(memo_code text, memo_text text) returns bool as $$
+begin
+  return (
+      memo_code is not null and memo_code = 'X' and
+      memo_text is not null and memo_text ~* 'earmark|earmk|ermk'
+  );
+end
+$$ language plpgsql immutable;

--- a/data/functions/utils.sql
+++ b/data/functions/utils.sql
@@ -1,0 +1,5 @@
+create or replace function get_cycle(year numeric) returns int as $$
+begin
+    return year + year % 2;
+end
+$$ language plpgsql;

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_employer.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_employer.sql
@@ -10,7 +10,7 @@ select
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
-and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
+and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
 group by cmte_id, cycle, employer
 ;
 
@@ -45,7 +45,7 @@ begin
             select * from old
         ) t
         where contb_receipt_amt is not null
-        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
+        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
         group by cmte_id, cycle, employer
     ),
     inc as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_occupation.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_occupation.sql
@@ -10,7 +10,7 @@ select
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
-and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
+and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
 group by cmte_id, cycle, occupation
 ;
 
@@ -45,7 +45,7 @@ begin
             select * from old
         ) t
         where contb_receipt_amt is not null
-        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
+        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
         group by cmte_id, cycle, occupation
     ),
     inc as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
@@ -22,7 +22,7 @@ select
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
-and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
+and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
 group by cmte_id, cycle, size
 ;
 
@@ -57,7 +57,7 @@ begin
             select * from old
         ) t
         where contb_receipt_amt is not null
-        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
+        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
         group by cmte_id, cycle, size
     ),
     inc as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_state.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_state.sql
@@ -10,7 +10,7 @@ select
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
-and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
+and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
 group by cmte_id, cycle, state
 ;
 
@@ -46,7 +46,7 @@ begin
             select * from old
         ) t
         where contb_receipt_amt is not null
-        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
+        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
         group by cmte_id, cycle, state
     ),
     inc as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_zip.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_zip.sql
@@ -12,7 +12,7 @@ select
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 and contb_receipt_amt is not null
-and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
+and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
 group by cmte_id, cycle, zip
 ;
 
@@ -51,7 +51,7 @@ begin
             select * from old
         ) t
         where contb_receipt_amt is not null
-        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text)
+        and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
         group by cmte_id, cycle, zip
     ),
     inc as (

--- a/data/sql_setup/prepare_schedule_a.sql
+++ b/data/sql_setup/prepare_schedule_a.sql
@@ -8,7 +8,9 @@ create index on sched_a (contbr_st) where rpt_yr >= :START_YEAR_ITEMIZED;
 create index on sched_a (contbr_city) where rpt_yr >= :START_YEAR_ITEMIZED;
 
 -- Create functional index on individual receipts
-create index on sched_a (is_individual(contb_receipt_amt, receipt_tp, line_num, memo_text));
+create index on sched_a
+    (is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text))
+    where rpt_yr >= :START_YEAR_ITEMIZED;
 
 -- Create composite indices on sortable columns
 create index on sched_a (contb_receipt_dt, sched_a_sk) where rpt_yr >= :START_YEAR_ITEMIZED;

--- a/data/sql_updates/post_committees_create_filings_view.sql
+++ b/data/sql_updates/post_committees_create_filings_view.sql
@@ -1,3 +1,12 @@
+create or replace function filings_year(report_year numeric, receipt_date date) returns int as $$
+begin
+    return case
+        when report_year != 0 then report_year
+        else date_part('year', receipt_date)
+    end;
+end
+$$ language plpgsql;
+
 drop materialized view if exists ofec_filings_mv_tmp;
 create materialized view ofec_filings_mv_tmp as
 select
@@ -12,7 +21,7 @@ select
     receipt_date,
     election_year,
     fh.form_type,
-    report_year,
+    filings_year(report_year, receipt_date) as report_year,
     report_type,
     to_from_indicator as document_type,
     expand_document(to_from_indicator) as document_type_full,
@@ -42,11 +51,11 @@ select
     amendment_indicator,
     update_date
 from vw_filing_history fh
-left join ofec_committee_history_mv_tmp com on fh.committee_id = com.committee_id and fh.report_year + fh.report_year % 2 = com.cycle
-left join ofec_candidate_history_mv_tmp cand on fh.committee_id = cand.candidate_id and fh.report_year + fh.report_year % 2 = cand.two_year_period
+left join ofec_committee_history_mv_tmp com on fh.committee_id = com.committee_id and get_cycle(fh.report_year) = com.cycle
+left join ofec_candidate_history_mv_tmp cand on fh.committee_id = cand.candidate_id and get_cycle(fh.report_year) = cand.two_year_period
 left join dimreporttype report on fh.report_type = report.rpt_tp
 where
-    report_year >= :START_YEAR
+    filings_year(report_year, receipt_date) >= :START_YEAR
 ;
 
 create unique index on ofec_filings_mv_tmp (idx);

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -202,7 +202,7 @@ class TestItemized(ApiBaseTest):
         ]
         earmarks = [
             factories.ScheduleAFactory(),
-            factories.ScheduleAFactory(line_number='12', contribution_receipt_amount=150, memo_text='earmark'),
+            factories.ScheduleAFactory(line_number='12', contribution_receipt_amount=150, memo_code='X', memo_text='earmark'),
         ]
         results = self._results(api.url_for(ScheduleAView))
         self.assertEqual(

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -13,6 +13,7 @@ is_individual = sa.func.is_individual(
     models.ScheduleA.contribution_receipt_amount,
     models.ScheduleA.receipt_type,
     models.ScheduleA.line_number,
+    models.ScheduleA.memo_code,
     models.ScheduleA.memo_text,
 )
 


### PR DESCRIPTION
The filings view is currently filtered on `report_year`, but this column
is always set to 0 for F1 filings. This patch checks both the
`report_year` and `receipt_date` columns, such that F1 filings have
dates and can be included.

Partial workaround for #1147.