### PR TITLE
Hide district 99 from election search.

### DIFF
--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -89,6 +89,11 @@ class ElectionList(utils.Resource):
             CandidateHistory.two_year_period,
         ).filter(
             CandidateHistory.candidate_inactive == None,  # noqa
+            # TODO(jmcarp) Revert after #1271 is resolved
+            sa.or_(
+                CandidateHistory.district == None,  # noqa
+                CandidateHistory.district != '99',
+            )
         )
         if kwargs.get('cycle'):
             query = query.filter(CandidateHistory.election_years.contains(kwargs['cycle']))


### PR DESCRIPTION
Hide elections with district "99" from election search results.

Note: this is a workaround; a better solution would be to fix the
underlying data, as described in #1271.

Related to https://github.com/18F/openFEC-web-app/issues/766