### PR TITLE
Exclude filings with missing report years from cycle aggregation.

### DIFF
--- a/data/sql_updates/create_committee_history.sql
+++ b/data/sql_updates/create_committee_history.sql
@@ -10,6 +10,7 @@ with
                 2
             ) as cycle
         from vw_filing_history
+        where report_year != 0
         group by committee_id
     ),
     cycle_agg as (


### PR DESCRIPTION
Self-explanatory. Deals with missing data as described in #1235.