### PR TITLE
Generalize and document itemized committee queries.

### DIFF
--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -1,7 +1,10 @@
+import sqlalchemy as sa
 from flask.ext.restful import Resource
 
 from webservices import utils
 from webservices import filters
+from webservices import sorting
+from webservices import exceptions
 from webservices.common import counts
 from webservices.common import models
 from webservices.config import SQL_CONFIG
@@ -36,6 +39,19 @@ class ItemizedResource(ApiResource):
     filter_fulltext_fields = []
 
     def get(self, **kwargs):
+        """Get itemized resources. If multiple values are passed for `committee_id`,
+        create a subquery for each and combine with `UNION ALL`. This is necessary
+        to avoid slow queries when one or more relevant committees has many
+        records.
+        """
+        if len(kwargs['committee_id']) > 5:
+            raise exceptions.ApiError(
+                'Can only specify up to five values for "committee_id".',
+                status_code=422,
+            )
+        if len(kwargs['committee_id']) > 1:
+            query, count = self.join_committee_queries(kwargs)
+            return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)
         query = self.build_query(**kwargs)
         count = counts.count_estimate(query, models.db.session, threshold=5000)
         return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)
@@ -45,6 +61,33 @@ class ItemizedResource(ApiResource):
         query = query.filter(self.year_column >= SQL_CONFIG['START_YEAR_ITEMIZED'])
         query = self.filter_fulltext(query, kwargs)
         return query
+
+    def join_committee_queries(self, kwargs):
+        """Build and compose per-committee subqueries using `UNION ALL`.
+        """
+        queries = []
+        total = 0
+        for committee_id in kwargs['committee_id']:
+            query, count = self.build_committee_query(kwargs, committee_id)
+            queries.append(query.subquery().select())
+            total += count
+        query = models.db.session.query(
+            self.model
+        ).select_entity_from(
+            sa.union_all(*queries)
+        )
+        query = query.options(*self.query_options)
+        return query, total
+
+    def build_committee_query(self, kwargs, committee_id):
+        """Build a subquery by committee.
+        """
+        query = self.build_query(_apply_options=False, **utils.extend(kwargs, {'committee_id': [committee_id]}))
+        sort, hide_null, nulls_large = kwargs['sort'], kwargs['sort_hide_null'], kwargs['sort_nulls_large']
+        query, _ = sorting.sort(query, sort, model=self.model, hide_null=hide_null, nulls_large=nulls_large)
+        page_query = utils.fetch_seek_page(query, kwargs, self.index_column, count=-1, eager=False).results
+        count = counts.count_estimate(query, models.db.session, threshold=5000)
+        return page_query, count
 
     def filter_fulltext(self, query, kwargs):
         if any(kwargs[key] for key, column in self.filter_fulltext_fields):

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -3,12 +3,8 @@ import sqlalchemy as sa
 from webservices import args
 from webservices import docs
 from webservices import spec
-from webservices import utils
 from webservices import filters
 from webservices import schemas
-from webservices import sorting
-from webservices import exceptions
-from webservices.common import counts
 from webservices.common import models
 from webservices.common.views import ItemizedResource
 
@@ -80,43 +76,12 @@ class ScheduleAView(ItemizedResource):
     )
     @schemas.marshal_with(schemas.ScheduleAPageSchema())
     def get(self, **kwargs):
-        if len(kwargs['committee_id']) > 5:
-            raise exceptions.ApiError(
-                'Can only specify up to five values for "committee_id".',
-                status_code=422,
-            )
-        if len(kwargs['committee_id']) > 1:
-            query, count = self.join_committee_queries(kwargs)
-            return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)
-        return super(ScheduleAView, self).get(**kwargs)
+        return super().get(**kwargs)
 
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
         query = filters.filter_contributor_type(query, self.model.entity_type, kwargs)
         return query
-
-    def join_committee_queries(self, kwargs):
-        queries = []
-        total = 0
-        for committee_id in kwargs['committee_id']:
-            query, count = self.build_committee_query(kwargs, committee_id)
-            queries.append(query.subquery().select())
-            total += count
-        query = models.db.session.query(
-            models.ScheduleA
-        ).select_entity_from(
-            sa.union_all(*queries)
-        )
-        query = query.options(*self.query_options)
-        return query, total
-
-    def build_committee_query(self, kwargs, committee_id):
-        query = self.build_query(_apply_options=False, **utils.extend(kwargs, {'committee_id': [committee_id]}))
-        sort, hide_null, nulls_large = kwargs['sort'], kwargs['sort_hide_null'], kwargs['sort_nulls_large']
-        query, _ = sorting.sort(query, sort, model=models.ScheduleA, hide_null=hide_null, nulls_large=nulls_large)
-        page_query = utils.fetch_seek_page(query, kwargs, self.index_column, count=-1, eager=False).results
-        count = counts.count_estimate(query, models.db.session, threshold=5000)
-        return page_query, count
 
     def join_fulltext(self, query):
         return query.join(

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -51,7 +51,7 @@ class ScheduleBView(ItemizedResource):
     )
     @schemas.marshal_with(schemas.ScheduleBPageSchema())
     def get(self, **kwargs):
-        return super(ScheduleBView, self).get(**kwargs)
+        return super().get(**kwargs)
 
     def build_query(self, **kwargs):
         query = super(ScheduleBView, self).build_query(**kwargs)


### PR DESCRIPTION
Apply the `UNION ALL` optimization for performant queries on itemized
resources by multiple committees to the base `ItemizedResource` class.
This patch improves performance for these queries against Schedule B
transactions.