### PR TITLE
Show Senate and Presidential elections on district election search.

### DIFF
--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -20,18 +20,18 @@ class TestElectionSearch(ApiBaseTest):
             candidate_status='C',
         )
         self.candidates = [
-            factory(office='P', state='US', district=None),
-            factory(office='S', state='NJ', district=None),
+            factory(office='P', state='US', district='00'),
+            factory(office='S', state='NJ', district='00'),
             factory(office='H', state='NJ', district='09'),
-            factory(office='S', state='VA', district=None),
+            factory(office='S', state='VA', district='00'),
             factory(office='H', state='VA', district='05'),
         ]
 
     def test_search_district(self):
         results = self._results(api.url_for(ElectionList, state='NJ', district='09'))
         self.assertEqual(len(results), 3)
-        self.assertDictsSubset(results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': None})
-        self.assertDictsSubset(results[1], {'cycle': 2012, 'office': 'S', 'state': 'NJ', 'district': None})
+        self.assertDictsSubset(results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'})
+        self.assertDictsSubset(results[1], {'cycle': 2012, 'office': 'S', 'state': 'NJ', 'district': '00'})
         self.assertDictsSubset(results[2], {'cycle': 2012, 'office': 'H', 'state': 'NJ', 'district': '09'})
 
     def test_search_district_padding(self):
@@ -48,8 +48,8 @@ class TestElectionSearch(ApiBaseTest):
     def test_search_zip(self):
         results = self._results(api.url_for(ElectionList, zip='22902'))
         self.assertEqual(len(results), 3)
-        self.assertDictsSubset(results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': None})
-        self.assertDictsSubset(results[1], {'cycle': 2012, 'office': 'S', 'state': 'VA', 'district': None})
+        self.assertDictsSubset(results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'})
+        self.assertDictsSubset(results[1], {'cycle': 2012, 'office': 'S', 'state': 'VA', 'district': '00'})
         self.assertDictsSubset(results[2], {'cycle': 2012, 'office': 'H', 'state': 'VA', 'district': '05'})
 
     def test_search_incumbent(self):

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -101,12 +101,17 @@ class ElectionList(utils.Resource):
             values = [each[0].upper() for each in kwargs['office']]
             query = query.filter(CandidateHistory.office.in_(values))
         if kwargs.get('state'):
-            query = query.filter(CandidateHistory.state.in_(kwargs['state'] + ['US']))
+            query = query.filter(
+                sa.or_(
+                    CandidateHistory.state.in_(kwargs['state']),
+                    CandidateHistory.office == 'P',
+                )
+            )
         if kwargs.get('district'):
             query = query.filter(
                 sa.or_(
                     CandidateHistory.district.in_(kwargs['district']),
-                    CandidateHistory.district == None  # noqa
+                    CandidateHistory.office.in_(['P', 'S']),
                 ),
             )
         if kwargs.get('zip'):


### PR DESCRIPTION
Searching elections by zip code or congressional district is expected to
return relevant Senate and Presidental elections, as well as House
elections. This behavior was broken with the switch to
`cand_valid_fec_yr`. This patch restores the expected search behavior
for congressional districts.