### PR TITLE
Revert null position option.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,17 +41,6 @@ class TestSort(ApiBaseTest):
         query, columns = sorting.sort(models.Candidate.query, 'district', model=models.Candidate, hide_null=True)
         self.assertEqual(query.all(), candidates[:2])
 
-    def test_nulls_large(self):
-        candidates = [
-            factories.CandidateFactory(district='01'),
-            factories.CandidateFactory(district='02'),
-            factories.CandidateFactory(),
-        ]
-        query, columns = sorting.sort(models.Candidate.query, 'district', model=models.Candidate, nulls_large=False)
-        self.assertEqual(query.all(), candidates[-1:] + candidates[:2])
-        query, columns = sorting.sort(models.Candidate.query, '-district', model=models.Candidate, nulls_large=False)
-        self.assertEqual(query.all(), [candidates[1], candidates[0], candidates[2]])
-
 
 class TestArgs(unittest.TestCase):
 

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -95,7 +95,7 @@ class IndexValidator(OptionValidator):
     def _is_excluded(self, value):
         return not value or value in self.exclude
 
-def make_sort_args(default=None, validator=None, default_hide_null=False, default_nulls_large=True):
+def make_sort_args(default=None, validator=None, default_hide_null=False):
     return {
         'sort': fields.Str(
             missing=default,
@@ -106,10 +106,6 @@ def make_sort_args(default=None, validator=None, default_hide_null=False, defaul
             missing=default_hide_null,
             description='Hide null values on sorted column(s).'
         ),
-        'sort_nulls_large': fields.Bool(
-            missing=default_nulls_large,
-            description='Treat null values as large on sorted column(s)',
-        )
     }
 
 def make_seek_args(field=fields.Int, description=None):

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -100,8 +100,8 @@ class ItemizedResource(ApiResource):
         """Build a subquery by committee.
         """
         query = self.build_query(_apply_options=False, **utils.extend(kwargs, {'committee_id': [committee_id]}))
-        sort, hide_null, nulls_large = kwargs['sort'], kwargs['sort_hide_null'], kwargs['sort_nulls_large']
-        query, _ = sorting.sort(query, sort, model=self.model, hide_null=hide_null, nulls_large=nulls_large)
+        sort, hide_null = kwargs['sort'], kwargs['sort_hide_null']
+        query, _ = sorting.sort(query, sort, model=self.model, hide_null=hide_null)
         page_query = utils.fetch_seek_page(query, kwargs, self.index_column, count=-1, eager=False).results
         count = counts.count_estimate(query, models.db.session, threshold=5000)
         return page_query, count

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -162,7 +162,7 @@ class ElectionView(utils.Resource):
 
     @use_kwargs(args.paging)
     @use_kwargs(args.elections)
-    @use_kwargs(args.make_sort_args(default='-total_receipts', default_nulls_large=False))
+    @use_kwargs(args.make_sort_args(default='-total_receipts'))
     @marshal_with(schemas.ElectionPageSchema())
     def get(self, **kwargs):
         query = self._get_records(kwargs)

--- a/webservices/sorting.py
+++ b/webservices/sorting.py
@@ -1,23 +1,20 @@
 import sqlalchemy as sa
-from sqlalchemy.sql.expression import nullsfirst, nullslast
 
 from webservices.exceptions import ApiError
 
 
-def parse_option(option, model=None, aliases=None, join_columns=None, nulls_large=True):
+def parse_option(option, model=None, aliases=None, join_columns=None):
     """Parse sort option to SQLAlchemy order expression.
 
     :param str option: Column name, possibly prefixed with "-"
     :param model: Optional SQLAlchemy model to sort on
     :param join_columns: Mapping of column names to sort and join rules; used
         for sorting on related columns
-    :param nulls_large: Treat null values as large
     :raises: ApiError if column not found on model
     """
     aliases = aliases or {}
     join_columns = join_columns or {}
     order = sa.desc if option.startswith('-') else sa.asc
-    nulls = nullsfirst if (nulls_large ^ (not option.startswith('-'))) else nullslast
     column = option.lstrip('-')
     relationship = None
     if column in aliases:
@@ -29,11 +26,11 @@ def parse_option(option, model=None, aliases=None, join_columns=None, nulls_larg
             column = getattr(model, column)
         except AttributeError:
             raise ApiError('Field "{0}" not found'.format(column))
-    return column, order, nulls, relationship
+    return column, order, relationship
 
 
 def sort(query, key, model, aliases=None, join_columns=None, clear=False,
-         hide_null=False, nulls_large=True, index_column=None):
+         hide_null=False, index_column=None):
     """Sort query using string-formatted columns.
 
     :param query: Original query
@@ -43,7 +40,6 @@ def sort(query, key, model, aliases=None, join_columns=None, clear=False,
         for sorting on related columns
     :param clear: Clear existing sort conditions
     :param hide_null: Exclude null values on sorted column(s)
-    :param nulls_large: Treat null values as large on sorted column(s)
     """
     if clear:
         query = query.order_by(False)
@@ -55,14 +51,13 @@ def sort(query, key, model, aliases=None, join_columns=None, clear=False,
         if len(query._entities) == 1 and hasattr(query._entities[0], 'mapper')
         else None
     )
-    column, order, nulls, relationship = parse_option(
+    column, order, relationship = parse_option(
         key,
         model=sort_model,
         aliases=aliases,
         join_columns=join_columns,
-        nulls_large=nulls_large,
     )
-    query = query.order_by(nulls(order(column)))
+    query = query.order_by(order(column))
     if relationship:
         query = query.join(relationship)
     if hide_null:

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -24,7 +24,7 @@ from webservices.tasks import utils as task_utils
 
 logger = logging.getLogger(__name__)
 
-IGNORE_FIELDS = {'page', 'per_page', 'sort', 'sort_hide_null', 'sort_nulls_large'}
+IGNORE_FIELDS = {'page', 'per_page', 'sort', 'sort_hide_null'}
 RESOURCE_WHITELIST = {
     candidates.CandidateList,
     committees.CommitteeList,

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -47,11 +47,11 @@ def check_cap(kwargs, cap):
 def fetch_page(query, kwargs, model=None, aliases=None, join_columns=None, clear=False,
                count=None, cap=100, index_column=None):
     check_cap(kwargs, cap)
-    sort, hide_null, nulls_large = kwargs.get('sort'), kwargs.get('sort_hide_null'), kwargs.get('sort_nulls_large')
+    sort, hide_null = kwargs.get('sort'), kwargs.get('sort_hide_null')
     if sort:
         query, _ = sorting.sort(
             query, sort, model=model, aliases=aliases, join_columns=join_columns,
-            clear=clear, hide_null=hide_null, nulls_large=nulls_large, index_column=index_column,
+            clear=clear, hide_null=hide_null, index_column=index_column,
         )
     paginator = paginators.OffsetPaginator(query, kwargs['per_page'], count=count)
     return paginator.get_page(kwargs['page'])
@@ -69,11 +69,11 @@ def fetch_seek_page(query, kwargs, index_column, clear=False, count=None, cap=10
 def fetch_seek_paginator(query, kwargs, index_column, clear=False, count=None, cap=100):
     check_cap(kwargs, cap)
     model = index_column.parent.class_
-    sort, hide_null, nulls_large = kwargs.get('sort'), kwargs.get('sort_hide_null'), kwargs.get('sort_nulls_large')
+    sort, hide_null = kwargs.get('sort'), kwargs.get('sort_hide_null')
     if sort:
         query, sort_column = sorting.sort(
             query, sort,
-            model=model, clear=clear, hide_null=hide_null, nulls_large=nulls_large,
+            model=model, clear=clear, hide_null=hide_null,
         )
     else:
         sort_column = None


### PR DESCRIPTION
Allowing users to control where nulls appear in sort order has the
undesirable consequence of permitting queries that sort without relying
on an index. This patch removes the `sort_nulls_large` option to prevent
users from sending potentially slow queries of this type.