### PR TITLE
Nullify index column on candidate aggregates.

### DIFF
--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -226,6 +226,12 @@ class ScheduleBByPurposeView(AggregateResource):
 
 
 class CandidateAggregateResource(AggregateResource):
+
+    # Since candidate aggregates are aggregated on the fly, they don't have a
+    # consistent unique index. We nullify `index_column` to avoiding sorting
+    # on the unique index of the base model.
+    index_column = None
+
     @property
     def sort_args(self):
         return args.make_sort_args(


### PR DESCRIPTION
Prevent candidate aggregate views from sorting on the index column of
their base models, which may not have a `FROM` clause in the aggregate
query. This fixes sorting on candidate aggregates for "other spending".

h/t @LindsayYoung