### PR TITLE
Fix concurrent refresh; add regression test.

### DIFF
--- a/data/sql_updates/create_election_outcome_view.sql
+++ b/data/sql_updates/create_election_outcome_view.sql
@@ -39,6 +39,8 @@ union all
 )
 ;
 
+create unique index on ofec_election_result_mv_tmp (cand_valid_yr_id);
+
 create index on ofec_election_result_mv_tmp (election_yr);
 create index on ofec_election_result_mv_tmp (cand_office);
 create index on ofec_election_result_mv_tmp (cand_office_st);

--- a/data/sql_updates/create_sched_e_aggregate_candidate.sql
+++ b/data/sql_updates/create_sched_e_aggregate_candidate.sql
@@ -1,6 +1,7 @@
 drop materialized view if exists ofec_sched_e_aggregate_candidate_mv_tmp;
 create materialized view ofec_sched_e_aggregate_candidate_mv_tmp as
 select
+    row_number() over () as idx,
     cmte_id,
     s_o_cand_id as cand_id,
     s_o_ind as support_oppose_indicator,
@@ -16,6 +17,8 @@ group by
     support_oppose_indicator,
     cycle
 ;
+
+create unique index on ofec_sched_e_aggregate_candidate_mv_tmp (idx);
 
 create index on ofec_sched_e_aggregate_candidate_mv_tmp (cmte_id);
 create index on ofec_sched_e_aggregate_candidate_mv_tmp (cand_id);

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -54,6 +54,9 @@ class TestViews(common.IntegrationTestCase):
                 continue
             self.assertGreater(model.query.count(), 0)
 
+    def test_refresh_materialized(self):
+        db.session.execute('select refresh_materialized()')
+
     def test_committee_year_filter(self):
         self._check_entity_model(models.Committee, 'committee_key')
         self._check_entity_model(models.CommitteeDetail, 'committee_key')


### PR DESCRIPTION
Using `REFRESH MATERIALIZED VIEW CONCURRENTLY` requires that the table
has at least one unique index. This patch adds unique indexes to tables
that were missing them before, and adds a regression test to prevent
errors of this type in the future.

h/t @LindsayYoung