### PR TITLE
Move generic helpers and Swagger tools to flask-smore.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,17 +4,18 @@ Flask-RESTful==0.3.3
 Flask-SQLAlchemy==2.0
 newrelic==2.52.0.40
 celery==3.1.18
-SQLAlchemy==1.0.6
+SQLAlchemy==1.0.8
 GitPython==1.0.1
 gunicorn==19.3.0
-webargs==0.14.0
+webargs==0.15.0
 csvkit==0.9.1
 ujson==1.33
 
 # Marshalling
+smore==0.1.0
 marshmallow==2.0.0b3
-git+https://github.com/marshmallow-code/smore@dev
-git+https://github.com/marshmallow-code/marshmallow-sqlalchemy@dev
+marshmallow-sqlalchemy==0.4.1
+git+https://github.com/jmcarp/flask-smore@master
 git+https://github.com/jmcarp/marshmallow-pagination@master
 
 # Development

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -2,7 +2,6 @@ import logging
 import functools
 
 import sqlalchemy as sa
-from smore import swagger
 from dateutil.parser import parse as parse_date
 
 import webargs
@@ -29,29 +28,6 @@ class FlaskRestParser(FlaskParser):
 
 
 parser = FlaskRestParser()
-
-
-def unique_on(values, predicate):
-    seen = set()
-    for value in values:
-        key = predicate(value)
-        if key not in seen:
-            seen.add(key)
-            yield value
-
-
-def register_kwargs(arg_dict):
-    def wrapper(func):
-        params = swagger.args2parameters(arg_dict, default_in='query')
-        func.__apidoc__ = getattr(func, '__apidoc__', {})
-        func.__apidoc__['parameters'] = list(
-            unique_on(
-                params + func.__apidoc__.get('parameters', []),
-                lambda value: value['name'],
-            )
-        )
-        return parser.use_kwargs(arg_dict)(func)
-    return wrapper
 
 
 def _validate_natural(value):

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -1,5 +1,3 @@
-from flask.ext.restful import Resource
-
 from webservices import utils
 from webservices import filters
 from webservices.common import counts
@@ -7,7 +5,7 @@ from webservices.common import models
 from webservices.config import SQL_CONFIG
 
 
-class ApiResource(Resource):
+class ApiResource(utils.Resource):
 
     model = None
     filter_match_fields = []

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -1,8 +1,10 @@
 import sqlalchemy as sa
 
+from flask_smore import doc, use_kwargs, marshal_with
+from flask_smore.utils import Ref
+
 from webservices import args
 from webservices import docs
-from webservices import spec
 from webservices import utils
 from webservices import filters
 from webservices import schemas
@@ -11,8 +13,22 @@ from webservices.common import models
 from webservices.common.views import ApiResource
 
 
-@spec.doc(path_params=[utils.committee_param])
+@doc(params={'committee_id': {'description': docs.COMMITTEE_ID}})
 class AggregateResource(ApiResource):
+
+    schema = None
+    query_args = {}
+
+    @property
+    def sort_args(self):
+        return args.make_sort_args(validator=args.IndexValidator(self.model))
+
+    @use_kwargs(args.paging)
+    @use_kwargs(Ref('sort_args'))
+    @use_kwargs(Ref('query_args'))
+    @marshal_with(Ref('schema'))
+    def get(self, committee_id=None, **kwargs):
+        return super().get(committee_id=committee_id, **kwargs)
 
     def build_query(self, committee_id, **kwargs):
         query = super().build_query(**kwargs)
@@ -21,31 +37,22 @@ class AggregateResource(ApiResource):
         return query
 
 
-@spec.doc(
+@doc(
     tags=['schedules/schedule_a'],
     description=docs.SIZE_DESCRIPTION,
 )
 class ScheduleABySizeView(AggregateResource):
 
     model = models.ScheduleABySize
+    schema = schemas.ScheduleABySizePageSchema
+    query_args = args.schedule_a_by_size
     filter_multi_fields = [
         ('cycle', models.ScheduleABySize.cycle),
         ('size', models.ScheduleABySize.size),
     ]
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.schedule_a_by_size)
-    @args.register_kwargs(
-        args.make_sort_args(
-            validator=args.IndexValidator(models.ScheduleABySize)
-        )
-    )
-    @schemas.marshal_with(schemas.ScheduleABySizePageSchema())
-    def get(self, committee_id=None, **kwargs):
-        return super(ScheduleABySizeView, self).get(committee_id=committee_id, **kwargs)
 
-
-@spec.doc(
+@doc(
     tags=['schedules/schedule_a'],
     description=(
         'Schedule A receipts aggregated by contributor state. To avoid double counting, '
@@ -55,21 +62,12 @@ class ScheduleABySizeView(AggregateResource):
 class ScheduleAByStateView(AggregateResource):
 
     model = models.ScheduleAByState
+    schema = schemas.ScheduleAByStatePageSchema
+    query_args = args.schedule_a_by_state
     filter_multi_fields = [
         ('cycle', models.ScheduleAByState.cycle),
         ('state', models.ScheduleAByState.state),
     ]
-
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.schedule_a_by_state)
-    @args.register_kwargs(
-        args.make_sort_args(
-            validator=args.IndexValidator(models.ScheduleAByState)
-        )
-    )
-    @schemas.marshal_with(schemas.ScheduleAByStatePageSchema())
-    def get(self, committee_id=None, **kwargs):
-        return super(ScheduleAByStateView, self).get(committee_id=committee_id, **kwargs)
 
     def build_query(self, committee_id, **kwargs):
         query = super().build_query(committee_id, **kwargs)
@@ -78,7 +76,7 @@ class ScheduleAByStateView(AggregateResource):
         return query
 
 
-@spec.doc(
+@doc(
     tags=['schedules/schedule_a'],
     description=(
         'Schedule A receipts aggregated by contributor zip code. To avoid double '
@@ -88,24 +86,15 @@ class ScheduleAByStateView(AggregateResource):
 class ScheduleAByZipView(AggregateResource):
 
     model = models.ScheduleAByZip
+    schema = schemas.ScheduleAByZipPageSchema
+    query_args = args.schedule_a_by_zip
     filter_multi_fields = [
         ('cycle', models.ScheduleAByZip.cycle),
         ('zip', models.ScheduleAByZip.zip),
     ]
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.schedule_a_by_zip)
-    @args.register_kwargs(
-        args.make_sort_args(
-            validator=args.IndexValidator(models.ScheduleAByZip)
-        )
-    )
-    @schemas.marshal_with(schemas.ScheduleAByZipPageSchema())
-    def get(self, committee_id=None, **kwargs):
-        return super().get(committee_id=committee_id, **kwargs)
 
-
-@spec.doc(
+@doc(
     tags=['schedules/schedule_a'],
     description=(
         'Schedule A receipts aggregated by contributor employer name. To avoid double '
@@ -115,26 +104,20 @@ class ScheduleAByZipView(AggregateResource):
 class ScheduleAByEmployerView(AggregateResource):
 
     model = models.ScheduleAByEmployer
+    schema = schemas.ScheduleAByEmployerPageSchema
+    query_args = args.schedule_a_by_employer
     filter_multi_fields = [
         ('cycle', models.ScheduleAByEmployer.cycle),
         ('employer', models.ScheduleAByEmployer.employer),
     ]
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.schedule_a_by_employer)
-    @args.register_kwargs(
-        args.make_sort_args(
-            validator=args.IndexValidator(models.ScheduleAByEmployer)
-        )
-    )
-    @schemas.marshal_with(schemas.ScheduleAByEmployerPageSchema())
     def get(self, committee_id=None, **kwargs):
         query = self.build_query(committee_id=committee_id, **kwargs)
         count = counts.count_estimate(query, models.db.session, threshold=5000)
         return utils.fetch_page(query, kwargs, model=self.model, count=count)
 
 
-@spec.doc(
+@doc(
     tags=['schedules/schedule_a'],
     description=(
         'Schedule A receipts aggregated by contributor occupation. To avoid double '
@@ -144,26 +127,20 @@ class ScheduleAByEmployerView(AggregateResource):
 class ScheduleAByOccupationView(AggregateResource):
 
     model = models.ScheduleAByOccupation
+    schema = schemas.ScheduleAByOccupationPageSchema
+    query_args = args.schedule_a_by_occupation
     filter_multi_fields = [
         ('cycle', models.ScheduleAByOccupation.cycle),
         ('occupation', models.ScheduleAByOccupation.occupation),
     ]
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.schedule_a_by_occupation)
-    @args.register_kwargs(
-        args.make_sort_args(
-            validator=args.IndexValidator(models.ScheduleAByOccupation)
-        )
-    )
-    @schemas.marshal_with(schemas.ScheduleAByOccupationPageSchema())
     def get(self, committee_id=None, **kwargs):
         query = self.build_query(committee_id=committee_id, **kwargs)
         count = counts.count_estimate(query, models.db.session, threshold=5000)
         return utils.fetch_page(query, kwargs, model=self.model, count=count)
 
 
-@spec.doc(
+@doc(
     tags=['schedules/schedule_a'],
     description=(
         'Schedule A receipts aggregated by contributor FEC ID, if applicable. To avoid '
@@ -173,24 +150,15 @@ class ScheduleAByOccupationView(AggregateResource):
 class ScheduleAByContributorView(AggregateResource):
 
     model = models.ScheduleAByContributor
+    schema = schemas.ScheduleAByContributorPageSchema
+    query_args = args.schedule_a_by_contributor
     filter_multi_fields = [
         ('cycle', models.ScheduleAByContributor.cycle),
         ('contributor_id', models.ScheduleAByContributor.contributor_id),
     ]
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.schedule_a_by_contributor)
-    @args.register_kwargs(
-        args.make_sort_args(
-            validator=args.IndexValidator(models.ScheduleAByContributor)
-        )
-    )
-    @schemas.marshal_with(schemas.ScheduleAByContributorPageSchema())
-    def get(self, committee_id=None, **kwargs):
-        return super().get(committee_id=committee_id, **kwargs)
 
-
-@spec.doc(
+@doc(
     tags=['schedules/schedule_a'],
     description=(
         'Schedule A receipts aggregated by contributor type (individual or committee), if applicable. '
@@ -200,6 +168,8 @@ class ScheduleAByContributorView(AggregateResource):
 class ScheduleAByContributorTypeView(AggregateResource):
 
     model = models.ScheduleAByContributorType
+    schema = schemas.ScheduleAByContributorTypePageSchema
+    query_args = args.schedule_a_by_contributor_type
     filter_match_fields = [
         ('individual', models.ScheduleAByContributorType.individual),
     ]
@@ -207,19 +177,8 @@ class ScheduleAByContributorTypeView(AggregateResource):
         ('cycle', models.ScheduleAByContributorType.cycle),
     ]
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.schedule_a_by_contributor_type)
-    @args.register_kwargs(
-        args.make_sort_args(
-            validator=args.IndexValidator(models.ScheduleAByContributorType)
-        )
-    )
-    @schemas.marshal_with(schemas.ScheduleAByContributorTypePageSchema())
-    def get(self, committee_id=None, **kwargs):
-        return super().get(committee_id=committee_id, **kwargs)
 
-
-@spec.doc(
+@doc(
     tags=['schedules/schedule_b'],
     description=(
         'Schedule B receipts aggregated by recipient name. To avoid '
@@ -229,24 +188,15 @@ class ScheduleAByContributorTypeView(AggregateResource):
 class ScheduleBByRecipientView(AggregateResource):
 
     model = models.ScheduleBByRecipient
+    schema = schemas.ScheduleBByRecipientPageSchema
+    query_args = args.schedule_b_by_recipient
     filter_multi_fields = [
         ('cycle', models.ScheduleBByRecipient.cycle),
         ('recipient_name', models.ScheduleBByRecipient.recipient_name),
     ]
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.schedule_b_by_recipient)
-    @args.register_kwargs(
-        args.make_sort_args(
-            validator=args.IndexValidator(models.ScheduleBByRecipient)
-        )
-    )
-    @schemas.marshal_with(schemas.ScheduleBByRecipientPageSchema())
-    def get(self, committee_id=None, **kwargs):
-        return super().get(committee_id=committee_id, **kwargs)
 
-
-@spec.doc(
+@doc(
     tags=['schedules/schedule_b'],
     description=(
         'Schedule B receipts aggregated by recipient committee ID, if applicable. To avoid '
@@ -256,24 +206,15 @@ class ScheduleBByRecipientView(AggregateResource):
 class ScheduleBByRecipientIDView(AggregateResource):
 
     model = models.ScheduleBByRecipientID
+    schema = schemas.ScheduleBByRecipientIDPageSchema
+    query_args = args.schedule_b_by_recipient_id
     filter_multi_fields = [
         ('cycle', models.ScheduleBByRecipientID.cycle),
         ('recipient_id', models.ScheduleBByRecipientID.recipient_id),
     ]
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.schedule_b_by_recipient_id)
-    @args.register_kwargs(
-        args.make_sort_args(
-            validator=args.IndexValidator(models.ScheduleBByRecipientID)
-        )
-    )
-    @schemas.marshal_with(schemas.ScheduleBByRecipientIDPageSchema())
-    def get(self, committee_id=None, **kwargs):
-        return super().get(committee_id=committee_id, **kwargs)
 
-
-@spec.doc(
+@doc(
     tags=['schedules/schedule_b'],
     description=(
         'Schedule B receipts aggregated by disbursement purpose category. To avoid double '
@@ -283,24 +224,15 @@ class ScheduleBByRecipientIDView(AggregateResource):
 class ScheduleBByPurposeView(AggregateResource):
 
     model = models.ScheduleBByPurpose
+    schema = schemas.ScheduleBByPurposePageSchema
+    query_args = args.schedule_b_by_purpose
     filter_multi_fields = [
         ('cycle', models.ScheduleBByPurpose.cycle),
         ('purpose', models.ScheduleBByPurpose.purpose),
     ]
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.schedule_b_by_purpose)
-    @args.register_kwargs(
-        args.make_sort_args(
-            validator=args.IndexValidator(models.ScheduleBByPurpose)
-        )
-    )
-    @schemas.marshal_with(schemas.ScheduleBByPurposePageSchema())
-    def get(self, committee_id=None, **kwargs):
-        return super().get(committee_id=committee_id, **kwargs)
 
-
-@spec.doc(
+@doc(
     tags=['schedules/schedule_b'],
     description=(
         'Schedule E receipts aggregated by recipient candidate. To avoid double '
@@ -310,6 +242,8 @@ class ScheduleBByPurposeView(AggregateResource):
 class ScheduleEByCandidateView(AggregateResource):
 
     model = models.ScheduleEByCandidate
+    schema = schemas.ScheduleEByCandidatePageSchema
+    query_args = utils.extend(args.elections, args.schedule_e_by_candidate)
     filter_multi_fields = [
         ('cycle', models.ScheduleEByCandidate.cycle),
         ('candidate_id', models.ScheduleEByCandidate.candidate_id),
@@ -322,30 +256,20 @@ class ScheduleEByCandidateView(AggregateResource):
         sa.orm.joinedload(models.ScheduleEByCandidate.committee),
     ]
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.elections)
-    @args.register_kwargs(args.schedule_e_by_candidate)
-    @args.register_kwargs(
-        args.make_sort_args(
-            validator=args.IndexValidator(models.ScheduleEByCandidate)
-        )
-    )
-    @schemas.marshal_with(schemas.ScheduleEByCandidatePageSchema())
-    def get(self, committee_id=None, **kwargs):
-        return super().get(committee_id=committee_id, **kwargs)
-
     def build_query(self, committee_id, **kwargs):
         query = super().build_query(committee_id, **kwargs)
         return filters.filter_election(query, kwargs, self.model.candidate_id, self.model.cycle)
 
 
-@spec.doc(
+@doc(
     tags=['communication_cost'],
     description='Communication cost aggregated by candidate ID and committee ID.',
 )
 class CommunicationCostByCandidateView(AggregateResource):
 
     model = models.CommunicationCostByCandidate
+    schema = schemas.CommunicationCostByCandidatePageSchema
+    query_args = utils.extend(args.elections, args.communication_cost_by_candidate)
     filter_multi_fields = [
         ('cycle', models.CommunicationCostByCandidate.cycle),
         ('candidate_id', models.CommunicationCostByCandidate.candidate_id),
@@ -358,46 +282,24 @@ class CommunicationCostByCandidateView(AggregateResource):
         sa.orm.joinedload(models.CommunicationCostByCandidate.committee),
     ]
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.elections)
-    @args.register_kwargs(args.communication_cost_by_candidate)
-    @args.register_kwargs(
-        args.make_sort_args(
-            validator=args.IndexValidator(models.CommunicationCostByCandidate)
-        )
-    )
-    @schemas.marshal_with(schemas.CommunicationCostByCandidatePageSchema())
-    def get(self, committee_id=None, **kwargs):
-        return super().get(committee_id=committee_id, **kwargs)
-
     def build_query(self, committee_id, **kwargs):
         query = super().build_query(committee_id, **kwargs)
         return filters.filter_election(query, kwargs, self.model.candidate_id, self.model.cycle)
 
 
-@spec.doc(
+@doc(
     tags=['electioneering'],
     description='Electioneering costs aggregated by candidate.',
 )
 class ElectioneeringByCandidateView(AggregateResource):
 
     model = models.ElectioneeringByCandidate
+    schema = schemas.ElectioneeringByCandidatePageSchema
+    query_args = utils.extend(args.elections, args.electioneering_by_candidate)
     filter_multi_fields = [
         ('cycle', models.ElectioneeringByCandidate.cycle),
         ('candidate_id', models.ElectioneeringByCandidate.candidate_id),
     ]
-
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.elections)
-    @args.register_kwargs(args.electioneering_by_candidate)
-    @args.register_kwargs(
-        args.make_sort_args(
-            validator=args.IndexValidator(models.ElectioneeringByCandidate)
-        )
-    )
-    @schemas.marshal_with(schemas.ElectioneeringByCandidatePageSchema())
-    def get(self, committee_id=None, **kwargs):
-        return super().get(committee_id=committee_id, **kwargs)
 
     def build_query(self, committee_id, **kwargs):
         query = super().build_query(committee_id, **kwargs)

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -1,8 +1,7 @@
 import sqlalchemy as sa
-from flask.ext.restful import Resource
+from flask_smore import doc, use_kwargs, marshal_with
 
 from webservices import args
-from webservices import spec
 from webservices import utils
 from webservices import schemas
 from webservices.common.models import (
@@ -46,32 +45,32 @@ def candidate_aggregate(aggregate_model, label_columns, group_columns, kwargs):
     )
 
 
-@spec.doc(
+@doc(
     tags=['schedules/schedule_a'],
     description='Schedule A receipts aggregated by contribution size.',
 )
-class ScheduleABySizeCandidateView(Resource):
+class ScheduleABySizeCandidateView(utils.Resource):
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.make_sort_args())
-    @args.register_kwargs(args.schedule_a_candidate_aggregate)
-    @schemas.marshal_with(schemas.ScheduleABySizeCandidatePageSchema())
+    @use_kwargs(args.paging)
+    @use_kwargs(args.make_sort_args())
+    @use_kwargs(args.schedule_a_candidate_aggregate)
+    @marshal_with(schemas.ScheduleABySizeCandidatePageSchema())
     def get(self, **kwargs):
         group_columns = [ScheduleABySize.size]
         query = candidate_aggregate(ScheduleABySize, group_columns, group_columns, kwargs)
         return utils.fetch_page(query, kwargs, cap=None)
 
 
-@spec.doc(
+@doc(
     tags=['schedules/schedule_a'],
     description='Schedule A receipts aggregated by contributor state.',
 )
-class ScheduleAByStateCandidateView(Resource):
+class ScheduleAByStateCandidateView(utils.Resource):
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.make_sort_args())
-    @args.register_kwargs(args.schedule_a_candidate_aggregate)
-    @schemas.marshal_with(schemas.ScheduleAByStateCandidatePageSchema())
+    @use_kwargs(args.paging)
+    @use_kwargs(args.make_sort_args())
+    @use_kwargs(args.schedule_a_candidate_aggregate)
+    @marshal_with(schemas.ScheduleAByStateCandidatePageSchema())
     def get(self, **kwargs):
         query = candidate_aggregate(
             ScheduleAByState,
@@ -85,16 +84,16 @@ class ScheduleAByStateCandidateView(Resource):
         return utils.fetch_page(query, kwargs, cap=0)
 
 
-@spec.doc(
+@doc(
     tags=['schedules/schedule_a'],
     description='Schedule A receipts aggregated by contributor type.',
 )
-class ScheduleAByContributorTypeCandidateView(Resource):
+class ScheduleAByContributorTypeCandidateView(utils.Resource):
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.make_sort_args())
-    @args.register_kwargs(args.schedule_a_candidate_aggregate)
-    @schemas.marshal_with(schemas.ScheduleAByContributorTypeCandidatePageSchema())
+    @use_kwargs(args.paging)
+    @use_kwargs(args.make_sort_args())
+    @use_kwargs(args.schedule_a_candidate_aggregate)
+    @marshal_with(schemas.ScheduleAByContributorTypeCandidatePageSchema())
     def get(self, **kwargs):
         group_columns = [ScheduleAByContributorType.individual]
         query = candidate_aggregate(ScheduleAByContributorType, group_columns, group_columns, kwargs)

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -1,9 +1,8 @@
 import sqlalchemy as sa
-from flask.ext.restful import Resource
+from flask_smore import doc, use_kwargs, marshal_with
 
 from webservices import args
 from webservices import docs
-from webservices import spec
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
@@ -21,26 +20,26 @@ filter_fields = {
 }
 
 
-@spec.doc(
+@doc(
     tags=['candidate'],
     description=docs.CANDIDATE_LIST,
 )
-class CandidateList(Resource):
+class CandidateList(utils.Resource):
 
     @property
     def query(self):
         return models.Candidate.query
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.candidate_list)
-    @args.register_kwargs(args.candidate_detail)
-    @args.register_kwargs(
+    @use_kwargs(args.paging)
+    @use_kwargs(args.candidate_list)
+    @use_kwargs(args.candidate_detail)
+    @use_kwargs(
         args.make_sort_args(
             default=['name'],
             validator=args.IndexValidator(models.Candidate),
         )
     )
-    @schemas.marshal_with(schemas.CandidatePageSchema())
+    @marshal_with(schemas.CandidatePageSchema())
     def get(self, **kwargs):
         query = self.get_candidates(kwargs)
         return utils.fetch_page(query, kwargs, model=models.Candidate)
@@ -71,7 +70,7 @@ class CandidateList(Resource):
         return candidates
 
 
-@spec.doc(
+@doc(
     tags=['candidate'],
     description=docs.CANDIDATE_SEARCH,
 )
@@ -84,35 +83,35 @@ class CandidateSearch(CandidateList):
             sa.orm.subqueryload(models.Candidate.principal_committees)
         )
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.candidate_list)
-    @args.register_kwargs(args.candidate_detail)
-    @args.register_kwargs(args.make_sort_args(validator=args.IndexValidator(models.Candidate)))
-    @schemas.marshal_with(schemas.CandidateSearchPageSchema())
+    @use_kwargs(args.paging)
+    @use_kwargs(args.candidate_list)
+    @use_kwargs(args.candidate_detail)
+    @use_kwargs(args.make_sort_args(validator=args.IndexValidator(models.Candidate)))
+    @marshal_with(schemas.CandidateSearchPageSchema())
     def get(self, **kwargs):
         query = self.get_candidates(kwargs)
         return utils.fetch_page(query, kwargs, model=models.Candidate)
 
 
-@spec.doc(
+@doc(
     tags=['candidate'],
     description=docs.CANDIDATE_DETAIL,
-    path_params=[
-        utils.candidate_param,
-        utils.committee_param,
-    ],
+    params={
+        'candidate_id': {'description': docs.CANDIDATE_ID},
+        'committee_id': {'description': docs.COMMITTEE_ID},
+    },
 )
-class CandidateView(Resource):
+class CandidateView(utils.Resource):
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.candidate_detail)
-    @args.register_kwargs(
+    @use_kwargs(args.paging)
+    @use_kwargs(args.candidate_detail)
+    @use_kwargs(
         args.make_sort_args(
             default=['-expire_date'],
             validator=args.IndexValidator(models.CandidateDetail),
         )
     )
-    @schemas.marshal_with(schemas.CandidateDetailPageSchema())
+    @marshal_with(schemas.CandidateDetailPageSchema())
     def get(self, candidate_id=None, committee_id=None, **kwargs):
         query = self.get_candidate(kwargs, candidate_id, committee_id)
         return utils.fetch_page(query, kwargs, model=models.CandidateDetail)
@@ -138,25 +137,25 @@ class CandidateView(Resource):
         return candidates
 
 
-@spec.doc(
+@doc(
     tags=['candidate'],
     description=docs.CANDIDATE_HISTORY,
-    path_params=[
-        utils.candidate_param,
-        utils.committee_param,
-        utils.cycle_param(description=docs.CANDIDATE_CYCLE),
-    ],
+    params={
+        'candidate_id': {'description': docs.CANDIDATE_ID},
+        'committee_id': {'description': docs.COMMITTEE_ID},
+        'cycle': {'description': docs.CANDIDATE_CYCLE},
+    },
 )
-class CandidateHistoryView(Resource):
+class CandidateHistoryView(utils.Resource):
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(
+    @use_kwargs(args.paging)
+    @use_kwargs(
         args.make_sort_args(
             default=['-two_year_period'],
             validator=args.IndexValidator(models.CandidateHistory),
         )
     )
-    @schemas.marshal_with(schemas.CandidateHistoryPageSchema())
+    @marshal_with(schemas.CandidateHistoryPageSchema())
     def get(self, candidate_id=None, committee_id=None, cycle=None, **kwargs):
         query = self.get_candidate(candidate_id, committee_id, cycle, kwargs)
         return utils.fetch_page(query, kwargs, model=models.CandidateHistory)

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -1,9 +1,8 @@
 import sqlalchemy as sa
-from flask.ext.restful import Resource
+from flask_smore import doc, use_kwargs, marshal_with
 
 from webservices import args
 from webservices import docs
-from webservices import spec
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
@@ -29,22 +28,22 @@ def filter_year(model, query, years):
     )  # noqa
 
 
-@spec.doc(
+@doc(
     tags=['committee'],
     description=docs.COMMITTEE_LIST,
 )
-class CommitteeList(Resource):
+class CommitteeList(utils.Resource):
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.committee)
-    @args.register_kwargs(args.committee_list)
-    @args.register_kwargs(
+    @use_kwargs(args.paging)
+    @use_kwargs(args.committee)
+    @use_kwargs(args.committee_list)
+    @use_kwargs(
         args.make_sort_args(
             default=['name'],
             validator=args.IndexValidator(models.Committee),
         )
     )
-    @schemas.marshal_with(schemas.CommitteePageSchema())
+    @marshal_with(schemas.CommitteePageSchema())
     def get(self, **kwargs):
         query = self.get_committees(kwargs)
         return utils.fetch_page(query, kwargs, model=models.Committee)
@@ -87,25 +86,25 @@ class CommitteeList(Resource):
         return committees
 
 
-@spec.doc(
+@doc(
     tags=['committee'],
     description=docs.COMMITTEE_DETAIL,
-    path_params=[
-        utils.candidate_param,
-        utils.committee_param,
-    ],
+    params={
+        'candidate_id': {'description': docs.CANDIDATE_ID},
+        'committee_id': {'description': docs.COMMITTEE_ID},
+    },
 )
-class CommitteeView(Resource):
+class CommitteeView(utils.Resource):
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.committee)
-    @args.register_kwargs(
+    @use_kwargs(args.paging)
+    @use_kwargs(args.committee)
+    @use_kwargs(
         args.make_sort_args(
             default=['name'],
             validator=args.IndexValidator(models.CommitteeDetail),
         )
     )
-    @schemas.marshal_with(schemas.CommitteeDetailPageSchema())
+    @marshal_with(schemas.CommitteeDetailPageSchema())
     def get(self, committee_id=None, candidate_id=None, **kwargs):
         query = self.get_committee(kwargs, committee_id, candidate_id)
         return utils.fetch_page(query, kwargs, model=models.CommitteeDetail)
@@ -135,25 +134,25 @@ class CommitteeView(Resource):
         return committees
 
 
-@spec.doc(
+@doc(
     tags=['committee'],
     description=docs.COMMITTEE_HISTORY,
-    path_params=[
-        utils.candidate_param,
-        utils.committee_param,
-        utils.cycle_param(description=docs.COMMITTEE_CYCLE),
-    ],
+    params={
+        'candidate_id': {'description': docs.CANDIDATE_ID},
+        'committee_id': {'description': docs.COMMITTEE_ID},
+        'cycle': {'description': docs.COMMITTEE_CYCLE},
+    },
 )
-class CommitteeHistoryView(Resource):
+class CommitteeHistoryView(utils.Resource):
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(
+    @use_kwargs(args.paging)
+    @use_kwargs(
         args.make_sort_args(
             default=['-cycle'],
             validator=args.IndexValidator(models.CommitteeHistory),
         )
     )
-    @schemas.marshal_with(schemas.CommitteeHistoryPageSchema())
+    @marshal_with(schemas.CommitteeHistoryPageSchema())
     def get(self, committee_id=None, candidate_id=None, cycle=None, **kwargs):
         query = self.get_committee(committee_id, candidate_id, cycle, kwargs)
         return utils.fetch_page(query, kwargs, model=models.CommitteeHistory)

--- a/webservices/resources/dates.py
+++ b/webservices/resources/dates.py
@@ -1,9 +1,8 @@
 from datetime import date
 
-from flask.ext.restful import Resource
+from flask_smore import doc, use_kwargs, marshal_with
 
 from webservices import args
-from webservices import spec
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
@@ -16,8 +15,8 @@ def filter_upcoming(query, column, kwargs):
     return query
 
 
-@spec.doc(tags=['dates'])
-class DatesResource(Resource):
+@doc(tags=['dates'])
+class DatesResource(utils.Resource):
 
     def get(self, **kwargs):
         query = self.model.query
@@ -26,7 +25,7 @@ class DatesResource(Resource):
         return utils.fetch_page(query, kwargs, model=self.model)
 
 
-@spec.doc(description='FEC reporting dates since 1995.')
+@doc(description='FEC reporting dates since 1995.')
 class ReportingDatesView(DatesResource):
 
     model = models.ReportingDates
@@ -42,19 +41,19 @@ class ReportingDatesView(DatesResource):
         'update_date',
     }
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.reporting_dates)
-    @args.register_kwargs(
+    @use_kwargs(args.paging)
+    @use_kwargs(args.reporting_dates)
+    @use_kwargs(
         args.make_sort_args(
             default=['-due_date'],
         )
     )
-    @schemas.marshal_with(schemas.ReportingDatesPageSchema())
+    @marshal_with(schemas.ReportingDatesPageSchema())
     def get(self, **kwargs):
         return super().get(**kwargs)
 
 
-@spec.doc(description='FEC election dates since 1995.')
+@doc(description='FEC election dates since 1995.')
 class ElectionDatesView(DatesResource):
 
     model = models.ElectionDates
@@ -76,13 +75,13 @@ class ElectionDatesView(DatesResource):
         'pg_date',
     }
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.reporting_dates)
-    @args.register_kwargs(
+    @use_kwargs(args.paging)
+    @use_kwargs(args.reporting_dates)
+    @use_kwargs(
         args.make_sort_args(
             default=['-election_date'],
         )
     )
-    @schemas.marshal_with(schemas.ElectionDatesPageSchema())
+    @marshal_with(schemas.ElectionDatesPageSchema())
     def get(self, **kwargs):
         return super().get(**kwargs)

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -1,8 +1,8 @@
 import sqlalchemy as sa
+from flask_smore import doc, use_kwargs, marshal_with
 
 from webservices import args
 from webservices import docs
-from webservices import spec
 from webservices import utils
 from webservices import schemas
 from webservices.common import views
@@ -10,10 +10,13 @@ from webservices.common import counts
 from webservices.common import models
 
 
-@spec.doc(
+@doc(
     tags=['filings'],
     description=docs.FILINGS,
-    path_params=[utils.committee_param, utils.candidate_param],
+    params={
+        'candidate_id': {'description': docs.CANDIDATE_ID},
+        'committee_id': {'description': docs.COMMITTEE_ID},
+    },
 )
 class BaseFilings(views.ApiResource):
 
@@ -44,15 +47,15 @@ class BaseFilings(views.ApiResource):
 
 class FilingsView(BaseFilings):
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.filings)
-    @args.register_kwargs(
+    @use_kwargs(args.paging)
+    @use_kwargs(args.filings)
+    @use_kwargs(
         args.make_sort_args(
             default=['-receipt_date'],
             validator=args.IndexValidator(models.Filings),
         )
     )
-    @schemas.marshal_with(schemas.FilingsPageSchema())
+    @marshal_with(schemas.FilingsPageSchema())
     def get(self, **kwargs):
         return super().get(**kwargs)
 
@@ -72,15 +75,15 @@ class FilingsList(BaseFilings):
         ('candidate_id', models.Filings.candidate_id),
     ]
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.filings)
-    @args.register_kwargs(args.entities)
-    @args.register_kwargs(
+    @use_kwargs(args.paging)
+    @use_kwargs(args.filings)
+    @use_kwargs(args.entities)
+    @use_kwargs(
         args.make_sort_args(
             default=['-receipt_date'],
             validator=args.IndexValidator(models.Filings),
         )
     )
-    @schemas.marshal_with(schemas.FilingsPageSchema())
+    @marshal_with(schemas.FilingsPageSchema())
     def get(self, **kwargs):
         return super().get(**kwargs)

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -1,9 +1,8 @@
 import sqlalchemy as sa
-from flask.ext.restful import Resource
+from flask_smore import doc, use_kwargs, marshal_with
 
 from webservices import args
 from webservices import docs
-from webservices import spec
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
@@ -38,26 +37,23 @@ def parse_types(types):
     return include, exclude
 
 
-@spec.doc(
+@doc(
     tags=['financial'],
     description=docs.REPORTS,
-    path_params=[
-        utils.committee_param,
-        {
-            'name': 'committee_type',
-            'in': 'path',
-            'type': 'string',
+    params={
+        'committee_id': {'description': docs.COMMITTEE_ID},
+        'committee_type': {
             'description': 'House, Senate, presidential, independent expenditure only',
             'enum': ['presidential', 'pac-party', 'house-senate', 'ie-only'],
         },
-    ],
+    },
 )
-class ReportsView(Resource):
+class ReportsView(utils.Resource):
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.reports)
-    @args.register_kwargs(args.make_sort_args(default=['-coverage_end_date']))
-    @schemas.marshal_with(schemas.CommitteeReportsPageSchema(), wrap=False)
+    @use_kwargs(args.paging)
+    @use_kwargs(args.reports)
+    @use_kwargs(args.make_sort_args(default=['-coverage_end_date']))
+    @marshal_with(schemas.CommitteeReportsPageSchema(), apply=False)
     def get(self, committee_id=None, committee_type=None, **kwargs):
         query, reports_class, reports_schema = self.get_reports(committee_id, committee_type, kwargs)
         validator = args.IndexValidator(reports_class)

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -1,8 +1,8 @@
 import sqlalchemy as sa
+from flask_smore import doc, use_kwargs, marshal_with
 
 from webservices import args
 from webservices import docs
-from webservices import spec
 from webservices import utils
 from webservices import filters
 from webservices import schemas
@@ -22,7 +22,7 @@ is_individual = sa.func.is_individual(
 )
 
 
-@spec.doc(
+@doc(
     tags=['schedules/schedule_a'],
     description=docs.SCHEDULE_A,
 )
@@ -65,10 +65,10 @@ class ScheduleAView(ItemizedResource):
         sa.orm.joinedload(models.ScheduleA.contributor),
     ]
 
-    @args.register_kwargs(args.itemized)
-    @args.register_kwargs(args.schedule_a)
-    @args.register_kwargs(args.make_seek_args())
-    @args.register_kwargs(
+    @use_kwargs(args.itemized)
+    @use_kwargs(args.schedule_a)
+    @use_kwargs(args.make_seek_args())
+    @use_kwargs(
         args.make_sort_args(
             validator=args.OptionValidator([
                 'contribution_receipt_date',
@@ -78,7 +78,7 @@ class ScheduleAView(ItemizedResource):
             multiple=False,
         )
     )
-    @schemas.marshal_with(schemas.ScheduleAPageSchema())
+    @marshal_with(schemas.ScheduleAPageSchema())
     def get(self, **kwargs):
         if len(kwargs['committee_id']) > 5:
             raise exceptions.ApiError(

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -1,14 +1,14 @@
 import sqlalchemy as sa
+from flask_smore import doc, use_kwargs, marshal_with
 
 from webservices import args
 from webservices import docs
-from webservices import spec
 from webservices import schemas
 from webservices.common import models
 from webservices.common.views import ItemizedResource
 
 
-@spec.doc(
+@doc(
     tags=['schedules/schedule_b'],
     description=docs.SCHEDULE_B,
 )
@@ -40,16 +40,16 @@ class ScheduleBView(ItemizedResource):
         (('min_image_number', 'max_image_number'), models.ScheduleB.image_number),
     ]
 
-    @args.register_kwargs(args.itemized)
-    @args.register_kwargs(args.schedule_b)
-    @args.register_kwargs(args.make_seek_args())
-    @args.register_kwargs(
+    @use_kwargs(args.itemized)
+    @use_kwargs(args.schedule_b)
+    @use_kwargs(args.make_seek_args())
+    @use_kwargs(
         args.make_sort_args(
             validator=args.OptionValidator(['disbursement_date', 'disbursement_amount']),
             multiple=False,
         )
     )
-    @schemas.marshal_with(schemas.ScheduleBPageSchema())
+    @marshal_with(schemas.ScheduleBPageSchema())
     def get(self, **kwargs):
         return super(ScheduleBView, self).get(**kwargs)
 

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -1,15 +1,15 @@
 import sqlalchemy as sa
+from flask_smore import doc, use_kwargs, marshal_with
 
 from webservices import args
 from webservices import docs
-from webservices import spec
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
 from webservices.common.views import ItemizedResource
 
 
-@spec.doc(
+@doc(
     tags=['schedules/schedule_e'],
     description=docs.SCHEDULE_E,
 )
@@ -41,10 +41,10 @@ class ScheduleEView(ItemizedResource):
         (('min_image_number', 'max_image_number'), models.ScheduleE.image_number),
     ]
 
-    @args.register_kwargs(args.itemized)
-    @args.register_kwargs(args.schedule_e)
-    @args.register_kwargs(args.make_seek_args())
-    @args.register_kwargs(
+    @use_kwargs(args.itemized)
+    @use_kwargs(args.schedule_e)
+    @use_kwargs(args.make_seek_args())
+    @use_kwargs(
         args.make_sort_args(
             validator=args.OptionValidator([
                 'expenditure_date',
@@ -54,7 +54,7 @@ class ScheduleEView(ItemizedResource):
             multiple=False,
         )
     )
-    @schemas.marshal_with(schemas.ScheduleEPageSchema())
+    @marshal_with(schemas.ScheduleEPageSchema())
     def get(self, **kwargs):
         return super(ScheduleEView, self).get(**kwargs)
 

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -1,9 +1,8 @@
 import sqlalchemy as sa
-from flask.ext.restful import Resource
+from flask_smore import doc, use_kwargs, marshal_with
 
 from webservices import args
 from webservices import docs
-from webservices import spec
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
@@ -19,17 +18,17 @@ totals_schema_map = {
 default_schemas = (models.CommitteeTotalsPacParty, schemas.CommitteeTotalsPacPartyPageSchema)
 
 
-@spec.doc(
+@doc(
     tags=['financial'],
     description=docs.TOTALS,
-    path_params=[utils.committee_param],
+    params={'committee_id': {'description': docs.COMMITTEE_ID}},
 )
-class TotalsView(Resource):
+class TotalsView(utils.Resource):
 
-    @args.register_kwargs(args.paging)
-    @args.register_kwargs(args.totals)
-    @args.register_kwargs(args.make_sort_args(default=['-cycle']))
-    @schemas.marshal_with(schemas.CommitteeTotalsPageSchema(), wrap=False)
+    @use_kwargs(args.paging)
+    @use_kwargs(args.totals)
+    @use_kwargs(args.make_sort_args(default=['-cycle']))
+    @marshal_with(schemas.CommitteeTotalsPageSchema(), apply=False)
     def get(self, committee_id, **kwargs):
         totals_class, totals_schema = totals_schema_map.get(
             self._resolve_committee_type(committee_id, kwargs),

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -1,5 +1,4 @@
 import re
-import http
 import functools
 
 import marshmallow as ma
@@ -14,26 +13,6 @@ from webservices import __API_VERSION__
 
 spec.definition('OffsetInfo', schema=paging_schemas.OffsetInfoSchema)
 spec.definition('SeekInfo', schema=paging_schemas.SeekInfoSchema)
-
-
-def marshal_with(schema, code=http.client.OK, description=None, wrap=True):
-    def wrapper(func):
-        func.__apidoc__ = getattr(func, '__apidoc__', {})
-        func.__apidoc__.setdefault('responses', {}).update({
-            code: {
-                'schema': schema,
-                'description': description or '',
-            }
-        })
-
-        if wrap:
-            @functools.wraps(func)
-            def wrapped(*args, **kwargs):
-                return schema.dump(func(*args, **kwargs)).data
-            return wrapped
-        return func
-
-    return wrapper
 
 
 def register_schema(schema, definition_name=None):
@@ -359,7 +338,7 @@ class ElectionSummarySchema(ApiSchema):
     receipts = ma.fields.Decimal(places=2)
     disbursements = ma.fields.Decimal(places=2)
     independent_expenditures = ma.fields.Decimal(places=2)
-augment_schemas(ElectionSummarySchema)
+register_schema(ElectionSummarySchema)
 
 class ElectionSchema(ma.Schema):
     candidate_id = ma.fields.Str()

--- a/webservices/spec.py
+++ b/webservices/spec.py
@@ -1,5 +1,3 @@
-import copy
-
 from smore.apispec import APISpec
 
 from webservices import docs
@@ -64,11 +62,3 @@ spec = APISpec(
         },
     ]
 )
-
-
-def doc(**kwargs):
-    def wrapper(func):
-        func.__apidoc__ = copy.deepcopy(getattr(func, '__apidoc__', {}))
-        func.__apidoc__.update(kwargs)
-        return func
-    return wrapper

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -1,15 +1,22 @@
 import re
 import functools
 
+import six
 import sqlalchemy as sa
 from sqlalchemy.orm import foreign
 from sqlalchemy.ext.declarative import declared_attr
-from marshmallow_pagination import paginators
 
-from webservices import docs
+from flask.ext import restful
+from marshmallow_pagination import paginators
+from flask_smore.views import MethodResourceMeta
+
 from webservices import sorting
 from webservices import exceptions
 from webservices import decoders
+
+
+class Resource(six.with_metaclass(MethodResourceMeta, restful.Resource)):
+    pass
 
 
 def check_cap(kwargs, cap):
@@ -183,18 +190,6 @@ def make_image_pdf_url(image_number):
     return 'http://docquery.fec.gov/cgi-bin/fecimg/?{0}'.format(image_number)
 
 
-committee_param = {
-    'name': 'committee_id',
-    'type': 'string',
-    'in': 'path',
-    'description': docs.COMMITTEE_ID,
-}
-candidate_param = {
-    'name': 'candidate_id',
-    'type': 'string',
-    'in': 'path',
-    'description': docs.CANDIDATE_ID,
-}
 def cycle_param(**kwargs):
     ret = {
         'name': 'cycle',


### PR DESCRIPTION
Glue code for parsing request parameters with webargs and marshalling responses with marshmallow, plus generating swagger documentation, has moved over to https://github.com/jmcarp/flask-smore, which is more flexible and better tested than the code in this repo. This patch removes code that lives in flask-smore and takes advantage of improved APIs to reduce duplication.

h/t @sloria for help with flask-smore design