### PR TITLE
Feature/capture email logs

### DIFF
--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -12,7 +12,7 @@ def environ(monkeypatch):
     monkeypatch.setenv('MANDRILL_API_KEY', '12345')
     monkeypatch.setenv('FEC_EMAIL_SENDER', 'cj@whitehouse.gov')
     monkeypatch.setenv('FEC_EMAIL_RECIPIENTS', 'toby@whitehouse.gov')
-    monkeypatch.setenv('VCAP_APPLICATION', '{"name": "api", "space-name": "dev"}')
+    monkeypatch.setenv('VCAP_APPLICATION', '{"name": "api", "space_name": "dev"}')
 
 @pytest.fixture
 def client():
@@ -29,7 +29,7 @@ class TestHelpers:
 
     def test_get_subject(self):
         settings = {
-            'space-name': 'dev',
+            'space_name': 'dev',
             'name': 'api',
         }
         assert mail.get_subject(settings) == 'FEC Update: dev | api'

--- a/webservices/mail.py
+++ b/webservices/mail.py
@@ -17,8 +17,11 @@ class CaptureLogs:
             fmt='%(asctime)s %(levelname)s:%(name)s:%(message)s',
             datefmt='%Y-%m-%d %H:%M:%S',
         )
+
         self.handler = logging.StreamHandler(self.buffer)
         self.handler.setFormatter(self.formatter)
+        self.handler.setLevel(logging.INFO)
+
         self.logger.addHandler(self.handler)
 
     def __exit__(self, exc_type, exc_value, exc_tb):
@@ -37,7 +40,7 @@ def send_mail(buffer):
 
 def get_subject(settings):
     return 'FEC Update: {space} | {app}'.format(
-        space=settings.get('space-name', 'unknown-space'),
+        space=settings.get('space_name', 'unknown-space'),
         app=settings.get('name', 'unknown-app'),
     )
 

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -4,7 +4,6 @@ full documentation visit: https://api.open.fec.gov/developers.
 """
 import os
 import http
-import logging
 
 from flask import abort
 from flask import request
@@ -44,10 +43,6 @@ from webservices.resources import elections
 from webservices.resources import filings
 from webservices.resources import dates
 
-speedlogger = logging.getLogger('speed')
-speedlogger.setLevel(logging.CRITICAL)
-speedlogger.addHandler(logging.FileHandler(('rest_speed.log')))
-
 
 def sqla_conn_string():
     sqla_conn_string = os.getenv('SQLA_CONN')
@@ -66,12 +61,9 @@ app.config['APISPEC_FORMAT_RESPONSE'] = None
 db.init_app(app)
 cors.CORS(app)
 
-logger = logging.getLogger(__name__)
-
 class FlaskRestParser(FlaskParser):
 
     def handle_error(self, error):
-        logger.error(error)
         message = error.messages
         status_code = getattr(error, 'status_code', 422)
         raise exceptions.ApiError(message, status_code)


### PR DESCRIPTION
I noticed that our automated emails weren't capturing logs at the `logging.INFO` level. This patch fixes the log level, and fixes a typo in a Cloud Foundry environment variable.