### PR TITLE
Weight typeahead search by committee receipts.

### DIFF
--- a/data/sql_updates/create_candidate_history_view.sql
+++ b/data/sql_updates/create_candidate_history_view.sql
@@ -131,32 +131,3 @@ create index on ofec_candidate_detail_mv_tmp(incumbent_challenge);
 
 create index on ofec_candidate_detail_mv_tmp using gin (cycles);
 create index on ofec_candidate_detail_mv_tmp using gin (election_years);
-
-drop table if exists dimcand_fulltext;
-drop materialized view if exists ofec_candidate_fulltext_mv_tmp;
-create materialized view ofec_candidate_fulltext_mv_tmp as
-with nicknames as (
-    select
-        candidate_id,
-        string_agg(nickname, ' ') as nicknames
-    from ofec_nicknames
-    group by candidate_id
-)
-select distinct on (candidate_id)
-    row_number() over () as idx,
-    candidate_id as id,
-    name,
-    office as office_sought,
-    case
-        when name is not null then
-            setweight(to_tsvector(name), 'A') ||
-            setweight(to_tsvector(coalesce(nicknames, '')), 'A') ||
-            setweight(to_tsvector(candidate_id), 'B')
-        else null::tsvector
-    end as fulltxt
-from ofec_candidate_detail_mv_tmp
-left join nicknames using (candidate_id)
-;
-
-create unique index on ofec_candidate_fulltext_mv_tmp(idx);
-create index on ofec_candidate_fulltext_mv_tmp using gin(fulltxt);

--- a/data/sql_updates/create_committee_history.sql
+++ b/data/sql_updates/create_committee_history.sql
@@ -132,31 +132,3 @@ create index on ofec_committee_detail_mv_tmp(organization_type_full);
 
 create index on ofec_committee_detail_mv_tmp using gin (cycles);
 create index on ofec_committee_detail_mv_tmp using gin (candidate_ids);
-
-drop table if exists dimcmte_fulltext;
-drop materialized view if exists ofec_committee_fulltext_mv_tmp;
-create materialized view ofec_committee_fulltext_mv_tmp as
-with pacronyms as (
-    select
-        "ID NUMBER" as committee_id,
-        string_agg("PACRONYM", ' ') as pacronyms
-    from ofec_pacronyms
-    group by committee_id
-)
-select distinct on (committee_id)
-    row_number() over () as idx,
-    committee_id as id,
-    name,
-    case
-        when name is not null then
-            setweight(to_tsvector(name), 'A') ||
-            setweight(to_tsvector(coalesce(pac.pacronyms, '')), 'A') ||
-            setweight(to_tsvector(committee_id), 'B')
-        else null::tsvector
-    end as fulltxt
-from ofec_committee_detail_mv_tmp cd
-left join pacronyms pac using (committee_id)
-;
-
-create unique index on ofec_committee_fulltext_mv_tmp(idx);
-create index on ofec_committee_fulltext_mv_tmp using gin(fulltxt);

--- a/data/sql_updates/create_totals_house_senate_view.sql
+++ b/data/sql_updates/create_totals_house_senate_view.sql
@@ -1,4 +1,4 @@
-drop materialized view if exists ofec_totals_house_senate_mv_tmp;
+drop materialized view if exists ofec_totals_house_senate_mv_tmp cascade;
 create materialized view ofec_totals_house_senate_mv_tmp as
 with last as (
     select distinct on (cmte_sk, two_yr_period_sk) *

--- a/data/sql_updates/create_totals_ie_only_view.sql
+++ b/data/sql_updates/create_totals_ie_only_view.sql
@@ -1,4 +1,4 @@
-drop materialized view if exists ofec_totals_ie_only_mv_tmp;
+drop materialized view if exists ofec_totals_ie_only_mv_tmp cascade;
 create materialized view ofec_totals_ie_only_mv_tmp as
 select
     row_number() over () as idx,

--- a/data/sql_updates/create_totals_pacs_parties_view.sql
+++ b/data/sql_updates/create_totals_pacs_parties_view.sql
@@ -1,4 +1,4 @@
-drop materialized view if exists ofec_totals_pacs_parties_mv_tmp;
+drop materialized view if exists ofec_totals_pacs_parties_mv_tmp cascade;
 create materialized view ofec_totals_pacs_parties_mv_tmp as
 with last as (
     select distinct on (cmte_sk, two_yr_period_sk) *

--- a/data/sql_updates/create_totals_presidential_view.sql
+++ b/data/sql_updates/create_totals_presidential_view.sql
@@ -1,4 +1,4 @@
-drop materialized view if exists ofec_totals_presidential_mv_tmp;
+drop materialized view if exists ofec_totals_presidential_mv_tmp cascade;
 create materialized view ofec_totals_presidential_mv_tmp as
 with last as (
     select distinct on (cmte_sk, two_yr_period_sk) *

--- a/data/sql_updates/post_totals_create_fulltext_views.sql
+++ b/data/sql_updates/post_totals_create_fulltext_views.sql
@@ -1,0 +1,90 @@
+-- Concatenate committee totals
+drop table if exists ofec_committee_totals cascade;
+create table ofec_committee_totals as
+    select committee_id, cycle, receipts from ofec_totals_pacs_parties_mv_tmp
+    union all
+    select committee_id, cycle, receipts from ofec_totals_house_senate_mv_tmp
+    union all
+    select committee_id, cycle, receipts from ofec_totals_presidential_mv_tmp
+;
+
+-- Create candidate fulltext view
+drop materialized view if exists ofec_committee_fulltext_mv_tmp;
+create materialized view ofec_committee_fulltext_mv_tmp as
+with pacronyms as (
+    select
+        "ID NUMBER" as committee_id,
+        string_agg("PACRONYM", ' ') as pacronyms
+    from ofec_pacronyms
+    group by committee_id
+), totals as (
+    select
+        committee_id,
+        sum(receipts) as receipts
+    from ofec_committee_totals
+    group by committee_id
+)
+select distinct on (committee_id)
+    row_number() over () as idx,
+    committee_id as id,
+    name,
+    case
+        when name is not null then
+            setweight(to_tsvector(name), 'A') ||
+            setweight(to_tsvector(coalesce(pac.pacronyms, '')), 'A') ||
+            setweight(to_tsvector(committee_id), 'B')
+        else null::tsvector
+    end as fulltxt,
+    coalesce(totals.receipts, 0) as receipts
+from ofec_committee_detail_mv_tmp cd
+left join pacronyms pac using (committee_id)
+left join totals using (committee_id)
+;
+
+create unique index on ofec_committee_fulltext_mv_tmp(idx);
+
+create index on ofec_committee_fulltext_mv_tmp using gin(fulltxt);
+create index on ofec_committee_fulltext_mv_tmp (receipts);
+
+-- Create committee fulltext view
+drop materialized view if exists ofec_candidate_fulltext_mv_tmp;
+create materialized view ofec_candidate_fulltext_mv_tmp as
+with nicknames as (
+    select
+        candidate_id,
+        string_agg(nickname, ' ') as nicknames
+    from ofec_nicknames
+    group by candidate_id
+), totals as (
+    select
+        cand_id as candidate_id,
+        sum(receipts) as receipts
+    from cand_cmte_linkage link
+    join ofec_committee_totals totals on
+        link.cmte_id = totals.committee_id and
+        link.fec_election_yr = totals.cycle
+    where cmte_dsgn in ('P', 'A')
+    group by cand_id
+)
+select distinct on (candidate_id)
+    row_number() over () as idx,
+    candidate_id as id,
+    name,
+    office as office_sought,
+    case
+        when name is not null then
+            setweight(to_tsvector(name), 'A') ||
+            setweight(to_tsvector(coalesce(nicknames, '')), 'A') ||
+            setweight(to_tsvector(candidate_id), 'B')
+        else null::tsvector
+    end as fulltxt,
+    coalesce(totals.receipts, 0) as receipts
+from ofec_candidate_detail_mv_tmp
+left join nicknames using (candidate_id)
+left join totals using (candidate_id)
+;
+
+create unique index on ofec_candidate_fulltext_mv_tmp(idx);
+
+create index on ofec_candidate_fulltext_mv_tmp using gin(fulltxt);
+create index on ofec_candidate_fulltext_mv_tmp (receipts);

--- a/webservices/common/models/candidates.py
+++ b/webservices/common/models/candidates.py
@@ -10,6 +10,7 @@ class CandidateSearch(BaseModel):
     name = db.Column(db.String)
     office_sought = db.Column(db.String)
     fulltxt = db.Column(TSVECTOR)
+    receipts = db.Column(db.Numeric(30, 2))
 
 
 class BaseCandidate(BaseModel):

--- a/webservices/common/models/committees.py
+++ b/webservices/common/models/committees.py
@@ -9,6 +9,7 @@ class CommitteeSearch(BaseModel):
     id = db.Column(db.String)
     name = db.Column(db.String)
     fulltxt = db.Column(TSVECTOR)
+    receipts = db.Column(db.Numeric(30, 2))
 
 
 class BaseCommittee(BaseModel):

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -91,5 +91,5 @@ class ItemizedResource(ApiResource):
     def filter_fulltext(self, query, kwargs):
         for key, column in self.filter_fulltext_fields:
             if kwargs.get(key):
-                query = utils.search_text(query, column, kwargs[key], order=False)
+                query = utils.search_text(query, column, kwargs[key])
         return query

--- a/webservices/resources/search.py
+++ b/webservices/resources/search.py
@@ -1,12 +1,13 @@
 import sqlalchemy as sa
 
-from flask_apispec import doc, use_kwargs, marshal_with
+from flask_apispec import doc, marshal_with
 
 from webservices import args
 from webservices import docs
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
+from webservices.utils import use_kwargs
 
 
 def search_typeahead_text(model, text, order_by):

--- a/webservices/resources/search.py
+++ b/webservices/resources/search.py
@@ -1,0 +1,47 @@
+import sqlalchemy as sa
+
+from flask_apispec import doc, use_kwargs, marshal_with
+
+from webservices import args
+from webservices import docs
+from webservices import utils
+from webservices import schemas
+from webservices.common import models
+
+
+def search_typeahead_text(model, text, order_by):
+    query = utils.search_text(model.query, model.fulltxt, text)
+    query = query.order_by(order_by)
+    query = query.limit(20)
+    return {'results': query.all()}
+
+@doc(
+    tags=['search'],
+    description=docs.NAME_SEARCH,
+)
+class CandidateNameSearch(utils.Resource):
+
+    @use_kwargs(args.names)
+    @marshal_with(schemas.CandidateSearchListSchema())
+    def get(self, **kwargs):
+        return search_typeahead_text(
+            models.CandidateSearch,
+            kwargs['q'],
+            sa.desc(models.CandidateSearch.receipts),
+        )
+
+
+@doc(
+    tags=['search'],
+    description=docs.NAME_SEARCH,
+)
+class CommitteeNameSearch(utils.Resource):
+
+    @use_kwargs(args.names)
+    @marshal_with(schemas.CommitteeSearchListSchema())
+    def get(self, **kwargs):
+        return search_typeahead_text(
+            models.CommitteeSearch,
+            kwargs['q'],
+            sa.desc(models.CommitteeSearch.receipts),
+        )

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -17,6 +17,7 @@ from flask import Blueprint
 from flask.ext import cors
 from flask.ext import restful
 from raven.contrib.flask import Sentry
+import sqlalchemy as sa
 
 from webargs.flaskparser import FlaskParser
 from flask_apispec import doc, marshal_with, FlaskApiSpec
@@ -120,6 +121,7 @@ def add_caching_headers(response):
 
 def search_typeahead_text(model, text):
     query = utils.search_text(model.query, model.fulltxt, text)
+    query = query.order_by(sa.desc(model.receipts))
     query = query.limit(20)
     return {'results': query.all()}
 

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -79,7 +79,7 @@ def extend(*dicts):
     return ret
 
 
-def search_text(query, column, text, order=True):
+def search_text(query, column, text):
     """
 
     :param order: Order results by text similarity, descending; prohibitively
@@ -89,17 +89,7 @@ def search_text(query, column, text, order=True):
         part + ':*'
         for part in re.sub(r'\W', ' ', text).split()
     ])
-    query = query.filter(column.match(vector))
-    if order:
-        query = query.order_by(
-            sa.desc(
-                sa.func.ts_rank_cd(
-                    column,
-                    sa.func.to_tsquery(vector)
-                )
-            )
-        )
-    return query
+    return query.filter(column.match(vector))
 
 
 office_args_required = ['office', 'cycle']


### PR DESCRIPTION
Weight committee and candidate typeahead results by total receipts.

* Include total committee receipts in committee typeahead view
* Include total receipts summed over authorized and principals in candidate typeahead view
* Order typeahead results by descending receipts

Note: this patch uses total receipts as a very simple heuristic for search relevance. We can implement more elaborate rules if needed, such as including disbursements or weighting results by time, but I propose that we try this out first.

Pinging @LindsayYoung for review as time permits. @noahmanger: let me know if you want to take this for a test drive or demo to FEC, and we can deploy to dev.