### PR TITLE
Unify base resource classes.

### DIFF
--- a/data/functions/aggregates.sql
+++ b/data/functions/aggregates.sql
@@ -8,11 +8,10 @@ begin
     perform ofec_sched_a_update_aggregate_occupation();
     perform ofec_sched_a_update_aggregate_contributor_type();
 
-    perform ofec_sched_b_update_aggregate_recipient();
-    perform ofec_sched_b_update_aggregate_recipient_id();
-
     -- Update Schedule B aggregates in place
     perform ofec_sched_b_update_aggregate_purpose();
+    perform ofec_sched_b_update_aggregate_recipient();
+    perform ofec_sched_b_update_aggregate_recipient_id();
 
     -- Update full-text tables in place
     perform ofec_sched_a_update_fulltext();

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -7,30 +7,43 @@ from webservices.common import models
 from webservices.config import SQL_CONFIG
 
 
-class ItemizedResource(Resource):
+class ApiResource(Resource):
 
     model = None
+    filter_match_fields = []
+    filter_multi_fields = []
+    filter_range_fields = []
+    query_options = []
+
+    def get(self, **kwargs):
+        query = self.build_query(**kwargs)
+        return utils.fetch_page(query, kwargs, model=self.model)
+
+    def build_query(self, _apply_options=True, **kwargs):
+        query = self.model.query
+        query = filters.filter_match(query, kwargs, self.filter_match_fields)
+        query = filters.filter_multi(query, kwargs, self.filter_multi_fields)
+        query = filters.filter_range(query, kwargs, self.filter_range_fields)
+        if _apply_options:
+            query = query.options(*self.query_options)
+        return query
+
+
+class ItemizedResource(ApiResource):
+
     year_column = None
     index_column = None
-    filter_multi_fields = []
-    filter_match_fields = []
     filter_fulltext_fields = []
 
     def get(self, **kwargs):
-        query = self.build_query(kwargs)
+        query = self.build_query(**kwargs)
         count = counts.count_estimate(query, models.db.session, threshold=5000)
         return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)
 
-    def build_query(self, kwargs):
-        query = self.model.query.filter(
-            self.year_column >= SQL_CONFIG['START_YEAR_ITEMIZED'],
-        )
-
-        query = filters.filter_multi(query, kwargs, self.filter_multi_fields)
-        query = filters.filter_match(query, kwargs, self.filter_match_fields)
-        query = filters.filter_range(query, kwargs, self.filter_range_fields)
+    def build_query(self, **kwargs):
+        query = super().build_query(**kwargs)
+        query = query.filter(self.year_column >= SQL_CONFIG['START_YEAR_ITEMIZED'])
         query = self.filter_fulltext(query, kwargs)
-
         return query
 
     def filter_fulltext(self, query, kwargs):

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -53,8 +53,8 @@ class ScheduleBView(ItemizedResource):
     def get(self, **kwargs):
         return super(ScheduleBView, self).get(**kwargs)
 
-    def build_query(self, kwargs):
-        query = super(ScheduleBView, self).build_query(kwargs)
+    def build_query(self, **kwargs):
+        query = super(ScheduleBView, self).build_query(**kwargs)
         query = query.options(sa.orm.joinedload(models.ScheduleB.committee))
         query = query.options(sa.orm.joinedload(models.ScheduleB.recipient_committee))
         return query

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -58,8 +58,8 @@ class ScheduleEView(ItemizedResource):
     def get(self, **kwargs):
         return super(ScheduleEView, self).get(**kwargs)
 
-    def build_query(self, kwargs):
-        query = super(ScheduleEView, self).build_query(kwargs)
+    def build_query(self, **kwargs):
+        query = super(ScheduleEView, self).build_query(**kwargs)
         query = query.options(sa.orm.joinedload(models.ScheduleE.committee))
         query = query.options(sa.orm.joinedload(models.ScheduleE.candidate))
         return query


### PR DESCRIPTION
The codebase currently has a few different approaches at base resource
classes that handle query generation and filtering. To avoid
duplication, this patch unifies them into a single `ApiResource` class.