### PR TITLE
Add icalendar exports.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,16 +5,17 @@ Flask-Cors==2.1.0
 Flask-Script==2.0.5
 Flask-RESTful==0.3.3
 Flask-SQLAlchemy==2.0
+python-dateutil==2.4.2
 newrelic==2.52.0.40
 SQLAlchemy==1.0.8
 mandrill==1.0.57
+icalendar==3.9.1
 GitPython==1.0.1
 gunicorn==19.3.0
 webargs==0.18.0
 slacker==0.8.6
 raven[flask]==5.8.1
 ujson==1.33
-furl==0.4.6
 
 # Marshalling
 flask-apispec==0.2.0

--- a/webservices/calendar.py
+++ b/webservices/calendar.py
@@ -1,0 +1,39 @@
+from icalendar import Calendar, Event
+from marshmallow import Schema, fields, post_dump
+
+def format_start_date(row):
+    return (
+        row.start_date.date()
+        if row.start_date and not row.end_date
+        else row.start_date
+    )
+
+class EventSchema(Schema):
+
+    dtstart = fields.Function(format_start_date)
+    dtend = fields.Raw(attribute='end_date')
+
+    summary = fields.String()
+    description = fields.String()
+
+    location = fields.String()
+    categories = fields.String(attribute='category')
+
+    @post_dump
+    def to_event(self, data):
+        event = Event()
+        for key, value in data.items():
+            if value:
+                event.add(key, value)
+        return event
+
+class CalendarSchema(Schema):
+
+    events = fields.Nested(EventSchema, many=True)
+
+    @post_dump
+    def to_calendar(self, data):
+        calendar = Calendar()
+        for event in data.get('events', []):
+            calendar.add_component(event)
+        return calendar.to_ical()

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -153,6 +153,7 @@ api.add_resource(elections.ElectionSummary, '/elections/summary/')
 api.add_resource(dates.ElectionDatesView, '/election-dates/')
 api.add_resource(dates.ReportingDatesView, '/reporting-dates/')
 api.add_resource(dates.CalendarDatesView, '/calendar-dates/')
+api.add_resource(dates.CalendarDatesExport, '/export/calendar-dates/')
 
 def add_aggregate_resource(api, view, schedule, label):
     api.add_resource(

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -153,7 +153,7 @@ api.add_resource(elections.ElectionSummary, '/elections/summary/')
 api.add_resource(dates.ElectionDatesView, '/election-dates/')
 api.add_resource(dates.ReportingDatesView, '/reporting-dates/')
 api.add_resource(dates.CalendarDatesView, '/calendar-dates/')
-api.add_resource(dates.CalendarDatesExport, '/export/calendar-dates/')
+api.add_resource(dates.CalendarDatesExport, '/calendar-dates/export/')
 
 def add_aggregate_resource(api, view, schedule, label):
     api.add_resource(


### PR DESCRIPTION
Export calendar dates in ical format for use with Google Calendar, iCalendar, etc.

Note: All exports are automatically filtered to +/- 1 year around the time of the request. Pagination isn't an option here--calendar applications generally expect to get *all* events in a single request. Because there aren't many rows in the calendar table, performance is adequate without pagination--about 0.6s to get all events, with no filters.

@LindsayYoung @noahmanger 