### PR TITLE
Exclude expired linkage rows from views.

### DIFF
--- a/data/sql_updates/create_committee_history.sql
+++ b/data/sql_updates/create_committee_history.sql
@@ -30,6 +30,7 @@ with
             cmte_sk,
             array_agg(distinct cand_id)::text[] as candidate_ids
         from dimlinkages dl
+        where dl.expire_date is null
         group by cmte_sk
     )
 select distinct on (dcp.cmte_sk, cycle)

--- a/data/sql_updates/create_linkage_names_view.sql
+++ b/data/sql_updates/create_linkage_names_view.sql
@@ -10,56 +10,33 @@ select
     l.cand_election_yr as election_year,
     l.cmte_id as committee_id,
     l.cmte_tp as committee_type,
-    case l.cmte_tp
-        when 'P' then 'Presidential'
-        when 'H' then 'House'
-        when 'S' then 'Senate'
-        when 'C' then 'Communication Cost'
-        when 'D' then 'Delegate Committee'
-        when 'E' then 'Electioneering Communication'
-        when 'I' then 'Independent Expenditor (Person or Group)'
-        when 'N' then 'PAC - Nonqualified'
-        when 'O' then 'Independent Expenditure-Only (Super PACs)'
-        when 'Q' then 'PAC - Qualified'
-        when 'U' then 'Single Candidate Independent Expenditure'
-        when 'V' then 'PAC with Non-Contribution Account - Nonqualified'
-        when 'W' then 'PAC with Non-Contribution Account - Qualified'
-        when 'X' then 'Party - Nonqualified'
-        when 'Y' then 'Party - Qualified'
-        when 'Z' then 'National Party Nonfederal Account'
-        else 'unknown' end as committee_type_full,
     l.cmte_dsgn as committee_designation,
-    case l.cmte_dsgn
-        when 'A' then 'Authorized by a candidate'
-        when 'J' then 'Joint fundraising committee'
-        when 'P' then 'Principal campaign committee'
-        when 'U' then 'Unauthorized'
-        when 'B' then 'Lobbyist/Registrant PAC'
-        when 'D' then 'Leadership PAC'
-        else 'unknown' end as committee_designation_full,
+    expand_committee_type(l.cmte_tp) as committee_type_full,
+    expand_committee_designation(l.cmte_dsgn) as committee_designation_full,
     l.load_date as load_date,
-    l.expire_date as expire_date,
     candprops.cand_nm as candidate_name,
     cmteprops.cmte_nm as committee_name
 from dimlinkages l
-    left join (
-        select distinct on (cand_sk) cand_sk, cand_nm from dimcandproperties
-            order by cand_sk, candproperties_sk desc
-    ) candprops on l.cand_sk = candprops.cand_sk
-    left join (
-        select distinct on (cmte_sk) cmte_sk, cmte_nm from dimcmteproperties
-            order by cmte_sk, cmteproperties_sk desc
-    ) cmteprops on l.cmte_sk = cmteprops.cmte_sk
-    left join (
-        select cand_id, max(dl.cand_election_yr) as active_through from dimlinkages
-            join dimlinkages dl using (cand_id)
-            group by cand_id
-    ) active on l.cand_id = active.cand_id
-    and l.cmte_dsgn != 'U'
-    and l.fec_election_yr >= :START_YEAR
+left join (
+    select distinct on (cand_sk) cand_sk, cand_nm from dimcandproperties
+        order by cand_sk, candproperties_sk desc
+) candprops on l.cand_sk = candprops.cand_sk
+left join (
+    select distinct on (cmte_sk) cmte_sk, cmte_nm from dimcmteproperties
+        order by cmte_sk, cmteproperties_sk desc
+) cmteprops on l.cmte_sk = cmteprops.cmte_sk
+left join (
+    select cand_id, max(dl.cand_election_yr) as active_through from dimlinkages
+        join dimlinkages dl using (cand_id)
+        group by cand_id
+) active on l.cand_id = active.cand_id
+where l.cmte_dsgn != 'U'
+and l.expire_date is null
+and l.cand_election_yr >= :START_YEAR
 ;
 
 create unique index on ofec_name_linkage_mv_tmp(idx);
 
 create index on ofec_name_linkage_mv_tmp(candidate_key);
 create index on ofec_name_linkage_mv_tmp(committee_key);
+create index on ofec_name_linkage_mv_tmp(election_year);

--- a/webservices/common/models/links.py
+++ b/webservices/common/models/links.py
@@ -17,7 +17,6 @@ class CandidateCommitteeLink(BaseModel):
     candidate_id = db.Column(db.String)
     election_year = db.Column(db.Integer)
     active_through = db.Column(db.Integer)
-    expire_date = db.Column(db.DateTime)
     committee_name = db.Column(db.String)
     candidate_name = db.Column(db.String)
     committee_designation = db.Column(db.String)


### PR DESCRIPTION
This patch fixes double-counting in election summary totals. Some totals
were multiply counted because of repeated candidate-committee linkage
rows; this patch ignores these expired duplicate rows. Thanks
@LindsayYoung and @PaulClark2 for guidance.

* Exclude all linkage rows where `expire_date is not null`.
* Add missing index on linkage view.
* Use helpers to expand acronyms.

Replaces #1284.