### PR TITLE
Censor duplicate committee IDs in itemized tables.

### DIFF
--- a/data/functions/clean.sql
+++ b/data/functions/clean.sql
@@ -3,7 +3,18 @@
 -- * "Green Party Added)" becomes "Green Party"
 create or replace function clean_party(party text)
 returns text as $$
-    begin
-        return regexp_replace(party, '\s*(Added|Removed|\(.*?)\)$', '');
-    end
+begin
+    return regexp_replace(party, '\s*(Added|Removed|\(.*?)\)$', '');
+end
+$$ language plpgsql;
+
+-- Compare two values. If equal, return `NULL`, else return the first value.
+create or replace function clean_repeated(first anyelement, second anyelement)
+returns anyelement as $$
+begin
+    return case
+        when first = second then null
+        else first
+    end;
+end
 $$ language plpgsql;

--- a/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient_committee.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient_committee.sql
@@ -4,7 +4,7 @@ create table ofec_sched_b_aggregate_recipient_id as
 select
     cmte_id,
     rpt_yr + rpt_yr % 2 as cycle,
-    recipient_cmte_id,
+    clean_repeated(recipient_cmte_id, cmte_id) as recipient_cmte_id,
     max(recipient_nm) as recipient_nm,
     sum(disb_amt) as total,
     count(disb_amt) as count
@@ -12,8 +12,8 @@ from sched_b
 where rpt_yr >= :START_YEAR_AGGREGATE
 and disb_amt is not null
 and (memo_cd != 'X' or memo_cd is null)
-and recipient_cmte_id is not null
-group by cmte_id, cycle, recipient_cmte_id
+and clean_repeated(recipient_cmte_id, cmte_id) is not null
+group by cmte_id, cycle, clean_repeated(recipient_cmte_id, cmte_id)
 ;
 
 -- Create indices on aggregate
@@ -38,7 +38,7 @@ begin
         select
             cmte_id,
             rpt_yr + rpt_yr % 2 as cycle,
-            recipient_cmte_id,
+            clean_repeated(recipient_cmte_id, cmte_id) as recipient_cmte_id,
             max(recipient_nm) as recipient_nm,
             sum(disb_amt * multiplier) as total,
             sum(multiplier) as count
@@ -49,8 +49,8 @@ begin
         ) t
         where disb_amt is not null
         and (memo_cd != 'X' or memo_cd is null)
-        and recipient_cmte_id is not null
-        group by cmte_id, cycle, recipient_cmte_id
+        and clean_repeated(recipient_cmte_id, cmte_id) is not null
+        group by cmte_id, cycle, clean_repeated(recipient_cmte_id, cmte_id)
     ),
     inc as (
         update ofec_sched_b_aggregate_recipient_id ag

--- a/data/sql_incremental_aggregates/update_schedule_a_fulltext.sql
+++ b/data/sql_incremental_aggregates/update_schedule_a_fulltext.sql
@@ -10,7 +10,8 @@ begin
             to_tsvector(contbr_employer) as contributor_employer_text,
             to_tsvector(contbr_occupation) as contributor_occupation_text,
             is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
-                as is_individual
+                as is_individual,
+            clean_repeated(contbr_id, cmte_id) as clean_contbr_id
         from ofec_sched_a_queue_new
     );
 end

--- a/data/sql_incremental_aggregates/update_schedule_b_fulltext.sql
+++ b/data/sql_incremental_aggregates/update_schedule_b_fulltext.sql
@@ -8,7 +8,8 @@ begin
             *,
             to_tsvector(recipient_nm) as recipient_name_text,
             to_tsvector(disb_desc) as disbursement_description_text,
-            disbursement_purpose(disb_tp, disb_desc) as disbursement_purpose_category
+            disbursement_purpose(disb_tp, disb_desc) as disbursement_purpose_category,
+            clean_repeated(recipient_cmte_id, cmte_id) as clean_recipient_cmte_id
         from ofec_sched_b_queue_new
     );
 end

--- a/data/sql_setup/prepare_schedule_a.sql
+++ b/data/sql_setup/prepare_schedule_a.sql
@@ -7,7 +7,8 @@ select
     to_tsvector(contbr_employer) as contributor_employer_text,
     to_tsvector(contbr_occupation) as contributor_occupation_text,
     is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
-        as is_individual
+        as is_individual,
+    clean_repeated(contbr_id, cmte_id) as clean_contbr_id
 from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 ;
@@ -19,10 +20,10 @@ create index on ofec_sched_a (rpt_yr);
 create index on ofec_sched_a (entity_tp);
 create index on ofec_sched_a (image_num);
 create index on ofec_sched_a (sched_a_sk);
-create index on ofec_sched_a (contbr_id);
 create index on ofec_sched_a (contbr_st);
 create index on ofec_sched_a (contbr_city);
 create index on ofec_sched_a (is_individual);
+create index on ofec_sched_a (clean_contbr_id);
 
 -- Create composite indices on sortable columns
 create index on ofec_sched_a (contb_receipt_dt, sched_a_sk);

--- a/data/sql_setup/prepare_schedule_b.sql
+++ b/data/sql_setup/prepare_schedule_b.sql
@@ -5,7 +5,8 @@ select
     *,
     to_tsvector(recipient_nm) as recipient_name_text,
     to_tsvector(disb_desc) as disbursement_description_text,
-    disbursement_purpose(disb_tp, disb_desc) as disbursement_purpose_category
+    disbursement_purpose(disb_tp, disb_desc) as disbursement_purpose_category,
+    clean_repeated(recipient_cmte_id, cmte_id) as clean_recipient_cmte_id
 from sched_b
 where rpt_yr >= :START_YEAR_ITEMIZED
 ;
@@ -18,7 +19,7 @@ create index on ofec_sched_b (image_num);
 create index on ofec_sched_b (sched_b_sk);
 create index on ofec_sched_b (recipient_st);
 create index on ofec_sched_b (recipient_city);
-create index on ofec_sched_b (recipient_cmte_id);
+create index on ofec_sched_b (clean_recipient_cmte_id);
 
 -- Create composite indices on sortable columns
 create index on ofec_sched_b(disb_dt, sched_b_sk);

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -43,7 +43,7 @@ class ScheduleA(BaseItemized):
     __tablename__ = 'ofec_sched_a'
 
     sched_a_sk = db.Column(db.Integer, primary_key=True)
-    contributor_id = db.Column('contbr_id', db.String)
+    contributor_id = db.Column('clean_contbr_id', db.String)
     contributor = db.relationship(
         'CommitteeHistory',
         primaryjoin='''and_(
@@ -93,7 +93,7 @@ class ScheduleB(BaseItemized):
     __tablename__ = 'ofec_sched_b'
 
     sched_b_sk = db.Column(db.Integer, primary_key=True)
-    recipient_committee_id = db.Column('recipient_cmte_id', db.String)
+    recipient_committee_id = db.Column('clean_recipient_cmte_id', db.String)
     recipient_committee = db.relationship(
         'CommitteeHistory',
         primaryjoin='''and_(


### PR DESCRIPTION
As described in #1306 and #1330, committees sometimes enter the same values for
`contbr_id` and `cmte_id` (for receipts) and for `recipient_cmte_id` and
`cmte_id` (for disbursements). In these cases, values of `contbr_id` and
`recipient_cmte_id` should be ignored for receipts and disbursements,
respectively. This patch creates `clean_contbr_id` and
`clean_recipient_cmte_id` columns, which are displayed in the API
instead of the original `contbr_id` and `recipient_cmte_id` columns.

[Resolves #1306]
[Resolves #1330]

To verify, we'll rebuild the itemized tables on the dev server and verify that the incorrect contributor and recipient committee IDs described in #1306 aren't displayed in the API (or on the data site).