### PR TITLE
Check for null entity type on filter.

### DIFF
--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_contributor.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_contributor.sql
@@ -12,7 +12,7 @@ from sched_a
 where rpt_yr >= :START_YEAR_AGGREGATE
 and contb_receipt_amt is not null
 and contbr_id is not null
-and entity_tp != 'IND'
+and coalesce(entity_tp, '') != 'IND'
 and (memo_cd != 'X' or memo_cd is null)
 group by cmte_id, cycle, contbr_id
 ;
@@ -50,7 +50,7 @@ begin
         ) t
         where contb_receipt_amt is not null
         and contbr_id is not null
-        and entity_tp != 'IND'
+        and coalesce(entity_tp, '') != 'IND'
         and (memo_cd != 'X' or memo_cd is null)
         group by cmte_id, cycle, contbr_id
     ),

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -10,6 +10,7 @@ class TestFilter(ApiBaseTest):
     def setUp(self):
         super(TestFilter, self).setUp()
         self.receipts = [
+            factories.ScheduleAFactory(entity_type=None),
             factories.ScheduleAFactory(entity_type='IND'),
             factories.ScheduleAFactory(entity_type='CCM'),
             factories.ScheduleAFactory(entity_type='COM'),

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -1,3 +1,5 @@
+import sqlalchemy as sa
+
 from webservices import utils
 from webservices import exceptions
 from webservices.common import models
@@ -30,7 +32,7 @@ def filter_contributor_type(query, column, kwargs):
     if kwargs.get('contributor_type') == ['individual']:
         return query.filter(column == 'IND')
     if kwargs.get('contributor_type') == ['committee']:
-        return query.filter(column != 'IND')
+        return query.filter(sa.or_(column != 'IND', column == None))  # noqa
     return query
 
 


### PR DESCRIPTION
When aggregating receipts by contributing committee, we filter out items
with entity type equal to "IND". As implemented, this filter
unintentionally remove items with entity type `null` as well. To fix,
this patch coalesces `entity_tp` with the empty string.

[Resolves #1294]