### PR TITLE
Handle multiple representations of null districts.

### DIFF
--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -136,7 +136,13 @@ class ElectionList(utils.Resource):
                 ),
                 # Senate and presidential races from matching states
                 sa.and_(
-                    CandidateHistory.district_number == None,  # noqa
+                    # Note: Missing districts may be represented as "00" or `None`.
+                    # For now, handle both values; going forward, we should choose
+                    # a consistent representation.
+                    sa.or_(
+                        CandidateHistory.district_number == 0,
+                        CandidateHistory.district_number == None,  # noqa
+                    ),
                     CandidateHistory.state.in_([districts.c['Official USPS Code'], 'US'])
                 ),
             )


### PR DESCRIPTION
Following changes in the construction of the candidate history view,
representations of missing states and districts changed such that
missing districts may be encoded as "00" or `None`. Until this
inconsistency is resolved, handle both missing values in the election
search view.

h/t @noahmanger