### PR TITLE
Ignore linkages with mismatched committee types.

### DIFF
--- a/data/sql_updates/create_cand_cmte_linkage_view.sql
+++ b/data/sql_updates/create_cand_cmte_linkage_view.sql
@@ -4,6 +4,9 @@ select
     row_number() over () as idx,
     *
 from cand_cmte_linkage
+where
+    substr(cand_id, 1, 1) = cmte_tp or
+    cmte_tp not in ('P', 'S', 'H')
 ;
 
 create unique index on ofec_cand_cmte_linkage_mv_tmp(idx);

--- a/data/sql_updates/post_totals_create_fulltext_views.sql
+++ b/data/sql_updates/post_totals_create_fulltext_views.sql
@@ -63,7 +63,11 @@ with nicknames as (
     join ofec_committee_totals totals on
         link.cmte_id = totals.committee_id and
         link.fec_election_yr = totals.cycle
-    where cmte_dsgn in ('P', 'A')
+    where
+        cmte_dsgn in ('P', 'A') and (
+            substr(cand_id, 1, 1) = cmte_tp or
+            cmte_tp not in ('P', 'S', 'H')
+        )
     group by cand_id
 )
 select distinct on (candidate_id)

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -167,7 +167,10 @@ class CommitteeHistoryView(utils.Resource):
         if candidate_id:
             query = query.join(
                 models.CandidateCommitteeLink,
-                models.CandidateCommitteeLink.committee_id == models.CommitteeHistory.committee_id,
+                sa.and_(
+                    models.CandidateCommitteeLink.committee_id == models.CommitteeHistory.committee_id,
+                    models.CandidateCommitteeLink.fec_election_year == models.CommitteeHistory.cycle,
+                )
             ).filter(
                 models.CandidateCommitteeLink.candidate_id == candidate_id
             ).distinct()


### PR DESCRIPTION
Ignore linkages with mismatched committee types.

[Resolves #1406]

To verify:
* House candidate Tammy Baldwin should not be linked to Baldwin for Senate
* Senate candidate Tammy Baldwin should appear before House candidate Tammy Baldwin in typeahead search results

cc @PaulClark2 @LindsayYoung 