### PR TITLE
Pin node and buildpack versions.

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
-https://github.com/cloudfoundry/python-buildpack
-https://github.com/cloudfoundry/nodejs-buildpack
-https://github.com/cloudfoundry/staticfile-buildpack
+https://github.com/cloudfoundry/python-buildpack#v1.5.1
+https://github.com/cloudfoundry/nodejs-buildpack.git#v1.5.0
+https://github.com/cloudfoundry/staticfile-buildpack#v1.2.2

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "dependencies": {
      "swagger-ui": "git://github.com/18F/swagger-ui.git"
+  },
+  "engines": {
+    "node": "0.12.7",
+    "npm": "2.11.3"
   }
 }


### PR DESCRIPTION
The Cloud Foundry team recently updated the node buildpack and the
default version of node installed. This causes deployments to fail on
buildpack compilation. This patch pins our node and buildpack versions
to the last known working releases.