### PR TITLE
Remove temporary workarounds around filings report years.

### DIFF
--- a/data/sql_updates/create_committee_history.sql
+++ b/data/sql_updates/create_committee_history.sql
@@ -10,7 +10,6 @@ with
                 2
             ) as cycle
         from vw_filing_history
-        where report_year != 0
         group by committee_id
     ),
     cycle_agg as (

--- a/data/sql_updates/post_committees_create_filings_view.sql
+++ b/data/sql_updates/post_committees_create_filings_view.sql
@@ -1,12 +1,3 @@
-create or replace function filings_year(report_year numeric, receipt_date date) returns int as $$
-begin
-    return case
-        when report_year != 0 then report_year
-        else date_part('year', receipt_date)
-    end;
-end
-$$ language plpgsql;
-
 drop materialized view if exists ofec_filings_mv_tmp;
 create materialized view ofec_filings_mv_tmp as
 select
@@ -21,7 +12,7 @@ select
     receipt_date,
     election_year,
     fh.form_type,
-    filings_year(report_year, receipt_date) as report_year,
+    date_part('year', receipt_date) as report_year,
     report_year + report_year % 2 as cycle,
     report_type,
     to_from_indicator as document_type,


### PR DESCRIPTION
Thanks to @PaulClark2, all records in `vw_filing_history` now have
non-zero values for `report_year`, so we can revert a few temporary
patches for handling missing years.

This doesn't add a feature or fix a bug--we're just deleting crufty code that no longer serves a purpose.