### PR TITLE
Expose expiration date on IE reports.

### DIFF
--- a/data/sql_updates/create_reports_ie_only.sql
+++ b/data/sql_updates/create_reports_ie_only.sql
@@ -34,12 +34,12 @@ from
     left join dimdates end_date on cvg_end_dt_sk = end_date.date_sk and cvg_end_dt_sk != 1
 where
     two_yr_period_sk >= :START_YEAR
-    and ief5.expire_date is null
 ;
 
 create unique index on ofec_reports_ie_only_mv_tmp(idx);
 
 create index on ofec_reports_ie_only_mv_tmp(cycle);
+create index on ofec_reports_ie_only_mv_tmp(expire_date);
 create index on ofec_reports_ie_only_mv_tmp(report_type);
 create index on ofec_reports_ie_only_mv_tmp(report_year);
 create index on ofec_reports_ie_only_mv_tmp(committee_id);

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -70,21 +70,29 @@ class TestReports(ApiBaseTest):
         )
 
     def test_reports_by_amended(self):
-        reports = [
-            factories.ReportsPresidentialFactory(expire_date=None),
-            factories.ReportsPresidentialFactory(expire_date=datetime.date(2014, 1, 1)),
+        params = [
+            ('house-senate', factories.ReportsHouseSenateFactory),
+            ('presidential', factories.ReportsPresidentialFactory),
+            ('pac-party', factories.ReportsPacPartyFactory),
+            ('ie-only', factories.ReportsIEOnlyFactory),
         ]
 
-        results = self._results(api.url_for(ReportsView, committee_type='presidential'))
-        self.assertEqual(len(results), 2)
+        for category, factory in params:
+            reports = [
+                factory(expire_date=None),
+                factory(expire_date=datetime.date(2014, 1, 1)),
+            ]
 
-        results = self._results(api.url_for(ReportsView, committee_type='presidential', is_amended='false'))
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]['committee_id'], reports[0].committee_id)
+            results = self._results(api.url_for(ReportsView, committee_type=category))
+            self.assertEqual(len(results), 2)
 
-        results = self._results(api.url_for(ReportsView, committee_type='presidential', is_amended='true'))
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]['committee_id'], reports[1].committee_id)
+            results = self._results(api.url_for(ReportsView, committee_type=category, is_amended='false'))
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0]['committee_id'], reports[0].committee_id)
+
+            results = self._results(api.url_for(ReportsView, committee_type=category, is_amended='true'))
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0]['committee_id'], reports[1].committee_id)
 
     def test_reports_by_committee_type_and_year(self):
         presidential_report_2012 = factories.ReportsPresidentialFactory(report_year=2012)

--- a/webservices/common/models/reports.py
+++ b/webservices/common/models/reports.py
@@ -241,6 +241,7 @@ class CommitteeReportsPresidential(CommitteeReports):
 class CommitteeReportsIEOnly(PdfMixin, BaseModel):
     __tablename__ = 'ofec_reports_ie_only_mv'
 
+    expire_date = db.Column(db.DateTime)
     beginning_image_number = db.Column(db.BigInteger)
     committee_id = db.Column(db.String)
     cycle = db.Column(db.Integer)


### PR DESCRIPTION
Expose expiration date on IE reports.

Fixes an uncaught exception on fetching IE reports with
`is_amended=false`. Thanks @PaulClark2 for reporting.

To verify, check a URL like localhost:5000/v1/committee/C00590398/reports/?is_amended=false (or likewise for any IE filer) and check that the response code is 200, not 500.

Attention @LindsayYoung 