### PR TITLE
[hotfix] Rename flask-smore to flask-apispec.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,9 @@ csvkit==0.9.1
 ujson==1.33
 
 # Marshalling
-apispec==0.3.0
 marshmallow==2.1.0
 marshmallow-sqlalchemy==0.6.0
-git+https://github.com/jmcarp/flask-smore@master
+git+https://github.com/jmcarp/flask-apispec@master
 git+https://github.com/jmcarp/marshmallow-pagination@master
 
 # Development

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -1,7 +1,7 @@
 import sqlalchemy as sa
 
-from flask_smore import doc, marshal_with
-from flask_smore.utils import Ref
+from flask_apispec import doc, marshal_with
+from flask_apispec.utils import Ref
 
 from webservices import args
 from webservices import docs

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -1,5 +1,5 @@
 import sqlalchemy as sa
-from flask_smore import doc, marshal_with
+from flask_apispec import doc, marshal_with
 
 from webservices import args
 from webservices import utils

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -1,5 +1,5 @@
 import sqlalchemy as sa
-from flask_smore import doc, marshal_with
+from flask_apispec import doc, marshal_with
 
 from webservices import args
 from webservices import docs

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -1,5 +1,5 @@
 import sqlalchemy as sa
-from flask_smore import doc, marshal_with
+from flask_apispec import doc, marshal_with
 
 from webservices import args
 from webservices import docs

--- a/webservices/resources/dates.py
+++ b/webservices/resources/dates.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from flask_smore import doc, marshal_with
+from flask_apispec import doc, marshal_with
 
 from webservices import args
 from webservices import utils

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -1,5 +1,5 @@
 import sqlalchemy as sa
-from flask_smore import doc, marshal_with
+from flask_apispec import doc, marshal_with
 
 from webservices import args
 from webservices import docs

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -1,5 +1,5 @@
 import sqlalchemy as sa
-from flask_smore import doc, marshal_with
+from flask_apispec import doc, marshal_with
 
 from webservices import args
 from webservices import docs

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -1,5 +1,5 @@
 import sqlalchemy as sa
-from flask_smore import doc, marshal_with
+from flask_apispec import doc, marshal_with
 
 from webservices import args
 from webservices import docs

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -1,5 +1,5 @@
 import sqlalchemy as sa
-from flask_smore import doc, marshal_with
+from flask_apispec import doc, marshal_with
 
 from webservices import args
 from webservices import docs

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -1,5 +1,5 @@
 import sqlalchemy as sa
-from flask_smore import doc, marshal_with
+from flask_apispec import doc, marshal_with
 
 from webservices import args
 from webservices import docs

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -1,5 +1,5 @@
 import sqlalchemy as sa
-from flask_smore import doc, marshal_with
+from flask_apispec import doc, marshal_with
 
 from webservices import args
 from webservices import docs

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -1,5 +1,5 @@
 import sqlalchemy as sa
-from flask_smore import doc, marshal_with
+from flask_apispec import doc, marshal_with
 
 from webservices import args
 from webservices import docs

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -19,7 +19,7 @@ from flask.ext import cors
 from flask.ext import restful
 
 from webargs.flaskparser import FlaskParser
-from flask_smore import doc, marshal_with
+from flask_apispec import doc, marshal_with
 
 from webservices import args
 from webservices import docs
@@ -61,7 +61,7 @@ def sqla_conn_string():
 app = Flask(__name__)
 app.debug = True
 app.config['SQLALCHEMY_DATABASE_URI'] = sqla_conn_string()
-app.config['SMORE_FORMAT_RESPONSE'] = None
+app.config['APISPEC_FORMAT_RESPONSE'] = None
 # app.config['SQLALCHEMY_ECHO'] = True
 db.init_app(app)
 cors.CORS(app)
@@ -77,7 +77,7 @@ class FlaskRestParser(FlaskParser):
         raise exceptions.ApiError(message, status_code)
 
 parser = FlaskRestParser()
-app.config['SMORE_WEBARGS_PARSER'] = parser
+app.config['APISPEC_WEBARGS_PARSER'] = parser
 
 v1 = Blueprint('v1', __name__, url_prefix='/v1')
 api = restful.Api(v1)
@@ -243,7 +243,7 @@ api.add_resource(
 api.add_resource(filings.FilingsList, '/filings/')
 
 
-from flask_smore.apidoc import Documentation
+from flask_apispec.apidoc import Documentation
 docs = Documentation(app, spec.spec)
 
 docs.register(CandidateNameSearch, blueprint='v1')

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -11,8 +11,8 @@ from flask.ext import restful
 from marshmallow_pagination import paginators
 
 from webargs import fields
-from flask_smore import use_kwargs as use_kwargs_original
-from flask_smore.views import MethodResourceMeta
+from flask_apispec import use_kwargs as use_kwargs_original
+from flask_apispec.views import MethodResourceMeta
 
 from webservices import docs
 from webservices import sorting


### PR DESCRIPTION
Upgrade to latest flask-smore, which has been renamed to flask-apispec. This fixes the issue reported by @LindsayYoung and @leahbannon where the demo key isn't added in production.

Note: this is a hotfix, so once it's reviewed, we'll merge into both develop and master.