### PR TITLE
Use committee designation on linkage table.

### DIFF
--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -97,6 +97,7 @@ class CandidateFormatTest(ApiBaseTest):
             factories.CandidateCommitteeLinkFactory(
                 candidate_key=candidate.candidate_key,
                 committee_key=principal_committee.committee_key,
+                committee_designation='P',
             ),
             factories.CandidateCommitteeLinkFactory(
                 candidate_key=candidate.candidate_key,

--- a/webservices/common/models/candidates.py
+++ b/webservices/common/models/candidates.py
@@ -50,9 +50,12 @@ class Candidate(BaseConcreteCandidate):
         secondary='ofec_name_linkage_mv',
         secondaryjoin='''and_(
             Committee.committee_key == ofec_name_linkage_mv.c.committee_key,
-            Committee.designation == 'P',
+            ofec_name_linkage_mv.c.committee_designation == 'P',
         )''',
-        order_by='desc(Committee.last_file_date)',
+        order_by=(
+            'desc(ofec_name_linkage_mv.c.election_year),'
+            'desc(Committee.last_file_date),'
+        )
     )
 
 


### PR DESCRIPTION
Join candidates to their principal committees using committee
designation values from the linkage table. This ensures that we're
fetching the most recent principal committee, not the most recent
committee that was ever a principal committee. This also fixes a few
candidates for whom principal committee designations are correct in the
linkage table but missing in the committee designation table.

Related to #1299.