### PR TITLE
Show all candidates in election views.

### DIFF
--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -286,7 +286,7 @@ def join_candidate_totals(query, kwargs, totals_model):
     ).join(
         CommitteeHistory,
         CandidateCommitteeLink.committee_key == CommitteeHistory.committee_key,
-    ).join(
+    ).outerjoin(
         totals_model,
         CommitteeHistory.committee_id == totals_model.committee_id,
     )
@@ -311,6 +311,9 @@ def filter_candidate_totals(query, kwargs, totals_model):
         CandidateCommitteeLink.election_year.in_([kwargs['cycle'], kwargs['cycle'] - 1]),
         CommitteeHistory.cycle == kwargs['cycle'],
         CommitteeHistory.designation.in_(['P', 'A']),
-        totals_model.cycle == kwargs['cycle'],
+        sa.or_(
+            totals_model.cycle == None,  # noqa
+            totals_model.cycle == kwargs['cycle'],
+        ),
     )
     return query

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -163,7 +163,9 @@ def document_description(report_year, report_type=None, document_type=None, form
 
 
 def report_pdf_url(report_year, beginning_image_number, form_type=None, committee_type=None):
-    if report_year and report_year >= 2000:
+    if not report_year:
+        return None
+    if report_year >= 2000:
         return make_report_pdf_url(beginning_image_number)
     if form_type in ['F3X', 'F3P'] and report_year > 1993:
         return make_report_pdf_url(beginning_image_number)


### PR DESCRIPTION
Currently, we use an `INNER JOIN` to join candidates on totals for the
election summary and detail views. This has the unwanted effect of
excluding candidates with no totals from these views. This patch uses
a `LEFT OUTER JOIN` and updates the queries accordingly, such that all
relevant candidates are included.

Related to #646.