### PR TITLE
Update exclusion rule.

### DIFF
--- a/data/sql_updates/create_omnibus_dates.sql
+++ b/data/sql_updates/create_omnibus_dates.sql
@@ -147,9 +147,10 @@ with elections_raw as(
     select * from trc_report_due_date reports
     left join dimreporttype on reports.report_type = dimreporttype.rpt_tp
     left join elections_raw using (trc_election_id)
-    where coalesce(trc_election_status_id, 1) = 1 and
-    -- exclude pre-primary presidential reports in even years
-        (report_type not in ('12C', '12P') and extract(year from due_date)::numeric % 2 = 0)
+    where
+        coalesce(trc_election_status_id, 1) = 1 and
+        -- exclude pre-primary presidential reports in even years
+        not (report_type in ('12C', '12P') and extract(year from due_date)::numeric % 2 = 1)
 ), reports as (
     select
         'report-' || report_type as category,

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -493,7 +493,7 @@ State filtering is only applicable to the reporting and election resources.
 
 Presidential pre-primary report due dates are not shown on even years.
 Filers generally opt to file monthly rather than submit over 50 pre-primary election
-reports. All reporting deadlines are available in the /reporting-dates/ for reference.
+reports. All reporting deadlines are available at /reporting-dates/ for reference.
 '''
 
 COMMUNICATION_TAG = '''


### PR DESCRIPTION
As written, this patch excluded all odd-year reports and all reports
with the 12C or 12P types. This update only excludes 12C and 12P reports
in even years.