### PR TITLE
Revert temporary fix for dependency conflicts.

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,6 +1,3 @@
-# TODO: Install dependencies from PyPI once updated
-pip install -U git+https://github.com/marshmallow-code/marshmallow-sqlalchemy@dev
-pip install marshmallow==2.0.0b4
 eval $(python webservices/setenv.py)
 python manage.py cf_startup && \
     (pkill gunicorn || true) && \


### PR DESCRIPTION
Previously, different dependencies pinned to conflicting versions of
upstream dependencies, requiring an manual install of pinned versions on
deploy. The conflict has been resolved, and the pinned versions are now
out of date, so this patch reverts the workaround.