### PR TITLE
Fix last cash on hand.

### DIFF
--- a/data/sql_updates/create_totals_house_senate_view.sql
+++ b/data/sql_updates/create_totals_house_senate_view.sql
@@ -7,7 +7,7 @@ with last as (
     )
         cmte_sk,
         two_yr_period_sk,
-        coh_cop as cash_on_hand_end_period,
+        coalesce(coh_cop_i, coh_cop_ii) as cash_on_hand_end_period,
         begin_image_num as beginning_image_number,
         rpt_yr as report_year,
         rt.rpt_tp_desc as report_type_full,

--- a/data/sql_updates/create_totals_house_senate_view.sql
+++ b/data/sql_updates/create_totals_house_senate_view.sql
@@ -7,7 +7,7 @@ with last as (
     )
         cmte_sk,
         two_yr_period_sk,
-        coh_bop as cash_on_hand_end_period,
+        coh_cop as cash_on_hand_end_period,
         begin_image_num as beginning_image_number,
         rpt_yr as report_year,
         rt.rpt_tp_desc as report_type_full,

--- a/data/sql_updates/create_totals_pacs_parties_view.sql
+++ b/data/sql_updates/create_totals_pacs_parties_view.sql
@@ -7,7 +7,7 @@ with last as (
     )
         cmte_sk,
         two_yr_period_sk,
-        coh_bop as cash_on_hand_end_period,
+        coh_cop as cash_on_hand_end_period,
         begin_image_num as beginning_image_number,
         rpt_yr as report_year,
         rt.rpt_tp_desc as report_type_full,

--- a/data/sql_updates/create_totals_presidential_view.sql
+++ b/data/sql_updates/create_totals_presidential_view.sql
@@ -7,7 +7,7 @@ with last as (
     )
         cmte_sk,
         two_yr_period_sk,
-        coh_bop as cash_on_hand_end_period,
+        coh_cop as cash_on_hand_end_period,
         begin_image_num as beginning_image_number,
         rpt_yr as report_year,
         rt.rpt_tp_desc as report_type_full,


### PR DESCRIPTION
Fix a typo mixing up starting and ending cash on hand. After this
change, fundraising totals on the election page are identical to the
corresponding totals on each candidate's detail page.

[Resolves #1110]