### PR TITLE
Temporarily fetch committee type from detail table.

### DIFF
--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -104,7 +104,12 @@ class ReportsView(utils.Resource):
             if kwargs.get('cycle'):
                 query = query.filter(models.CommitteeHistory.cycle.in_(kwargs['cycle']))
             query = query.order_by(sa.desc(models.CommitteeHistory.cycle))
-            committee = query.first_or_404()
+            committee = (
+                query.first() or
+                models.CommitteeDetail.query.filter_by(
+                    committee_id=committee_id
+                ).first_or_404()
+            )
             return committee.committee_type
         elif committee_type is not None:
             return reports_type_map.get(committee_type)

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -52,5 +52,10 @@ class TotalsView(utils.Resource):
         if kwargs.get('cycle'):
             query = query.filter(models.CommitteeHistory.cycle.in_(kwargs['cycle']))
         query = query.order_by(sa.desc(models.CommitteeHistory.cycle))
-        committee = query.first_or_404()
+        committee = (
+            query.first() or
+            models.CommitteeDetail.query.filter_by(
+                committee_id=committee_id
+            ).first_or_404()
+        )
         return committee.committee_type


### PR DESCRIPTION
Due to a mismatch in active cycles between `dimcmteproperties` and
`vw_filing_history`, some committee reports and totals return 404s on
attempting to resolve the committee type when a cycle is specified. This
patch temporarily falls back to resolving committee type from the detail
table when no matching results can be found for the specified cycle.

Note: this should be reverted after the underlying issue described in
https://github.com/18F/openFEC-web-app/issues/875 is resolved.