### PR TITLE
Use detailed query statistics.

### DIFF
--- a/data/sql_setup/prepare_schedule_a.sql
+++ b/data/sql_setup/prepare_schedule_a.sql
@@ -24,6 +24,9 @@ create index on sched_a (cmte_id, contb_receipt_dt, sched_a_sk) where rpt_yr >= 
 create index on sched_a (cmte_id, contb_receipt_amt, sched_a_sk) where rpt_yr >= :START_YEAR_ITEMIZED;
 create index on sched_a (cmte_id, contb_aggregate_ytd, sched_a_sk) where rpt_yr >= :START_YEAR_ITEMIZED;
 
+-- Use smaller histogram bins on state column for faster queries on rare states (AS, PR)
+alter table sched_a alter column contbr_st set statistics 1000;
+
 -- Create Schedule A fulltext table
 drop table if exists ofec_sched_a_fulltext;
 create table ofec_sched_a_fulltext as
@@ -41,6 +44,10 @@ alter table ofec_sched_a_fulltext add primary key (sched_a_sk);
 create index on ofec_sched_a_fulltext using gin (contributor_name_text);
 create index on ofec_sched_a_fulltext using gin (contributor_employer_text);
 create index on ofec_sched_a_fulltext using gin (contributor_occupation_text);
+
+-- Analyze tables
+analyze sched_a;
+analyze ofec_sched_a_fulltext;
 
 -- Create queue tables to hold changes to Schedule A
 drop table if exists ofec_sched_a_queue_new;

--- a/data/sql_setup/prepare_schedule_b.sql
+++ b/data/sql_setup/prepare_schedule_b.sql
@@ -19,6 +19,9 @@ create index on sched_b (cmte_id, disb_amt, sched_b_sk) where rpt_yr >= :START_Y
 -- Create index for join on electioneering costs
 create index on sched_b (link_id) where rpt_yr >= 2002;
 
+-- Use smaller histogram bins on state column for faster queries on rare states (AS, PR)
+alter table sched_b alter column recipient_st set statistics 1000;
+
 -- Create Schedule B fulltext table
 drop table if exists ofec_sched_b_fulltext;
 create table ofec_sched_b_fulltext as
@@ -34,6 +37,10 @@ where rpt_yr >= :START_YEAR_ITEMIZED
 alter table ofec_sched_b_fulltext add primary key (sched_b_sk);
 create index on ofec_sched_b_fulltext using gin (recipient_name_text);
 create index on ofec_sched_b_fulltext using gin (disbursement_description_text);
+
+-- Analyze tables
+analyze sched_b;
+analyze ofec_sched_b_fulltext;
 
 -- Create queue tables to hold changes to Schedule B
 drop table if exists ofec_sched_b_queue_new;


### PR DESCRIPTION
By default, the histograms used by the query planner are too coarse to
capture rarely-occurring values in large tables. This means that queries
by state on rare states (AS, PR) can be extremely slow. This patch
insructs the database to use finer histogram bins for state columns on
the itemized tables and explicitly re-analyzes the tables after creating
indexes for better performance on these queries.