### PR TITLE
Ensure stable sort on aggregate tables.

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -177,6 +177,11 @@ class ScheduleAByStateFactory(BaseAggregateFactory):
         model = models.ScheduleAByState
 
 
+class ScheduleAByEmployerFactory(BaseAggregateFactory):
+    class Meta:
+        model = models.ScheduleAByEmployer
+
+
 class ScheduleAByContributorFactory(BaseAggregateFactory):
     class Meta:
         model = models.ScheduleAByContributor

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -6,6 +6,7 @@ from tests.common import ApiBaseTest
 from webservices import schemas
 from webservices.rest import db, api
 from webservices.resources.aggregates import (
+    ScheduleAByEmployerView,
     ScheduleEByCandidateView,
     CommunicationCostByCandidateView,
     ElectioneeringByCandidateView,
@@ -15,6 +16,24 @@ from webservices.resources.candidate_aggregates import (
     ScheduleAByStateCandidateView,
     TotalsCandidateView,
 )
+
+
+class TestCommitteeAggregates(ApiBaseTest):
+
+    def test_stable_sort(self):
+        rows = [
+            factories.ScheduleAByEmployerFactory(
+                committee_id='C001',
+                employer='omnicorp-{}'.format(idx),
+                total=538,
+            )
+            for idx in range(100)
+        ]
+        employers = []
+        for page in range(2):
+            results = self._results(api.url_for(ScheduleAByEmployerView, sort='-total', per_page=50, page=page + 1))
+            employers.extend(result['employer'] for result in results)
+        assert len(set(employers)) == len(rows)
 
 
 class TestAggregates(ApiBaseTest):

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -208,18 +208,3 @@ class CandidateFormatTest(ApiBaseTest):
         self.assertEqual([each['candidate_id'] for each in results], candidate_ids)
         results = self._results(api.url_for(CandidateSearch, sort='-candidate_status'))
         self.assertEqual([each['candidate_id'] for each in results], candidate_ids)
-
-    def test_candidate_multi_sort(self):
-        candidates = [
-            factories.CandidateFactory(candidate_status='C', party='DFL'),
-            factories.CandidateFactory(candidate_status='P', party='FLP'),
-            factories.CandidateFactory(candidate_status='P', party='REF'),
-        ]
-        candidate_ids = [each.candidate_id for each in candidates]
-        results = self._results(api.url_for(CandidateList, sort=['candidate_status', 'party']))
-        self.assertEqual([each['candidate_id'] for each in results], candidate_ids)
-        results = self._results(api.url_for(CandidateList, sort=['candidate_status', '-party']))
-        self.assertEqual(
-            [each['candidate_id'] for each in results],
-            [candidate_ids[0], candidate_ids[2], candidate_ids[1]],
-        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,16 +30,6 @@ class TestSort(ApiBaseTest):
         query, columns = sorting.sort(models.Candidate.query, '-district', model=models.Candidate)
         self.assertEqual(query.all(), candidates[::-1])
 
-    def test_multi_column(self):
-        candidates = [
-            factories.CandidateFactory(district='01', party='DEM'),
-            factories.CandidateFactory(district='01', party='REP'),
-            factories.CandidateFactory(district='02', party='DEM'),
-            factories.CandidateFactory(district='02', party='REP'),
-        ]
-        query, columns = sorting.sort(models.Candidate.query, ['district', 'party'], model=models.Candidate)
-        self.assertEqual(query.all(), candidates)
-
     def test_hide_null(self):
         candidates = [
             factories.CandidateFactory(district='01'),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -101,22 +101,13 @@ class IndexValidator(OptionValidator):
     def _is_excluded(self, value):
         return not value or value in self.exclude
 
-def make_sort_args(default=None, multiple=True, validator=None, default_hide_null=False, default_nulls_large=True):
-    description = 'Provide a field to sort by. Use - for descending order.'
-    if multiple:
-        sort_field = fields.List(
-            fields.Str(validate=validator),
-            missing=default,
-            description=description,
-        )
-    else:
-        sort_field = fields.Str(
+def make_sort_args(default=None, validator=None, default_hide_null=False, default_nulls_large=True):
+    return {
+        'sort': fields.Str(
             missing=default,
             validate=validator,
-            description=description,
-        )
-    return {
-        'sort': sort_field,
+            description='Provide a field to sort by. Use - for descending order.',
+        ),
         'sort_hide_null': fields.Bool(
             missing=default_hide_null,
             description='Hide null values on sorted column(s).'

--- a/webservices/common/models/aggregates.py
+++ b/webservices/common/models/aggregates.py
@@ -1,15 +1,15 @@
 from webservices import utils
 
-from .base import db
+from .base import db, BaseModel
 
 
-class BaseAggregate(db.Model):
+class BaseAggregate(BaseModel):
     __abstract__ = True
 
     committee_id = db.Column('cmte_id', db.String, primary_key=True)
     cycle = db.Column(db.Integer, primary_key=True)
-    total = db.Column(db.Numeric(30, 2))
-    count = db.Column(db.Integer)
+    total = db.Column(db.Numeric(30, 2), index=True)
+    count = db.Column(db.Integer, index=True)
 
 
 class ScheduleABySize(BaseAggregate):

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -17,6 +17,7 @@ class ApiResource(utils.Resource):
     schema = None
     page_schema = None
     index_column = None
+    unique_column = None
     filter_match_fields = []
     filter_multi_fields = []
     filter_range_fields = []
@@ -28,9 +29,11 @@ class ApiResource(utils.Resource):
     @marshal_with(Ref('page_schema'))
     def get(self, *args, **kwargs):
         query = self.build_query(*args, **kwargs)
+        count = counts.count_estimate(query, models.db.session, threshold=5000)
         return utils.fetch_page(
             query, kwargs,
-            model=self.model, join_columns=self.join_columns, aliases=self.aliases,
+            count=count, model=self.model, join_columns=self.join_columns, aliases=self.aliases,
+            index_column=self.index_column,
         )
 
     def build_query(self, *args, _apply_options=True, **kwargs):

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -30,6 +30,10 @@ class AggregateResource(ApiResource):
     def sort_args(self):
         return args.make_sort_args(validator=args.IndexValidator(self.model))
 
+    @property
+    def index_column(self):
+        return self.model.idx
+
     def build_query(self, committee_id=None, **kwargs):
         query = super().build_query(**kwargs)
         if committee_id is not None:
@@ -118,7 +122,7 @@ class ScheduleAByEmployerView(AggregateResource):
     def get(self, committee_id=None, **kwargs):
         query = self.build_query(committee_id=committee_id, **kwargs)
         count = counts.count_estimate(query, models.db.session, threshold=5000)
-        return utils.fetch_page(query, kwargs, model=self.model, count=count)
+        return utils.fetch_page(query, kwargs, model=self.model, count=count, index_column=self.index_column)
 
 
 @doc(
@@ -142,7 +146,7 @@ class ScheduleAByOccupationView(AggregateResource):
     def get(self, committee_id=None, **kwargs):
         query = self.build_query(committee_id=committee_id, **kwargs)
         count = counts.count_estimate(query, models.db.session, threshold=5000)
-        return utils.fetch_page(query, kwargs, model=self.model, count=count)
+        return utils.fetch_page(query, kwargs, model=self.model, count=count, index_column=self.index_column)
 
 
 @doc(

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -41,7 +41,7 @@ class CandidateList(ApiResource):
             args.candidate_list,
             args.candidate_detail,
             args.make_sort_args(
-                default=['name'],
+                default='name',
                 validator=args.IndexValidator(
                     models.Candidate,
                     extra=list(self.aliases.keys()),
@@ -110,7 +110,7 @@ class CandidateView(ApiResource):
             args.paging,
             args.candidate_detail,
             args.make_sort_args(
-                default=['name'],
+                default='name',
                 validator=args.IndexValidator(self.model),
             ),
         )
@@ -155,7 +155,7 @@ class CandidateHistoryView(ApiResource):
         return utils.extend(
             args.paging,
             args.make_sort_args(
-                default=['-two_year_period'],
+                default='-two_year_period',
                 validator=args.IndexValidator(self.model),
             ),
         )

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -55,7 +55,7 @@ class CommitteeList(ApiResource):
             args.committee,
             args.committee_list,
             args.make_sort_args(
-                default=['name'],
+                default='name',
                 validator=args.IndexValidator(
                     models.Committee,
                     extra=list(self.aliases.keys()),
@@ -132,7 +132,7 @@ class CommitteeView(ApiResource):
             args.paging,
             args.committee,
             args.make_sort_args(
-                default=['name'],
+                default='name',
                 validator=args.IndexValidator(self.model),
             ),
         )
@@ -180,7 +180,7 @@ class CommitteeHistoryView(ApiResource):
             args.paging,
             args.committee_history,
             args.make_sort_args(
-                default=['-cycle'],
+                default='-cycle',
                 validator=args.IndexValidator(self.model),
             ),
         )

--- a/webservices/resources/dates.py
+++ b/webservices/resources/dates.py
@@ -21,7 +21,7 @@ class ReportingDatesView(ApiResource):
             args.paging,
             args.reporting_dates,
             args.make_sort_args(
-                default=['-due_date'],
+                default='-due_date',
                 validator=args.IndexValidator(self.model),
             ),
         )
@@ -52,7 +52,7 @@ class ElectionDatesView(ApiResource):
             args.paging,
             args.election_dates,
             args.make_sort_args(
-                default=['-election_date'],
+                default='-election_date',
                 validator=args.IndexValidator(self.model),
             ),
         )

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -45,7 +45,7 @@ class ElectionList(utils.Resource):
 
     @use_kwargs(args.paging)
     @use_kwargs(args.election_search)
-    @use_kwargs(args.make_sort_args(default=['-_office_status']))
+    @use_kwargs(args.make_sort_args(default='-_office_status'))
     @marshal_with(schemas.ElectionSearchPageSchema())
     def get(self, **kwargs):
         query = self._get_records(kwargs)
@@ -162,7 +162,7 @@ class ElectionView(utils.Resource):
 
     @use_kwargs(args.paging)
     @use_kwargs(args.elections)
-    @use_kwargs(args.make_sort_args(default=['-total_receipts'], default_nulls_large=False))
+    @use_kwargs(args.make_sort_args(default='-total_receipts', default_nulls_large=False))
     @marshal_with(schemas.ElectionPageSchema())
     def get(self, **kwargs):
         query = self._get_records(kwargs)

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -47,7 +47,7 @@ class BaseFilings(views.ApiResource):
             args.paging,
             args.filings,
             args.make_sort_args(
-                default=['-receipt_date'],
+                default='-receipt_date',
                 validator=args.IndexValidator(models.Filings),
             ),
         )

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -53,7 +53,7 @@ class ReportsView(utils.Resource):
 
     @use_kwargs(args.paging)
     @use_kwargs(args.reports)
-    @use_kwargs(args.make_sort_args(default=['-coverage_end_date']))
+    @use_kwargs(args.make_sort_args(default='-coverage_end_date'))
     @marshal_with(schemas.CommitteeReportsPageSchema(), apply=False)
     def get(self, committee_id=None, committee_type=None, **kwargs):
         query, reports_class, reports_schema = self.build_query(
@@ -61,9 +61,9 @@ class ReportsView(utils.Resource):
             committee_type=committee_type,
             **kwargs
         )
-        validator = args.IndexValidator(reports_class)
-        for key in kwargs['sort']:
-            validator(key)
+        if kwargs['sort']:
+            validator = args.IndexValidator(reports_class)
+            validator(kwargs['sort'])
         page = utils.fetch_page(query, kwargs, model=reports_class)
         return reports_schema().dump(page).data
 

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -67,7 +67,6 @@ class ScheduleAView(ItemizedResource):
                     'contribution_receipt_amount',
                     'contributor_aggregate_ytd',
                 ]),
-                multiple=False,
             )
         )
 

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -51,7 +51,6 @@ class ScheduleBView(ItemizedResource):
             args.make_seek_args(),
             args.make_sort_args(
                 validator=args.OptionValidator(['disbursement_date', 'disbursement_amount']),
-                multiple=False,
             ),
         )
 

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -62,7 +62,6 @@ class ScheduleEView(ItemizedResource):
                     'expenditure_amount',
                     'office_total_ytd',
                 ]),
-                multiple=False,
             ),
         )
 

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -28,7 +28,7 @@ class TotalsView(utils.Resource):
 
     @use_kwargs(args.paging)
     @use_kwargs(args.totals)
-    @use_kwargs(args.make_sort_args(default=['-cycle']))
+    @use_kwargs(args.make_sort_args(default='-cycle'))
     @marshal_with(schemas.CommitteeTotalsPageSchema(), apply=False)
     def get(self, committee_id=None, committee_type=None, **kwargs):
         query, totals_class, totals_schema = self.build_query(
@@ -36,9 +36,9 @@ class TotalsView(utils.Resource):
             committee_type=committee_type,
             **kwargs
         )
-        validator = args.IndexValidator(totals_class)
-        for key in kwargs['sort']:
-            validator(key)
+        if kwargs['sort']:
+            validator = args.IndexValidator(totals_class)
+            validator(kwargs['sort'])
         page = utils.fetch_page(query, kwargs, model=totals_class)
         return totals_schema().dump(page).data
 

--- a/webservices/sorting.py
+++ b/webservices/sorting.py
@@ -32,20 +32,12 @@ def parse_option(option, model=None, aliases=None, join_columns=None, nulls_larg
     return column, order, nulls, relationship
 
 
-def ensure_list(value):
-    if isinstance(value, list):
-        return value
-    if value:
-        return [value]
-    return []
-
-
-def sort(query, options, model, aliases=None, join_columns=None, clear=False, hide_null=False, nulls_large=True):
+def sort(query, key, model, aliases=None, join_columns=None, clear=False,
+         hide_null=False, nulls_large=True, index_column=None):
     """Sort query using string-formatted columns.
 
     :param query: Original query
-    :param options: String or list of strings of column names; prepend with "-"
-        for descending sort
+    :param options: Sort column name; prepend with "-" for descending sort
     :param model: SQLAlchemy model
     :param join_columns: Mapping of column names to sort and join rules; used
         for sorting on related columns
@@ -55,8 +47,6 @@ def sort(query, options, model, aliases=None, join_columns=None, clear=False, hi
     """
     if clear:
         query = query.order_by(False)
-    options = ensure_list(options)
-    columns = []
     # If the query contains multiple entities (i.e., isn't a simple query on a
     # model), looking up the sort key on the model may lead to invalid queries.
     # In this case, use the string name of the sort key.
@@ -65,18 +55,18 @@ def sort(query, options, model, aliases=None, join_columns=None, clear=False, hi
         if len(query._entities) == 1 and hasattr(query._entities[0], 'mapper')
         else None
     )
-    for option in options:
-        column, order, nulls, relationship = parse_option(
-            option,
-            model=sort_model,
-            aliases=aliases,
-            join_columns=join_columns,
-            nulls_large=nulls_large,
-        )
-        query = query.order_by(nulls(order(column)))
-        if relationship:
-            query = query.join(relationship)
-        if hide_null:
-            query = query.filter(column != None)  # noqa
-        columns.append((column, order))
-    return query, columns
+    column, order, nulls, relationship = parse_option(
+        key,
+        model=sort_model,
+        aliases=aliases,
+        join_columns=join_columns,
+        nulls_large=nulls_large,
+    )
+    query = query.order_by(nulls(order(column)))
+    if relationship:
+        query = query.join(relationship)
+    if hide_null:
+        query = query.filter(column != None)  # noqa
+    if index_column:
+        query = query.order_by(order(index_column))
+    return query, (column, order)

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -44,10 +44,15 @@ def check_cap(kwargs, cap):
             )
 
 
-def fetch_page(query, kwargs, model=None, aliases=None, join_columns=None, clear=False, count=None, cap=100):
+def fetch_page(query, kwargs, model=None, aliases=None, join_columns=None, clear=False,
+               count=None, cap=100, index_column=None):
     check_cap(kwargs, cap)
     sort, hide_null, nulls_large = kwargs.get('sort'), kwargs.get('sort_hide_null'), kwargs.get('sort_nulls_large')
-    query, _ = sorting.sort(query, sort, model=model, aliases=aliases, join_columns=join_columns, clear=clear, hide_null=hide_null, nulls_large=nulls_large)
+    if sort:
+        query, _ = sorting.sort(
+            query, sort, model=model, aliases=aliases, join_columns=join_columns,
+            clear=clear, hide_null=hide_null, nulls_large=nulls_large, index_column=index_column,
+        )
     paginator = paginators.OffsetPaginator(query, kwargs['per_page'], count=count)
     return paginator.get_page(kwargs['page'])
 
@@ -65,8 +70,13 @@ def fetch_seek_paginator(query, kwargs, index_column, clear=False, count=None, c
     check_cap(kwargs, cap)
     model = index_column.parent.class_
     sort, hide_null, nulls_large = kwargs.get('sort'), kwargs.get('sort_hide_null'), kwargs.get('sort_nulls_large')
-    query, sort_columns = sorting.sort(query, sort, model=model, clear=clear, hide_null=hide_null, nulls_large=nulls_large)
-    sort_column = sort_columns[0] if sort_columns else None
+    if sort:
+        query, sort_column = sorting.sort(
+            query, sort,
+            model=model, clear=clear, hide_null=hide_null, nulls_large=nulls_large,
+        )
+    else:
+        sort_column = None
     return paginators.SeekPaginator(
         query,
         kwargs['per_page'],


### PR DESCRIPTION
* Disable multi-column sort
* Always sort on unique keys on aggregate tables

By sorting aggregate tables on a unique key as well as the
user-specified sort key, results are returned in a stable order even in
the presence of duplicates on the selected sort column. Note: this
requires that tables have composite indexes on each possible sort column
and the unique column.

[Resolves #1361]

Ping @LindsayYoung for code review. This doesn't change a huge amount of code, but it might be helpful to talk through the proposed changes synchronously at some point.