### PR TITLE
Improve the cycle selection for candidates

### DIFF
--- a/data/sql_updates/create_candidate_history_view.sql
+++ b/data/sql_updates/create_candidate_history_view.sql
@@ -27,6 +27,7 @@ with
                 2
             ) as cycle
         from dimcandproperties
+        where form_tp != 'F2Z'
         group by cand_sk
     ),
     cycle_agg as (


### PR DESCRIPTION
Checking for an F2 for cycle selection, so that we don't have dropdown options on candidate pages for periods that the candidates didn't file to run for office. 

(I tried to add the same logic to the elections, but it was too aggressive and took out real elections. So, that can be a different PR.) 

This should help with #964