### PR TITLE
Remove election search filter on candidate status.

### DIFF
--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -87,7 +87,6 @@ class ElectionList(utils.Resource):
             CandidateHistory.district,
             CandidateHistory.two_year_period,
         ).filter(
-            CandidateHistory.candidate_status == 'C',
             CandidateHistory.candidate_inactive == None,  # noqa
         )
         if kwargs.get('cycle'):


### PR DESCRIPTION
As discussed in #1252, candidate status values are sometimes out of
date or missing; filtering by candidate status inappropriately excludes
some relevant elections. This also makes the election search logic more
consistent with the election detail logic.

Related to https://github.com/18F/openFEC-web-app/issues/766.