### PR TITLE
Whitelist independent expenditure downloads.

### DIFF
--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -15,7 +15,7 @@ from celery_once import QueueOnce
 from webservices import utils
 from webservices.common import counts
 from webservices.common.models import db
-from webservices.resources import candidates, committees, filings
+from webservices.resources import candidates, committees, filings, sched_e
 
 from webservices.tasks import app
 from webservices.tasks import utils as task_utils
@@ -26,6 +26,7 @@ IGNORE_FIELDS = {'page', 'per_page', 'sort', 'sort_hide_null', 'sort_nulls_large
 RESOURCE_WHITELIST = {
     candidates.CandidateList,
     committees.CommitteeList,
+    sched_e.ScheduleEView,
     filings.FilingsList,
 }
 


### PR DESCRIPTION
Necessary for downloads on https://github.com/18F/openFEC-web-app/pull/987.

cc @LindsayYoung 