### PR TITLE
Exclude inactive candidates from election views.

### DIFF
--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -88,6 +88,7 @@ class ElectionList(Resource):
             CandidateHistory.two_year_period,
         ).filter(
             CandidateHistory.candidate_status == 'C',
+            CandidateHistory.candidate_inactive == None,  # noqa
         )
         if kwargs['cycle']:
             query = query.filter(CandidateHistory.election_years.contains(kwargs['cycle']))
@@ -308,6 +309,7 @@ def filter_candidates(query, kwargs):
 def filter_candidate_totals(query, kwargs, totals_model):
     query = filter_candidates(query, kwargs)
     query = query.filter(
+        CandidateHistory.candidate_inactive == None,  # noqa
         CandidateCommitteeLink.election_year.in_([kwargs['cycle'], kwargs['cycle'] - 1]),
         CommitteeHistory.cycle == kwargs['cycle'],
         CommitteeHistory.designation.in_(['P', 'A']),


### PR DESCRIPTION
This patch uses the `cand_inactive_flg` to exclude candidates from election views: candidates with non-`NULL` values for this column are no longer included in the election summary or detail views.

h/t @PaulClark2 @LindsayYoung

[Resolves #1193]