### PR TITLE
Remove all uses of dimlinkages from materialized views.

### DIFF
--- a/data/sql_updates/create_committee_history.sql
+++ b/data/sql_updates/create_committee_history.sql
@@ -18,8 +18,7 @@ with
         select
             cmte_id,
             array_agg(distinct cand_id)::text[] as candidate_ids
-        from dimlinkages dl
-        where dl.expire_date is null
+        from cand_cmte_linkage
         group by cmte_id
     )
 select distinct on (fec_yr.cmte_id, fec_yr.fec_election_yr)


### PR DESCRIPTION
I noticed one last reference to `dimlinkages` in our materialized views. This tiny patch switches it over to `cand_cmte_linkage`. The check on `expire_date` is removed because the column doesn't exist in the FECP table.