### PR TITLE
Restrict Schedule E aggregates to form F3X.

### DIFF
--- a/data/sql_updates/create_sched_e_aggregate_candidate.sql
+++ b/data/sql_updates/create_sched_e_aggregate_candidate.sql
@@ -11,7 +11,7 @@ select
 from sched_e
 where
     exp_amt is not null and
-    filing_form = 'F3X' and
+    filing_form in ('F3X', 'F5') and
     (memo_cd != 'X' or memo_cd is null)
 group by
     cmte_id,

--- a/data/sql_updates/create_sched_e_aggregate_candidate.sql
+++ b/data/sql_updates/create_sched_e_aggregate_candidate.sql
@@ -9,8 +9,10 @@ select
     sum(exp_amt) as total,
     count(exp_amt) as count
 from sched_e
-where exp_amt is not null
-and (memo_cd != 'X' or memo_cd is null)
+where
+    exp_amt is not null and
+    filing_form = 'F3X' and
+    (memo_cd != 'X' or memo_cd is null)
 group by
     cmte_id,
     cand_id,


### PR DESCRIPTION
This is a temporary fix for #1226. As described in the issue, Schedule E
transactions from 24- and 48-hour reports aren't currently grouped by
unique transaction, such that multiple amended versions of the same
transaction can exist in the database. In the long term, @paulclark2 and
@jwchumley will work on aggregating Schedule E transactions across
amendments, but as a short-term fix, this patch simply restricts
Schedule E aggregates to transactions filed on form F3X.