### PR TITLE
Feature/update committee data

### DIFF
--- a/data/sql_updates/create_committee_history.sql
+++ b/data/sql_updates/create_committee_history.sql
@@ -3,54 +3,42 @@ create materialized view ofec_committee_history_mv_tmp as
 with
     cycles as (
         select
-            committee_id,
-            generate_series(
-                min(get_cycle(report_year)),
-                max(get_cycle(report_year)),
-                2
-            ) as cycle
-        from vw_filing_history
-        group by committee_id
-    ),
-    cycle_agg as (
-        select
-            committee_id,
-            array_agg(cycles.cycle)::int[] as cycles,
-            max(cycles.cycle) as max_cycle
-        from cycles
-        group by committee_id
+            cmte_id,
+            array_agg(fec_election_yr)::int[] as cycles,
+            max(fec_election_yr) as max_cycle
+        from cmte_valid_fec_yr
+        group by cmte_id
     ),
     filings_original as (
         select committee_id, min(receipt_date) receipt_date from vw_filing_history
         where report_year >= :START_YEAR
         group by committee_id
     ),
-    candidate_agg as (
+    candidates as (
         select
-            cmte_sk,
+            cmte_id,
             array_agg(distinct cand_id)::text[] as candidate_ids
         from dimlinkages dl
         where dl.expire_date is null
-        group by cmte_sk
+        group by cmte_id
     )
-select distinct on (dcp.cmte_sk, cycle)
+select distinct on (fec_yr.cmte_id, fec_yr.fec_election_yr)
     row_number() over () as idx,
-    cycles.cycle,
+    fec_yr.fec_election_yr as cycle,
     dcp.cmte_sk as committee_key,
-    dcp.cmte_id as committee_id,
-    dcp.cmte_nm as name,
-    dcp.cmte_treasurer_nm as treasurer_name,
+    fec_yr.cmte_id as committee_id,
+    fec_yr.cmte_nm as name,
+    fec_yr.tres_nm as treasurer_name,
     dcp.org_tp as organization_type,
     expand_organization_type(dcp.org_tp) as organization_type_full,
-    dcp.cand_pty_affiliation as party,
-    dcp.cmte_st as state,
     dcp.expire_date as expire_date,
     -- Address
-    dcp.cmte_st1 as street_1,
-    dcp.cmte_st2 as street_2,
-    dcp.cmte_city as city,
+    fec_yr.cmte_st1 as street_1,
+    fec_yr.cmte_st2 as street_2,
+    fec_yr.cmte_city as city,
+    fec_yr.cmte_st as state,
     dcp.cmte_st_desc as state_full,
-    dcp.cmte_zip as zip,
+    fec_yr.cmte_zip as zip,
     -- Treasurer
     dcp.cmte_treasurer_city as treasurer_city,
     dcp.cmte_treasurer_f_nm as treasurer_name_1,
@@ -79,35 +67,33 @@ select distinct on (dcp.cmte_sk, cycle)
     dcp.cmte_custodian_title as custodian_name_title,
     dcp.cmte_custodian_zip as custodian_zip,
     -- Properties
-    dcp.cmte_email as email,
+    fec_yr.cmte_email as email,
     dcp.cmte_fax as fax,
-    dcp.cmte_web_url as website,
+    fec_yr.cmte_url as website,
     dcp.form_tp as form_type,
     dcp.leadership_pac as leadership_pac,
-    dcp.load_date as load_date,
     dcp.lobbyist_registrant_pac_flg as lobbyist_registrant_pac,
     dcp.party_cmte_type as party_type,
     dcp.party_cmte_type_desc as party_type_full,
     dcp.qual_dt as qualifying_date,
-    dcp.receipt_dt as last_file_date,
+    fec_yr.latest_receipt_dt as last_file_date,
     filings_original.receipt_date as first_file_date,
-    dd.cmte_dsgn as designation,
-    expand_committee_designation(dd.cmte_dsgn) as designation_full,
-    dd.cmte_tp as committee_type,
-    expand_committee_type(dd.cmte_tp) as committee_type_full,
-    dd.filing_freq as filing_frequency,
-    clean_party(p.party_affiliation_desc) as party_full,
-    cycle_agg.cycles,
-    coalesce(candidate_agg.candidate_ids, '{}'::text[]) as candidate_ids
-from dimcmteproperties dcp
-left join cycle_agg on dcp.cmte_id = cycle_agg.committee_id
-left join cycles on dcp.cmte_id = cycles.committee_id and dcp.rpt_yr <= cycles.cycle
-left join dimparty p on dcp.cand_pty_affiliation = p.party_affiliation
-left join dimcmtetpdsgn dd on dcp.cmte_sk = dd.cmte_sk and extract(year from dd.receipt_date) <= cycles.cycle
-left join filings_original on dcp.cmte_id = filings_original.committee_id
-left join candidate_agg on dcp.cmte_sk = candidate_agg.cmte_sk
-where max_cycle >= :START_YEAR
-order by dcp.cmte_sk, cycle desc, dcp.rpt_yr desc
+    fec_yr.cmte_dsgn as designation,
+    expand_committee_designation(fec_yr.cmte_dsgn) as designation_full,
+    fec_yr.cmte_tp as committee_type,
+    expand_committee_type(fec_yr.cmte_tp) as committee_type_full,
+    fec_yr.cmte_filing_freq as filing_frequency,
+    fec_yr.cmte_pty_affiliation as party,
+    fec_yr.cmte_pty_affiliation_desc as party_full,
+    cycles.cycles,
+    coalesce(candidates.candidate_ids, '{}'::text[]) as candidate_ids
+from cmte_valid_fec_yr fec_yr
+left join dimcmteproperties dcp on fec_yr.cmte_id = dcp.cmte_id and fec_yr.fec_election_yr >= dcp.rpt_yr
+left join cycles on fec_yr.cmte_id = cycles.cmte_id
+left join filings_original on fec_yr.cmte_id = filings_original.committee_id
+left join candidates on fec_yr.cmte_id = candidates.cmte_id
+where cycles.max_cycle >= :START_YEAR
+order by fec_yr.cmte_id, fec_yr.fec_election_yr desc, dcp.rpt_yr desc
 ;
 
 create unique index on ofec_committee_history_mv_tmp(idx);

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -74,7 +74,6 @@ class CommitteeFormatTest(ApiBaseTest):
             treasurer_name='Robert J. Lipshutz',
             party='DEM',
             form_type='F1Z',
-            load_date=datetime.datetime(1982, 12, 31),
             street_1='1795 Peachtree Road',
             zip='30309',
         )
@@ -87,7 +86,6 @@ class CommitteeFormatTest(ApiBaseTest):
         self.assertEqual(result['party'], committee.party)
         # Things on the detailed view
         self.assertEqual(result['form_type'], committee.form_type)
-        self.assertEqual(result['load_date'], isoformat(committee.load_date))
         self.assertEqual(result['street_1'], committee.street_1)
         self.assertEqual(result['zip'], committee.zip)
 

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -85,18 +85,18 @@ class TestElections(ApiBaseTest):
         ]
         factories.CandidateDetailFactory(candidate_key=self.candidate.candidate_key)
         [
-            factories.CommitteeDetailFactory(committee_key=each.committee_key)
+            factories.CommitteeDetailFactory(committee_id=each.committee_id)
             for each in self.committees
         ]
         db.session.flush()
         factories.CandidateCommitteeLinkFactory(
             candidate_key=self.candidate.candidate_key,
-            committee_key=self.committees[0].committee_key,
+            committee_id=self.committees[0].committee_id,
             election_year=2012,
         )
         factories.CandidateCommitteeLinkFactory(
             candidate_key=self.candidate.candidate_key,
-            committee_key=self.committees[1].committee_key,
+            committee_id=self.committees[1].committee_id,
             election_year=2011,
         )
         self.totals = [

--- a/webservices/common/models/committees.py
+++ b/webservices/common/models/committees.py
@@ -66,7 +66,6 @@ class CommitteeDetail(BaseConcreteCommittee):
     website = db.Column(db.String(50))
     form_type = db.Column(db.String(3))
     leadership_pac = db.Column(db.String(50))
-    load_date = db.Column(db.DateTime())
     lobbyist_registrant_pac = db.Column(db.String(1))
     party_type = db.Column(db.String(3))
     party_type_full = db.Column(db.String(15))

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -167,7 +167,7 @@ class CommitteeHistoryView(utils.Resource):
         if candidate_id:
             query = query.join(
                 models.CandidateCommitteeLink,
-                models.CandidateCommitteeLink.committee_key == models.CommitteeHistory.committee_key,
+                models.CandidateCommitteeLink.committee_id == models.CommitteeHistory.committee_id,
             ).filter(
                 models.CandidateCommitteeLink.candidate_id == candidate_id
             ).distinct()

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -303,7 +303,7 @@ def join_candidate_totals(query, kwargs, totals_model):
         CandidateHistory.candidate_key == CandidateCommitteeLink.candidate_key,
     ).join(
         CommitteeHistory,
-        CandidateCommitteeLink.committee_key == CommitteeHistory.committee_key,
+        CandidateCommitteeLink.committee_id == CommitteeHistory.committee_id,
     ).join(
         totals_model,
         CommitteeHistory.committee_id == totals_model.committee_id,

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -104,12 +104,7 @@ class ReportsView(utils.Resource):
             if kwargs.get('cycle'):
                 query = query.filter(models.CommitteeHistory.cycle.in_(kwargs['cycle']))
             query = query.order_by(sa.desc(models.CommitteeHistory.cycle))
-            committee = (
-                query.first() or
-                models.CommitteeDetail.query.filter_by(
-                    committee_id=committee_id
-                ).first_or_404()
-            )
+            committee = query.first_or_404()
             return committee.committee_type
         elif committee_type is not None:
             return reports_type_map.get(committee_type)

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -52,10 +52,5 @@ class TotalsView(utils.Resource):
         if kwargs.get('cycle'):
             query = query.filter(models.CommitteeHistory.cycle.in_(kwargs['cycle']))
         query = query.order_by(sa.desc(models.CommitteeHistory.cycle))
-        committee = (
-            query.first() or
-            models.CommitteeDetail.query.filter_by(
-                committee_id=committee_id
-            ).first_or_404()
-        )
+        committee = query.first_or_404()
         return committee.committee_type


### PR DESCRIPTION
Where possible, use `cmte_valid_fec_yr` instead of `dimcmteproperties`,
`dimparty`, and other data warehouse tables for committee materialized
views. This table is better vetted than the tables we're currently
using.

[Resolves #1287]
[Resolves https://github.com/18F/FEC/issues/109]

Paging @LindsayYoung for review. This should resolve a bunch of miscellaneous data errors (likely including some we haven't even noticed yet!), but it needs to be tested thoroughly on dev before it's ready for production.

Also, as implemented, this patch still pulls several fields from `dimcmteproperties` when they aren't available on `cmte_valid_fec_yr`. This includes treasurer address, custodian committee information, and fax number, for a few examples. As I understand it, we're going to want to stop using `dimcmteproperties` entirely, as with all tables that live in the data warehouse. If that's correct, it would be ideal if we could add those columns to `cmte_valid_fec_yr`, if they're useful. Thoughts @PaulClark2?