### PR TITLE
Ensure itemized queues are unique on corresponding primary key.

### DIFF
--- a/data/sql_incremental_aggregates/update_schedule_a.sql
+++ b/data/sql_incremental_aggregates/update_schedule_a.sql
@@ -1,8 +1,11 @@
 create or replace function ofec_sched_a_update() returns void as $$
 begin
+    -- Drop all queued deletes
     delete from ofec_sched_a
     where sched_a_sk = any(select sched_a_sk from ofec_sched_a_queue_old)
     ;
+    -- Insert all queued updates, unless a row with the same key exists in the
+    -- delete queue with a later timestamp
     insert into ofec_sched_a(
         select distinct on (sched_a_sk)
             new.*,

--- a/data/sql_incremental_aggregates/update_schedule_a_fulltext.sql
+++ b/data/sql_incremental_aggregates/update_schedule_a_fulltext.sql
@@ -4,15 +4,18 @@ begin
     where sched_a_sk = any(select sched_a_sk from ofec_sched_a_queue_old)
     ;
     insert into ofec_sched_a(
-        select
-            *,
-            to_tsvector(contbr_nm) as contributor_name_text,
-            to_tsvector(contbr_employer) as contributor_employer_text,
-            to_tsvector(contbr_occupation) as contributor_occupation_text,
-            is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
+        select distinct on (sched_a_sk)
+            new.*,
+            to_tsvector(new.contbr_nm) as contributor_name_text,
+            to_tsvector(new.contbr_employer) as contributor_employer_text,
+            to_tsvector(new.contbr_occupation) as contributor_occupation_text,
+            is_individual(new.contb_receipt_amt, new.receipt_tp, new.line_num, new.memo_cd, new.memo_text)
                 as is_individual,
-            clean_repeated(contbr_id, cmte_id) as clean_contbr_id
-        from ofec_sched_a_queue_new
+            clean_repeated(new.contbr_id, new.cmte_id) as clean_contbr_id
+        from ofec_sched_a_queue_new new
+        left join ofec_sched_a_queue_old old on new.sched_a_sk = old.sched_a_sk and old.timestamp > new.timestamp
+        where old.sched_a_sk is null
+        order by new.sched_a_sk, new.timestamp desc
     );
 end
 $$ language plpgsql;

--- a/data/sql_incremental_aggregates/update_schedule_b.sql
+++ b/data/sql_incremental_aggregates/update_schedule_b.sql
@@ -1,8 +1,11 @@
 create or replace function ofec_sched_b_update() returns void as $$
 begin
+    -- Drop all queued deletes
     delete from ofec_sched_b
     where sched_b_sk = any(select sched_b_sk from ofec_sched_b_queue_old)
     ;
+    -- Insert all queued updates, unless a row with the same key exists in the
+    -- delete queue with a later timestamp
     insert into ofec_sched_b(
         select distinct on(sched_b_sk)
             new.*,

--- a/data/sql_incremental_aggregates/update_schedule_b_fulltext.sql
+++ b/data/sql_incremental_aggregates/update_schedule_b_fulltext.sql
@@ -4,13 +4,16 @@ begin
     where sched_b_sk = any(select sched_b_sk from ofec_sched_b_queue_old)
     ;
     insert into ofec_sched_b(
-        select
-            *,
-            to_tsvector(recipient_nm) as recipient_name_text,
-            to_tsvector(disb_desc) as disbursement_description_text,
-            disbursement_purpose(disb_tp, disb_desc) as disbursement_purpose_category,
-            clean_repeated(recipient_cmte_id, cmte_id) as clean_recipient_cmte_id
-        from ofec_sched_b_queue_new
+        select distinct on(sched_b_sk)
+            new.*,
+            to_tsvector(new.recipient_nm) as recipient_name_text,
+            to_tsvector(new.disb_desc) as disbursement_description_text,
+            disbursement_purpose(new.disb_tp, new.disb_desc) as disbursement_purpose_category,
+            clean_repeated(new.recipient_cmte_id, new.cmte_id) as clean_recipient_cmte_id
+        from ofec_sched_b_queue_new new
+        left join ofec_sched_b_queue_old old on new.sched_b_sk = old.sched_b_sk and old.timestamp > new.timestamp
+        where old.sched_b_sk is null
+        order by new.sched_b_sk, new.timestamp desc
     );
 end
 $$ language plpgsql;

--- a/data/sql_incremental_aggregates/update_schedule_e.sql
+++ b/data/sql_incremental_aggregates/update_schedule_e.sql
@@ -1,8 +1,11 @@
 create or replace function ofec_sched_e_update() returns void as $$
 begin
+    -- Drop all queued deletes
     delete from ofec_sched_e
     where sched_e_sk = any(select sched_e_sk from ofec_sched_e_queue_old)
     ;
+    -- Insert all queued updates, unless a row with the same key exists in the
+    -- delete queue with a later timestamp
     insert into ofec_sched_e (
         select
             new.*,

--- a/data/sql_incremental_aggregates/update_schedule_e_fulltext.sql
+++ b/data/sql_incremental_aggregates/update_schedule_e_fulltext.sql
@@ -5,9 +5,12 @@ begin
     ;
     insert into ofec_sched_e (
         select
-            *,
-            to_tsvector(pye_nm) as payee_name_text
-        from ofec_sched_e_queue_new
+            new.*,
+            to_tsvector(new.pye_nm) as payee_name_text
+        from ofec_sched_e_queue_new new
+        left join ofec_sched_e_queue_old old on new.sched_e_sk = old.sched_e_sk and old.timestamp > new.timestamp
+        where old.sched_e_sk is null
+        order by new.sched_e_sk, new.timestamp desc
     );
 end
 $$ language plpgsql;

--- a/data/sql_setup/prepare_schedule_a.sql
+++ b/data/sql_setup/prepare_schedule_a.sql
@@ -3,6 +3,7 @@ drop table if exists ofec_sched_a;
 create table ofec_sched_a as
 select
     *,
+    cast(null as timestamp) as timestamp,
     to_tsvector(contbr_nm) as contributor_name_text,
     to_tsvector(contbr_employer) as contributor_employer_text,
     to_tsvector(contbr_occupation) as contributor_occupation_text,
@@ -52,32 +53,33 @@ drop table if exists ofec_sched_a_queue_new;
 drop table if exists ofec_sched_a_queue_old;
 create table ofec_sched_a_queue_new as select * from sched_a limit 0;
 create table ofec_sched_a_queue_old as select * from sched_a limit 0;
-alter table ofec_sched_a_queue_new add primary key (sched_a_sk);
-alter table ofec_sched_a_queue_old add primary key (sched_a_sk);
+alter table ofec_sched_a_queue_new add column timestamp timestamp;
+alter table ofec_sched_a_queue_old add column timestamp timestamp;
+create index on ofec_sched_a_queue_new (sched_a_sk);
+create index on ofec_sched_a_queue_old (sched_a_sk);
+create index on ofec_sched_a_queue_new (timestamp);
+create index on ofec_sched_a_queue_old (timestamp);
 
 -- Create trigger to maintain Schedule A queues
 create or replace function ofec_sched_a_update_queues() returns trigger as $$
 declare
     start_year int = TG_ARGV[0]::int;
+    timestamp timestamp = current_timestamp;
 begin
     if tg_op = 'INSERT' then
         if new.rpt_yr >= start_year then
-            delete from ofec_sched_a_queue_new where sched_a_sk = new.sched_a_sk;
-            insert into ofec_sched_a_queue_new values (new.*);
+            insert into ofec_sched_a_queue_new values (new.*, timestamp);
         end if;
         return new;
     elsif tg_op = 'UPDATE' then
         if new.rpt_yr >= start_year then
-            delete from ofec_sched_a_queue_new where sched_a_sk = new.sched_a_sk;
-            delete from ofec_sched_a_queue_old where sched_a_sk = old.sched_a_sk;
-            insert into ofec_sched_a_queue_new values (new.*);
-            insert into ofec_sched_a_queue_old values (old.*);
+            insert into ofec_sched_a_queue_new values (new.*, timestamp);
+            insert into ofec_sched_a_queue_old values (old.*, timestamp);
         end if;
         return new;
     elsif tg_op = 'DELETE' then
         if old.rpt_yr >= start_year then
-            delete from ofec_sched_a_queue_old where sched_a_sk = old.sched_a_sk;
-            insert into ofec_sched_a_queue_old values (old.*);
+            insert into ofec_sched_a_queue_old values (old.*, timestamp);
         end if;
         return old;
     end if;

--- a/data/sql_setup/prepare_schedule_a.sql
+++ b/data/sql_setup/prepare_schedule_a.sql
@@ -52,6 +52,8 @@ drop table if exists ofec_sched_a_queue_new;
 drop table if exists ofec_sched_a_queue_old;
 create table ofec_sched_a_queue_new as select * from sched_a limit 0;
 create table ofec_sched_a_queue_old as select * from sched_a limit 0;
+alter table ofec_sched_a_queue_new add primary key (sched_a_sk);
+alter table ofec_sched_a_queue_old add primary key (sched_a_sk);
 
 -- Create trigger to maintain Schedule A queues
 create or replace function ofec_sched_a_update_queues() returns trigger as $$
@@ -60,26 +62,22 @@ declare
 begin
     if tg_op = 'INSERT' then
         if new.rpt_yr >= start_year then
-            insert into ofec_sched_a_queue_new
-            values (new.*)
-            ;
+            delete from ofec_sched_a_queue_new where sched_a_sk = new.sched_a_sk;
+            insert into ofec_sched_a_queue_new values (new.*);
         end if;
         return new;
     elsif tg_op = 'UPDATE' then
         if new.rpt_yr >= start_year then
-            insert into ofec_sched_a_queue_new
-            values (new.*)
-            ;
-            insert into ofec_sched_a_queue_old
-            values (old.*)
-            ;
+            delete from ofec_sched_a_queue_new where sched_a_sk = new.sched_a_sk;
+            delete from ofec_sched_a_queue_old where sched_a_sk = old.sched_a_sk;
+            insert into ofec_sched_a_queue_new values (new.*);
+            insert into ofec_sched_a_queue_old values (old.*);
         end if;
         return new;
     elsif tg_op = 'DELETE' then
         if old.rpt_yr >= start_year then
-            insert into ofec_sched_a_queue_old
-            values (old.*)
-            ;
+            delete from ofec_sched_a_queue_old where sched_a_sk = old.sched_a_sk;
+            insert into ofec_sched_a_queue_old values (old.*);
         end if;
         return old;
     end if;

--- a/data/sql_setup/prepare_schedule_b.sql
+++ b/data/sql_setup/prepare_schedule_b.sql
@@ -3,6 +3,7 @@ drop table if exists ofec_sched_b;
 create table ofec_sched_b as
 select
     *,
+    cast(null as timestamp) as timestamp,
     to_tsvector(recipient_nm) as recipient_name_text,
     to_tsvector(disb_desc) as disbursement_description_text,
     disbursement_purpose(disb_tp, disb_desc) as disbursement_purpose_category,
@@ -48,8 +49,12 @@ drop table if exists ofec_sched_b_queue_new;
 drop table if exists ofec_sched_b_queue_old;
 create table ofec_sched_b_queue_new as select * from sched_b limit 0;
 create table ofec_sched_b_queue_old as select * from sched_b limit 0;
-alter table ofec_sched_b_queue_new add primary key (sched_b_sk);
-alter table ofec_sched_b_queue_old add primary key (sched_b_sk);
+alter table ofec_sched_b_queue_new add column timestamp timestamp;
+alter table ofec_sched_b_queue_old add column timestamp timestamp;
+create index on ofec_sched_b_queue_new (sched_b_sk);
+create index on ofec_sched_b_queue_old (sched_b_sk);
+create index on ofec_sched_b_queue_new (timestamp);
+create index on ofec_sched_b_queue_old (timestamp);
 
 -- Create trigger to maintain Schedule B queues
 create or replace function ofec_sched_b_update_queues() returns trigger as $$

--- a/data/sql_setup/prepare_schedule_b.sql
+++ b/data/sql_setup/prepare_schedule_b.sql
@@ -48,6 +48,8 @@ drop table if exists ofec_sched_b_queue_new;
 drop table if exists ofec_sched_b_queue_old;
 create table ofec_sched_b_queue_new as select * from sched_b limit 0;
 create table ofec_sched_b_queue_old as select * from sched_b limit 0;
+alter table ofec_sched_b_queue_new add primary key (sched_b_sk);
+alter table ofec_sched_b_queue_old add primary key (sched_b_sk);
 
 -- Create trigger to maintain Schedule B queues
 create or replace function ofec_sched_b_update_queues() returns trigger as $$
@@ -56,26 +58,22 @@ declare
 begin
     if tg_op = 'INSERT' then
         if new.rpt_yr >= start_year then
-            insert into ofec_sched_b_queue_new
-            values (new.*)
-            ;
+            delete from ofec_sched_b_queue_new where sched_b_sk = new.sched_b_sk;
+            insert into ofec_sched_b_queue_new values (new.*);
         end if;
         return new;
     elsif tg_op = 'UPDATE' then
         if new.rpt_yr >= start_year then
-            insert into ofec_sched_b_queue_new
-            values (new.*)
-            ;
-            insert into ofec_sched_b_queue_old
-            values (old.*)
-            ;
+            delete from ofec_sched_b_queue_new where sched_b_sk = new.sched_b_sk;
+            delete from ofec_sched_b_queue_old where sched_b_sk = old.sched_b_sk;
+            insert into ofec_sched_b_queue_new values (new.*);
+            insert into ofec_sched_b_queue_old values (old.*);
         end if;
         return new;
     elsif tg_op = 'DELETE' then
         if old.rpt_yr >= start_year then
-            insert into ofec_sched_b_queue_old
-            values (old.*)
-            ;
+            delete from ofec_sched_b_queue_old where sched_b_sk = old.sched_b_sk;
+            insert into ofec_sched_b_queue_old values (old.*);
         end if;
         return old;
     end if;

--- a/data/sql_setup/prepare_schedule_e.sql
+++ b/data/sql_setup/prepare_schedule_e.sql
@@ -3,6 +3,7 @@ drop table if exists ofec_sched_e;
 create table ofec_sched_e as
 select
     *,
+    cast(null as timestamp) as timestamp,
     to_tsvector(pye_nm) as payee_name_text
 from sched_e
 ;
@@ -27,8 +28,12 @@ drop table if exists ofec_sched_e_queue_new;
 drop table if exists ofec_sched_e_queue_old;
 create table ofec_sched_e_queue_new as select * from sched_e limit 0;
 create table ofec_sched_e_queue_old as select * from sched_e limit 0;
-alter table ofec_sched_e_queue_new add primary key (sched_e_sk);
-alter table ofec_sched_e_queue_old add primary key (sched_e_sk);
+alter table ofec_sched_e_queue_new add column timestamp timestamp;
+alter table ofec_sched_e_queue_old add column timestamp timestamp;
+create index on ofec_sched_e_queue_new (sched_e_sk);
+create index on ofec_sched_e_queue_old (sched_e_sk);
+create index on ofec_sched_e_queue_new (timestamp);
+create index on ofec_sched_e_queue_old (timestamp);
 
 -- Create trigger to maintain Schedule E queues
 create or replace function ofec_sched_e_update_queues() returns trigger as $$

--- a/data/sql_setup/prepare_schedule_e.sql
+++ b/data/sql_setup/prepare_schedule_e.sql
@@ -27,6 +27,8 @@ drop table if exists ofec_sched_e_queue_new;
 drop table if exists ofec_sched_e_queue_old;
 create table ofec_sched_e_queue_new as select * from sched_e limit 0;
 create table ofec_sched_e_queue_old as select * from sched_e limit 0;
+alter table ofec_sched_e_queue_new add primary key (sched_e_sk);
+alter table ofec_sched_e_queue_old add primary key (sched_e_sk);
 
 -- Create trigger to maintain Schedule E queues
 create or replace function ofec_sched_e_update_queues() returns trigger as $$
@@ -34,22 +36,18 @@ declare
     start_year int = TG_ARGV[0]::int;
 begin
     if tg_op = 'INSERT' then
-        insert into ofec_sched_e_queue_new
-        values (new.*)
-        ;
+        delete from ofec_sched_e_queue_new where sched_e_sk = new.sched_e_sk;
+        insert into ofec_sched_e_queue_new values (new.*);
         return new;
     elsif tg_op = 'UPDATE' then
-        insert into ofec_sched_e_queue_new
-        values (new.*)
-        ;
-        insert into ofec_sched_e_queue_old
-        values (old.*)
-        ;
+        delete from ofec_sched_e_queue_new where sched_e_sk = new.sched_e_sk;
+        delete from ofec_sched_e_queue_old where sched_e_sk = old.sched_e_sk;
+        insert into ofec_sched_e_queue_new values (new.*);
+        insert into ofec_sched_e_queue_old values (old.*);
         return new;
     elsif tg_op = 'DELETE' then
-        insert into ofec_sched_e_queue_old
-        values (old.*)
-        ;
+        delete from ofec_sched_e_queue_old where sched_e_sk = old.sched_e_sk;
+        insert into ofec_sched_e_queue_old values (old.*);
         return old;
     end if;
 end


### PR DESCRIPTION
Nightly updates on itemized tables fail when the same item has been
added or modified more than once within a single update cycle. To fix,
this patch adds primary key constraints on the queue tables and deletes
any existing records in the queues by primary key on insert.

Note: We'll be able to express this more concisely as an upsert once
postgres 9.5 is available on RDS.

[Resolves #1392]

@arowla: Have time to take a look? This is a very small patch--I just want to verify that the approach makes sense here, and that there isn't a smarter way to solve this problem.