### PR TITLE
Ensure unique candidate election years.

### DIFF
--- a/data/sql_updates/create_candidate_history_view.sql
+++ b/data/sql_updates/create_candidate_history_view.sql
@@ -14,6 +14,10 @@ with
             link.linkage_type in ('P', 'A')
     ),
     -- Aggregate election data across cycles by candidate
+    years as (
+        select distinct on (cand_id, cand_election_yr) fec_yr.* from fec_yr
+        order by cand_id, cand_election_yr
+    ),
     cycles as (
         select
             cand_id,
@@ -22,7 +26,7 @@ with
             array_agg(cand_election_yr)::int[] as election_years,
             array_agg(cand_office_district)::text[] as election_districts,
             max(fec_election_yr) as max_cycle
-        from fec_yr
+        from years
         group by cand_id
     )
 select distinct on (fec_yr.cand_id, fec_yr.fec_election_yr)

--- a/data/sql_updates/create_candidate_history_view.sql
+++ b/data/sql_updates/create_candidate_history_view.sql
@@ -13,20 +13,24 @@ with
             cand.fec_election_yr = link.fec_election_yr and
             link.linkage_type in ('P', 'A')
     ),
-    -- Aggregate election data across cycles by candidate
-    years as (
-        select distinct on (cand_id, cand_election_yr) fec_yr.* from fec_yr
-        order by cand_id, cand_election_yr
+    elections as (
+        select
+            cand_id,
+            max(cand_election_yr) as active_through,
+            array_agg(cand_election_yr)::int[] as election_years,
+            array_agg(cand_office_district)::text[] as election_districts
+        from (
+            select distinct on (cand_id, cand_election_yr) fec_yr.* from fec_yr
+            order by cand_id, cand_election_yr
+        ) dedup
+        group by cand_id
     ),
     cycles as (
         select
             cand_id,
-            max(cand_election_yr) as active_through,
             array_agg(fec_election_yr)::int[] as cycles,
-            array_agg(cand_election_yr)::int[] as election_years,
-            array_agg(cand_office_district)::text[] as election_districts,
             max(fec_election_yr) as max_cycle
-        from years
+        from fec_yr
         group by cand_id
     )
 select distinct on (fec_yr.cand_id, fec_yr.fec_election_yr)
@@ -52,12 +56,12 @@ select distinct on (fec_yr.cand_id, fec_yr.fec_election_yr)
     fec_yr.cand_pty_affiliation as party,
     clean_party(dp.party_affiliation_desc) as party_full,
     cycles.cycles,
-    cycles.election_years,
-    cycles.election_districts,
-    cycles.active_through
+    elections.election_years,
+    elections.election_districts,
+    elections.active_through
 from fec_yr
 left join cycles using (cand_id)
-left join dimcand dc using (cand_id)
+left join elections using (cand_id)
 left join cand_inactive inactive using (cand_id)
 inner join dimparty dp on fec_yr.cand_pty_affiliation = dp.party_affiliation
 where max_cycle >= :START_YEAR


### PR DESCRIPTION
Fix a regression from #1386 that allowed duplicate election years in
candidate views. Thanks @noahmanger for spotting.

IMO this fix has to go in before the next release, so I'm hoping @LindsayYoung can take a look in the morning. I'm going to deploy this change to the dev database for testing now.