### PR TITLE
Get candidate office from `cand_valid_fec_yr`.

### DIFF
--- a/data/functions/acronyms.sql
+++ b/data/functions/acronyms.sql
@@ -10,6 +10,18 @@ returns text as $$
     end
 $$ language plpgsql;
 
+create or replace function expand_office(acronym text)
+returns text as $$
+    begin
+        return case acronym
+            when 'P' then 'President'
+            when 'S' then 'Senate'
+            when 'H' then 'House'
+            else 'Unknown'
+        end;
+    end
+$$ language plpgsql;
+
 create or replace function expand_candidate_status(acronym text)
 returns text as $$
     begin

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -7,4 +7,4 @@ services:
 env:
   NEW_RELIC_APP_NAME: OpenFEC API (staging)
   NEW_RELIC_ENV: staging
-  FEC_API_WHITELIST_IPS: true
+  FEC_API_WHITELIST_IPS: "false"


### PR DESCRIPTION
Some candidate office districts assembled from `dimcandproperties`,
`dimcandoffice`, and `candoffice` have values of "99" instead of their
true values. Based on a suggestion from @PaulClark2, this patch uses
`cand_valid_fec_yr` instead of `dimcandoffice` and `candoffice` to fetch
candidate state and district values.

This patch only touches a few parts of our materialized view, but this will need a careful review. @LindsayYoung take a look when you have time, and if it makes sense, we can deploy to dev and make sure this doesn't cause any collateral problems.

[Resolves #1271]