### PR TITLE
Redirect /docs to documentaion

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -263,6 +263,7 @@ def swagger_static(filename):
 
 @app.route('/')
 @app.route('/v1/')
+@app.route('/docs')
 @docs.route('/developer/')
 def api_ui_redirect():
     return redirect(url_for('docs.api_ui'), code=http.client.MOVED_PERMANENTLY)


### PR DESCRIPTION
There were 7,000 hits looking for `/docs` in the last month, right now that just gives a 404. This forwards them to documentation instead. 

(this was a super small thing I noticed after usability testing)