### PR TITLE
Handle duplicate candidate-committee links.

### DIFF
--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -89,6 +89,12 @@ class TestElections(ApiBaseTest):
             for each in self.committees
         ]
         db.session.flush()
+        # Simulate duplicate candidate-committee links per year in `dimlinkages`
+        factories.CandidateCommitteeLinkFactory(
+            candidate_key=self.candidate.candidate_key,
+            committee_key=self.committees[0].committee_key,
+            election_year=2012,
+        )
         factories.CandidateCommitteeLinkFactory(
             candidate_key=self.candidate.candidate_key,
             committee_key=self.committees[0].committee_key,


### PR DESCRIPTION
Because some candidate-committee links occur more than once for a given
year in `dimlinkages`, some committee totals were multiple-counted for
the election summary endpoint. This patch adds the necessary DISTINCT ON
to the query and updates the unit tests to simulate duplicate linkage
records.

Related to https://github.com/18F/openFEC-web-app/issues/646.