### PR TITLE
Further simplify report year logic.

### DIFF
--- a/data/sql_updates/post_committees_create_filings_view.sql
+++ b/data/sql_updates/post_committees_create_filings_view.sql
@@ -12,8 +12,8 @@ select
     receipt_date,
     election_year,
     fh.form_type,
-    date_part('year', receipt_date) as report_year,
-    report_year + report_year % 2 as cycle,
+    report_year,
+    get_cycle(report_year) as cycle,
     report_type,
     to_from_indicator as document_type,
     expand_document(to_from_indicator) as document_type_full,
@@ -46,8 +46,7 @@ from vw_filing_history fh
 left join ofec_committee_history_mv_tmp com on fh.committee_id = com.committee_id and get_cycle(fh.report_year) = com.cycle
 left join ofec_candidate_history_mv_tmp cand on fh.committee_id = cand.candidate_id and get_cycle(fh.report_year) = cand.two_year_period
 left join dimreporttype report on fh.report_type = report.rpt_tp
-where
-    filings_year(report_year, receipt_date) >= :START_YEAR
+where report_year >= :START_YEAR
 ;
 
 create unique index on ofec_filings_mv_tmp (idx);


### PR DESCRIPTION
I was looking over my patch yesterday and realized it should be even simpler. We don't need to extract the year from the receipt date at all now that we have reliable report years in the filings view.