### PR TITLE
Use distinct queries for candidate and committee resources.

### DIFF
--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -218,6 +218,26 @@ class CommitteeFormatTest(ApiBaseTest):
             set((each.committee_id for each in committees)),
         )
 
+    def test_committees_by_candidatee_count(self):
+        candidate_id = 'id0'
+        committee = factories.CommitteeFactory()
+        db.session.flush()
+        [
+            factories.CandidateCommitteeLinkFactory(
+                candidate_id=candidate_id,
+                committee_id=committee.committee_id,
+                committee_key=committee.committee_key,
+            ),
+            factories.CandidateCommitteeLinkFactory(
+                candidate_id=candidate_id,
+                committee_id=committee.committee_id,
+                committee_key=committee.committee_key,
+            ),
+        ]
+        response = self._response(api.url_for(CommitteeView, candidate_id=candidate_id))
+        self.assertEqual(response['pagination']['count'], 1)
+        self.assertEqual(len(response['results']), 1)
+
     def test_committee_by_cand_filter(self):
         candidate_id = 'id0'
         committee = factories.CommitteeFactory(designation='P')

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -56,7 +56,7 @@ class CandidateList(utils.Resource):
                 ),
                 models.CandidateSearch.fulltxt,
                 kwargs['q'],
-            )
+            ).distinct()
 
         candidates = filter_query(models.Candidate, candidates, filter_fields, kwargs)
 
@@ -126,7 +126,7 @@ class CandidateView(utils.Resource):
                 models.CandidateCommitteeLink
             ).filter(
                 models.CandidateCommitteeLink.committee_id == committee_id
-            )
+            ).distinct()
 
         candidates = filter_query(models.CandidateDetail, candidates, filter_fields, kwargs)
 
@@ -172,7 +172,7 @@ class CandidateHistoryView(utils.Resource):
                 models.CandidateCommitteeLink.candidate_key == models.CandidateHistory.candidate_key,
             ).filter(
                 models.CandidateCommitteeLink.committee_id == committee_id
-            )
+            ).distinct()
 
         if cycle:
             query = query.filter(models.CandidateHistory.two_year_period == cycle)

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -65,7 +65,7 @@ class CommitteeList(utils.Resource):
                 ),
                 models.CommitteeSearch.fulltxt,
                 kwargs['q'],
-            )
+            ).distinct()
 
         if kwargs.get('name'):
             committees = committees.filter(models.Committee.name.ilike('%{}%'.format(kwargs['name'])))
@@ -121,7 +121,7 @@ class CommitteeView(utils.Resource):
                 models.CandidateCommitteeLink
             ).filter(
                 models.CandidateCommitteeLink.candidate_id == candidate_id
-            )
+            ).distinct()
 
         committees = filter_query(models.CommitteeDetail, committees, detail_filter_fields, kwargs)
 
@@ -169,7 +169,7 @@ class CommitteeHistoryView(utils.Resource):
                 models.CandidateCommitteeLink.committee_key == models.CommitteeHistory.committee_key,
             ).filter(
                 models.CandidateCommitteeLink.candidate_id == candidate_id
-            )
+            ).distinct()
 
         if cycle:
             query = query.filter(models.CommitteeHistory.cycle == cycle)


### PR DESCRIPTION
Candidate and committee counts can be inflated when queries involve
joins on the candidate-committee join table. This patch applies
`DISTINCT` to these queries to avoid double-counting.

h/t @dannguyen for reporting!

[Resolves #1112]