### PR TITLE
Create temporary itemized tables to avoid downtime.

### DIFF
--- a/data/sql_setup/prepare_schedule_a.sql
+++ b/data/sql_setup/prepare_schedule_a.sql
@@ -1,6 +1,6 @@
 -- Create Schedule A table
-drop table if exists ofec_sched_a;
-create table ofec_sched_a as
+drop table if exists ofec_sched_a_tmp;
+create table ofec_sched_a_tmp as
 select
     *,
     to_tsvector(contbr_nm) as contributor_name_text,
@@ -13,39 +13,39 @@ from sched_a
 where rpt_yr >= :START_YEAR_ITEMIZED
 ;
 
-alter table ofec_sched_a add primary key (sched_a_sk);
+alter table ofec_sched_a_tmp add primary key (sched_a_sk);
 
 -- Create simple indices on filtered columns
-create index on ofec_sched_a (rpt_yr);
-create index on ofec_sched_a (entity_tp);
-create index on ofec_sched_a (image_num);
-create index on ofec_sched_a (sched_a_sk);
-create index on ofec_sched_a (contbr_st);
-create index on ofec_sched_a (contbr_city);
-create index on ofec_sched_a (is_individual);
-create index on ofec_sched_a (clean_contbr_id);
+create index on ofec_sched_a_tmp (rpt_yr);
+create index on ofec_sched_a_tmp (entity_tp);
+create index on ofec_sched_a_tmp (image_num);
+create index on ofec_sched_a_tmp (sched_a_sk);
+create index on ofec_sched_a_tmp (contbr_st);
+create index on ofec_sched_a_tmp (contbr_city);
+create index on ofec_sched_a_tmp (is_individual);
+create index on ofec_sched_a_tmp (clean_contbr_id);
 
 -- Create composite indices on sortable columns
-create index on ofec_sched_a (contb_receipt_dt, sched_a_sk);
-create index on ofec_sched_a (contb_receipt_amt, sched_a_sk);
-create index on ofec_sched_a (contb_aggregate_ytd, sched_a_sk);
+create index on ofec_sched_a_tmp (contb_receipt_dt, sched_a_sk);
+create index on ofec_sched_a_tmp (contb_receipt_amt, sched_a_sk);
+create index on ofec_sched_a_tmp (contb_aggregate_ytd, sched_a_sk);
 
 -- Create composite indices on `cmte_id`; else filtering by committee can be very slow
-create index on ofec_sched_a (cmte_id, sched_a_sk);
-create index on ofec_sched_a (cmte_id, contb_receipt_dt, sched_a_sk);
-create index on ofec_sched_a (cmte_id, contb_receipt_amt, sched_a_sk);
-create index on ofec_sched_a (cmte_id, contb_aggregate_ytd, sched_a_sk);
+create index on ofec_sched_a_tmp (cmte_id, sched_a_sk);
+create index on ofec_sched_a_tmp (cmte_id, contb_receipt_dt, sched_a_sk);
+create index on ofec_sched_a_tmp (cmte_id, contb_receipt_amt, sched_a_sk);
+create index on ofec_sched_a_tmp (cmte_id, contb_aggregate_ytd, sched_a_sk);
 
 -- Create indices on filtered fulltext columns
-create index on ofec_sched_a using gin (contributor_name_text);
-create index on ofec_sched_a using gin (contributor_employer_text);
-create index on ofec_sched_a using gin (contributor_occupation_text);
+create index on ofec_sched_a_tmp using gin (contributor_name_text);
+create index on ofec_sched_a_tmp using gin (contributor_employer_text);
+create index on ofec_sched_a_tmp using gin (contributor_occupation_text);
 
 -- Use smaller histogram bins on state column for faster queries on rare states (AS, PR)
-alter table ofec_sched_a alter column contbr_st set statistics 1000;
+alter table ofec_sched_a_tmp alter column contbr_st set statistics 1000;
 
 -- Analyze tables
-analyze ofec_sched_a;
+analyze ofec_sched_a_tmp;
 
 -- Create queue tables to hold changes to Schedule A
 drop table if exists ofec_sched_a_queue_new;
@@ -90,3 +90,6 @@ drop trigger if exists ofec_sched_a_queue_trigger on sched_a;
 create trigger ofec_sched_a_queue_trigger before insert or update or delete
     on sched_a for each row execute procedure ofec_sched_a_update_queues(:START_YEAR_AGGREGATE)
 ;
+
+drop table if exists ofec_sched_a;
+alter table ofec_sched_a_tmp rename to ofec_sched_a;

--- a/data/sql_setup/prepare_schedule_b.sql
+++ b/data/sql_setup/prepare_schedule_b.sql
@@ -1,6 +1,6 @@
 -- Create Schedule B table
-drop table if exists ofec_sched_b;
-create table ofec_sched_b as
+drop table if exists ofec_sched_b_tmp;
+create table ofec_sched_b_tmp as
 select
     *,
     to_tsvector(recipient_nm) as recipient_name_text,
@@ -11,37 +11,37 @@ from sched_b
 where rpt_yr >= :START_YEAR_ITEMIZED
 ;
 
-alter table ofec_sched_b add primary key (sched_b_sk);
+alter table ofec_sched_b_tmp add primary key (sched_b_sk);
 
 -- Create simple indices on filtered columns
-create index on ofec_sched_b (rpt_yr);
-create index on ofec_sched_b (image_num);
-create index on ofec_sched_b (sched_b_sk);
-create index on ofec_sched_b (recipient_st);
-create index on ofec_sched_b (recipient_city);
-create index on ofec_sched_b (clean_recipient_cmte_id);
+create index on ofec_sched_b_tmp (rpt_yr);
+create index on ofec_sched_b_tmp (image_num);
+create index on ofec_sched_b_tmp (sched_b_sk);
+create index on ofec_sched_b_tmp (recipient_st);
+create index on ofec_sched_b_tmp (recipient_city);
+create index on ofec_sched_b_tmp (clean_recipient_cmte_id);
 
 -- Create composite indices on sortable columns
-create index on ofec_sched_b(disb_dt, sched_b_sk);
-create index on ofec_sched_b(disb_amt, sched_b_sk);
+create index on ofec_sched_b_tmp (disb_dt, sched_b_sk);
+create index on ofec_sched_b_tmp (disb_amt, sched_b_sk);
 
 -- Create composite indices on `cmte_id`; else filtering by committee can be very slow
-create index on ofec_sched_b (cmte_id, sched_b_sk);
-create index on ofec_sched_b (cmte_id, disb_dt, sched_b_sk);
-create index on ofec_sched_b (cmte_id, disb_amt, sched_b_sk);
+create index on ofec_sched_b_tmp (cmte_id, sched_b_sk);
+create index on ofec_sched_b_tmp (cmte_id, disb_dt, sched_b_sk);
+create index on ofec_sched_b_tmp (cmte_id, disb_amt, sched_b_sk);
 
 -- Create indices on fulltext columns
-create index on ofec_sched_b using gin (recipient_name_text);
-create index on ofec_sched_b using gin (disbursement_description_text);
+create index on ofec_sched_b_tmp using gin (recipient_name_text);
+create index on ofec_sched_b_tmp using gin (disbursement_description_text);
 
 -- Create index for join on electioneering costs
 create index on sched_b (link_id);
 
 -- Use smaller histogram bins on state column for faster queries on rare states (AS, PR)
-alter table ofec_sched_b alter column recipient_st set statistics 1000;
+alter table ofec_sched_b_tmp alter column recipient_st set statistics 1000;
 
 -- Analyze tables
-analyze ofec_sched_b;
+analyze ofec_sched_b_tmp;
 
 -- Create queue tables to hold changes to Schedule B
 drop table if exists ofec_sched_b_queue_new;
@@ -86,3 +86,6 @@ drop trigger if exists ofec_sched_b_queue_trigger on sched_b;
 create trigger ofec_sched_b_queue_trigger before insert or update or delete
     on sched_b for each row execute procedure ofec_sched_b_update_queues(:START_YEAR_AGGREGATE)
 ;
+
+drop table if exists ofec_sched_b;
+alter table ofec_sched_b_tmp rename to ofec_sched_b;

--- a/data/sql_setup/prepare_schedule_e.sql
+++ b/data/sql_setup/prepare_schedule_e.sql
@@ -1,26 +1,31 @@
 -- Create Schedule E table
-drop table if exists ofec_sched_e;
-create table ofec_sched_e as
+drop table if exists ofec_sched_e_tmp;
+create table ofec_sched_e_tmp as
 select
     *,
     to_tsvector(pye_nm) as payee_name_text
 from sched_e
 ;
 
+alter table ofec_sched_e_tmp add primary key (sched_e_sk);
+
 -- Create simple indices on filtered columns
-create index on ofec_sched_e (cmte_id);
-create index on ofec_sched_e (s_o_cand_id);
-create index on ofec_sched_e (entity_tp);
-create index on ofec_sched_e (image_num);
-create index on ofec_sched_e (rpt_yr);
+create index on ofec_sched_e_tmp (cmte_id);
+create index on ofec_sched_e_tmp (s_o_cand_id);
+create index on ofec_sched_e_tmp (entity_tp);
+create index on ofec_sched_e_tmp (image_num);
+create index on ofec_sched_e_tmp (rpt_yr);
 
 -- Create composite indices on sortable columns
-create index on ofec_sched_e (exp_dt, sched_e_sk);
-create index on ofec_sched_e (exp_amt, sched_e_sk);
-create index on ofec_sched_e (cal_ytd_ofc_sought, sched_e_sk);
+create index on ofec_sched_e_tmp (exp_dt, sched_e_sk);
+create index on ofec_sched_e_tmp (exp_amt, sched_e_sk);
+create index on ofec_sched_e_tmp (cal_ytd_ofc_sought, sched_e_sk);
 
 -- Create indices on filtered fulltext columns
-create index on ofec_sched_e using gin (payee_name_text);
+create index on ofec_sched_e_tmp using gin (payee_name_text);
+
+-- Analyze tables
+analyze ofec_sched_e_tmp;
 
 -- Create queue tables to hold changes to Schedule E
 drop table if exists ofec_sched_e_queue_new;
@@ -59,3 +64,6 @@ drop trigger if exists ofec_sched_e_queue_trigger on sched_e;
 create trigger ofec_sched_e_queue_trigger before insert or update or delete
     on sched_e for each row execute procedure ofec_sched_e_update_queues(:START_YEAR_AGGREGATE)
 ;
+
+drop table if exists ofec_sched_e;
+alter table ofec_sched_e_tmp rename to ofec_sched_e;


### PR DESCRIPTION
Create temporary itemized tables, then drop existing tables and rename
when ready. Avoids downtime on itemized resources during schema updates.