### PR TITLE
Cache compiled dependencies for faster builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 
 before_script:
   - psql -c 'create database "cfdm-unit-test";' -U postgres
+  - pip install -U pip wheel
   - pip install -U -r requirements.txt
 
 script: nosetests -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_install:
 
 before_script:
   - psql -c 'create database "cfdm-unit-test";' -U postgres
-  - pip install -U pip wheel
-  - pip install -U -r requirements.txt
+  - travis_retry pip install -U pip wheel
+  - travis_retry pip install -U -r requirements.txt
 
 script: nosetests -s
 


### PR DESCRIPTION
See https://github.com/nickstenning/travis-pip-cache.

To verify that this works, run the build more then once; expect faster install times after the first run.