### PR TITLE
Use election full flag in candidate history view.

### DIFF
--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -164,35 +164,6 @@ class CandidateFormatTest(ApiBaseTest):
             response = self._response(page)
             self.assertGreater(original_count, response['pagination']['count'])
 
-    def test_candidate_history(self):
-        history_2012 = factories.CandidateHistoryFactory(two_year_period=2012)
-        history_2008 = factories.CandidateHistoryFactory(two_year_period=2008, candidate_id=history_2012.candidate_id)
-        results = self._results(
-            api.url_for(CandidateHistoryView, candidate_id=history_2012.candidate_id)
-        )
-
-        self.assertEqual(results[0]['candidate_id'], history_2012.candidate_id)
-        self.assertEqual(results[1]['candidate_id'], history_2012.candidate_id)
-        self.assertEqual(results[0]['two_year_period'], history_2012.two_year_period)
-        self.assertEqual(results[1]['two_year_period'], history_2008.two_year_period)
-
-    def test_candidate_history_by_year(self):
-        history_2012 = factories.CandidateHistoryFactory(two_year_period=2012)
-        history_2008 = factories.CandidateHistoryFactory(two_year_period=2008, candidate_id=history_2012.candidate_id)
-        results = self._results(
-            api.url_for(CandidateHistoryView, candidate_id=history_2012.candidate_id)
-        )
-
-        results = self._results(
-            api.url_for(
-                CandidateHistoryView,
-                candidate_id=history_2012.candidate_id,
-                cycle=history_2008.two_year_period,
-            )
-        )
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]['candidate_id'], history_2012.candidate_id)
-        self.assertEqual(results[0]['two_year_period'], history_2008.two_year_period)
 
     def test_candidate_sort(self):
         candidates = [
@@ -208,3 +179,78 @@ class CandidateFormatTest(ApiBaseTest):
         self.assertEqual([each['candidate_id'] for each in results], candidate_ids)
         results = self._results(api.url_for(CandidateSearch, sort='-candidate_status'))
         self.assertEqual([each['candidate_id'] for each in results], candidate_ids)
+
+class TestCandidateHistory(ApiBaseTest):
+
+    def setUp(self):
+        super().setUp()
+        self.committee = factories.CommitteeDetailFactory()
+        self.candidates = [
+            factories.CandidateDetailFactory(candidate_id='P001'),
+            factories.CandidateDetailFactory(candidate_id='P002'),
+        ]
+        self.histories = [
+            factories.CandidateHistoryFactory(candidate_id=self.candidates[0].candidate_id, two_year_period=2010),
+            factories.CandidateHistoryFactory(candidate_id=self.candidates[1].candidate_id, two_year_period=2012),
+        ]
+        db.session.flush()
+        self.links = [
+            factories.CandidateCommitteeLinkFactory(
+                candidate_id=self.candidates[0].candidate_id,
+                committee_id=self.committee.committee_id,
+                fec_election_year=2010,
+                committee_type='P',
+            ),
+            factories.CandidateCommitteeLinkFactory(
+                candidate_id=self.candidates[1].candidate_id,
+                committee_id=self.committee.committee_id,
+                fec_election_year=2012,
+                committee_type='P',
+            ),
+        ]
+        self.elections = [
+            factories.CandidateElectionFactory(
+                candidate_id=self.candidates[0].candidate_id,
+                cand_election_year=2012,
+            ),
+            factories.CandidateElectionFactory(
+                candidate_id=self.candidates[1].candidate_id,
+                cand_election_year=2012,
+            ),
+        ]
+
+    def test_history(self):
+        history_2012 = factories.CandidateHistoryFactory(two_year_period=2012)
+        history_2008 = factories.CandidateHistoryFactory(two_year_period=2008, candidate_id=history_2012.candidate_id)
+        results = self._results(
+            api.url_for(CandidateHistoryView, candidate_id=history_2012.candidate_id)
+        )
+
+        assert results[0]['candidate_id'] == history_2012.candidate_id
+        assert results[1]['candidate_id'] == history_2012.candidate_id
+        assert results[0]['two_year_period'] == history_2012.two_year_period
+        assert results[1]['two_year_period'] == history_2008.two_year_period
+
+    def test_committee_cycle(self):
+        results = self._results(
+            api.url_for(
+                CandidateHistoryView,
+                committee_id=self.committee.committee_id, cycle=2012,
+            )
+        )
+        assert len(results) == 1
+        assert results[0]['two_year_period'] == 2012
+        assert results[0]['candidate_id'] == self.candidates[1].candidate_id
+
+    def test_election_full(self):
+        results = self._results(
+            api.url_for(
+                CandidateHistoryView,
+                committee_id=self.committee.committee_id, cycle=2012, election_full='true',
+            )
+        )
+        assert len(results) == 2
+        assert results[0]['two_year_period'] == 2010
+        assert results[0]['candidate_id'] == self.candidates[0].candidate_id
+        assert results[1]['two_year_period'] == 2012
+        assert results[1]['candidate_id'] == self.candidates[1].candidate_id

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -175,13 +175,13 @@ class TestElections(ApiBaseTest):
             'candidate_name': self.candidate.name,
             'incumbent_challenge_full': self.candidate.incumbent_challenge_full,
             'party_full': self.candidate.party_full,
-            'committee_ids': [each.committee_id for each in self.committees],
             'total_receipts': sum(each.receipts for each in totals),
             'total_disbursements': sum(each.disbursements for each in totals),
             'cash_on_hand_end_period': sum(each.last_cash_on_hand_end_period for each in totals),
             'won': False,
         }
-        self.assertEqual(results[0], expected)
+        assert_dicts_subset(results[0], expected)
+        assert set(each.committee_id for each in self.committees) == set(results[0]['committee_ids'])
 
     def test_elections_full(self):
         results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='NY', election_full='true'))

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -154,6 +154,7 @@ class CandidateHistoryView(ApiResource):
     def args(self):
         return utils.extend(
             args.paging,
+            args.candidate_history,
             args.make_sort_args(
                 default='-two_year_period',
                 validator=args.IndexValidator(self.model),


### PR DESCRIPTION
The `CandidateHistoryView` resource is meant to take an `election_full`
flag, but previously hadn't included the flag in its `args`. This patch
adds the missing request parser and a regression test.

[Resolves #1031]