### PR TITLE
Use ProxyFix middleware.

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -17,6 +17,7 @@ from flask import Blueprint
 from flask.ext import cors
 from flask.ext import restful
 from raven.contrib.flask import Sentry
+from werkzeug.contrib.fixers import ProxyFix
 import sqlalchemy as sa
 
 from webargs.flaskparser import FlaskParser
@@ -311,3 +312,5 @@ initialize_newrelic()
 
 if env.get_credential('SENTRY_DSN'):
     Sentry(app, dsn=env.get_credential('SENTRY_DSN'))
+
+app.wsgi_app = ProxyFix(app.wsgi_app)


### PR DESCRIPTION
Since we're running the API behind a proxy, we need to use the `ProxyFix`
middleware to pull the forwarded URL, scheme, etc. off the request. This
fixes redirects from https to http. I'm guessing this issue emerged when
we dropped the unnecessary nginx proxy.