### PR TITLE
Add election summary endpoint.

### DIFF
--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -3,7 +3,7 @@ import functools
 
 from webservices import utils
 from webservices.rest import db, api
-from webservices.resources.elections import ElectionList, ElectionView
+from webservices.resources.elections import ElectionList, ElectionView, ElectionSummary
 
 from tests import factories
 from tests.common import ApiBaseTest
@@ -189,3 +189,9 @@ class TestElections(ApiBaseTest):
             'won': True,
         }
         self.assertDictsSubset(results[0], expected)
+
+    def test_election_summary(self):
+        results = self._response(api.url_for(ElectionSummary, office='house', cycle=2012, state='NY', district='07'))
+        self.assertEqual(results['count'], 1)
+        self.assertEqual(results['receipts'], sum(each.receipts for each in self.totals))
+        self.assertEqual(results['disbursements'], sum(each.disbursements for each in self.totals))

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -174,7 +174,7 @@ api.add_resource(
     '/candidate/<candidate_id>/committees/history/<int:cycle>/',
 )
 api.add_resource(totals.TotalsView, '/committee/<string:committee_id>/totals/')
-api.add_resource(reports.ReportsView, '/committee/<string:committee_id>/reports', '/reports/<string:committee_type>/')
+api.add_resource(reports.ReportsView, '/committee/<string:committee_id>/reports/', '/reports/<string:committee_type>/')
 api.add_resource(CandidateNameSearch, '/names/candidates/')
 api.add_resource(CommitteeNameSearch, '/names/committees/')
 api.add_resource(sched_a.ScheduleAView, '/schedules/schedule_a/')
@@ -182,6 +182,7 @@ api.add_resource(sched_b.ScheduleBView, '/schedules/schedule_b/')
 api.add_resource(sched_e.ScheduleEView, '/schedules/schedule_e/')
 api.add_resource(elections.ElectionView, '/elections/')
 api.add_resource(elections.ElectionList, '/elections/search/')
+api.add_resource(elections.ElectionSummary, '/elections/summary/')
 api.add_resource(dates.ElectionDatesView, '/election-dates/')
 api.add_resource(dates.ReportingDatesView, '/reporting-dates/')
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -354,6 +354,12 @@ class ElectionSearchSchema(ma.Schema):
     incumbent_name = ma.fields.Str(attribute='cand_name')
 augment_schemas(ElectionSearchSchema)
 
+class ElectionSummarySchema(ApiSchema):
+    count = ma.fields.Int()
+    receipts = ma.fields.Decimal(places=2)
+    disbursements = ma.fields.Decimal(places=2)
+augment_schemas(ElectionSummarySchema)
+
 class ElectionSchema(ma.Schema):
     candidate_id = ma.fields.Str()
     candidate_name = ma.fields.Str()

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -358,6 +358,7 @@ class ElectionSummarySchema(ApiSchema):
     count = ma.fields.Int()
     receipts = ma.fields.Decimal(places=2)
     disbursements = ma.fields.Decimal(places=2)
+    independent_expenditures = ma.fields.Decimal(places=2)
 augment_schemas(ElectionSummarySchema)
 
 class ElectionSchema(ma.Schema):


### PR DESCRIPTION
Add an election summary endpoint returning the number of candidates and total receipts and disbursements across all associated committees for a given election:

```
$ http http://localhost:5000/v1/elections/summary/?office=president&cycle=2012
HTTP/1.0 200 OK
Content-Length: 89
Content-Type: application/json
Date: Wed, 09 Sep 2015 18:31:41 GMT
Server: Werkzeug/0.10.4 Python/3.4.3

{
    "api_version": "1.0",
    "count": 105,
    "disbursements": 1346584691.25,
    "receipts": 1347810482.25
}
```