### PR TITLE
Allow sorting candidates and committees by receipts.

### DIFF
--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -5,6 +5,7 @@ from webservices import args
 from webservices import docs
 from webservices import utils
 from webservices import schemas
+from webservices import exceptions
 from webservices.common import models
 from webservices.utils import use_kwargs
 from webservices.common.util import filter_query
@@ -35,21 +36,29 @@ def filter_year(model, query, years):
 )
 class CommitteeList(utils.Resource):
 
+    aliases = {'receipts': models.CommitteeSearch.receipts}
+
     @use_kwargs(args.paging)
     @use_kwargs(args.committee)
     @use_kwargs(args.committee_list)
     @use_kwargs(
         args.make_sort_args(
             default=['name'],
-            validator=args.IndexValidator(models.Committee),
+            validator=args.IndexValidator(models.Committee, extra=list(aliases.keys())),
         )
     )
     @marshal_with(schemas.CommitteePageSchema())
     def get(self, **kwargs):
         query = self.get_committees(kwargs)
-        return utils.fetch_page(query, kwargs, model=models.Committee)
+        return utils.fetch_page(query, kwargs, model=models.Committee, aliases=self.aliases)
 
     def get_committees(self, kwargs):
+
+        if {'receipts', '-receipts'}.intersection(kwargs.get('sort', [])) and 'q' not in kwargs:
+            raise exceptions.ApiError(
+                'Cannot sort on receipts when parameter "q" is not set',
+                status_code=422,
+            )
 
         committees = models.Committee.query
 

--- a/webservices/sorting.py
+++ b/webservices/sorting.py
@@ -4,7 +4,7 @@ from sqlalchemy.sql.expression import nullsfirst, nullslast
 from webservices.exceptions import ApiError
 
 
-def parse_option(option, model=None, join_columns=None, nulls_large=True):
+def parse_option(option, model=None, aliases=None, join_columns=None, nulls_large=True):
     """Parse sort option to SQLAlchemy order expression.
 
     :param str option: Column name, possibly prefixed with "-"
@@ -14,12 +14,15 @@ def parse_option(option, model=None, join_columns=None, nulls_large=True):
     :param nulls_large: Treat null values as large
     :raises: ApiError if column not found on model
     """
+    aliases = aliases or {}
     join_columns = join_columns or {}
     order = sa.desc if option.startswith('-') else sa.asc
     nulls = nullsfirst if (nulls_large ^ (not option.startswith('-'))) else nullslast
     column = option.lstrip('-')
     relationship = None
-    if column in join_columns:
+    if column in aliases:
+        column = aliases[column]
+    elif column in join_columns:
         column, relationship = join_columns[column]
     elif model:
         try:
@@ -37,7 +40,7 @@ def ensure_list(value):
     return []
 
 
-def sort(query, options, model, join_columns=None, clear=False, hide_null=False, nulls_large=True):
+def sort(query, options, model, aliases=None, join_columns=None, clear=False, hide_null=False, nulls_large=True):
     """Sort query using string-formatted columns.
 
     :param query: Original query
@@ -58,6 +61,7 @@ def sort(query, options, model, join_columns=None, clear=False, hide_null=False,
         column, order, nulls, relationship = parse_option(
             option,
             model=model,
+            aliases=aliases,
             join_columns=join_columns,
             nulls_large=nulls_large,
         )

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -44,10 +44,10 @@ def check_cap(kwargs, cap):
             )
 
 
-def fetch_page(query, kwargs, model=None, join_columns=None, clear=False, count=None, cap=100):
+def fetch_page(query, kwargs, model=None, aliases=None, join_columns=None, clear=False, count=None, cap=100):
     check_cap(kwargs, cap)
     sort, hide_null, nulls_large = kwargs.get('sort'), kwargs.get('sort_hide_null'), kwargs.get('sort_nulls_large')
-    query, _ = sorting.sort(query, sort, model=model, join_columns=join_columns, clear=clear, hide_null=hide_null, nulls_large=nulls_large)
+    query, _ = sorting.sort(query, sort, model=model, aliases=aliases, join_columns=join_columns, clear=clear, hide_null=hide_null, nulls_large=nulls_large)
     paginator = paginators.OffsetPaginator(query, kwargs['per_page'], count=count)
     return paginator.get_page(kwargs['page'])
 


### PR DESCRIPTION
Allow sorting candidates and committees by total receipts when the "q"
parameter is set; otherwise, full-text search tables aren't joined, and
sorting by receipts is undefined.

[Resolves #1396]