### PR TITLE
Looking to update data 4 am eastern, 9 GMT to get fresher data

### DIFF
--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -29,7 +29,7 @@ app.conf.update(
     CELERYBEAT_SCHEDULE={
         'refresh': {
             'task': 'webservices.tasks',
-            'schedule': crontab(minute=0, hour=0),
+            'schedule': crontab(minute=0, hour=9),
         },
     }
 )


### PR DESCRIPTION
Starting our refresh at 4 am will get us all the main tables except for calendar data. That isn't done until 7am and I think if we waited that long to do our update, that would impact performance. 

@jmcarp do you agree that starting our data refresh at 4 will give us enough time so we don't run into morning performance issues?

Closes #1448