### PR TITLE
Fix and clean up statutory candidate flag.

### DIFF
--- a/data/sql_updates/create_candidate_history_view.sql
+++ b/data/sql_updates/create_candidate_history_view.sql
@@ -25,25 +25,15 @@ with
         ) dedup
         group by cand_id
     ),
-    cycles as (
+    aggregates as (
         select
             cand_id,
             array_agg(fec_election_yr)::int[] as cycles,
-            max(fec_election_yr) as max_cycle
+            max(fec_election_yr) as max_cycle,
+            array_agg(cand_status)::text[] && array['C', 'F', 'P']
+                as five_thousand_flag
         from fec_yr
         group by cand_id
-    ),
-    five_thousand as (
-        select
-            distinct on (cand_id)
-            cand_id,
-            case when array_agg(fec_yr.cand_status)::text[] && array['C', 'F', 'P'] then
-                true::boolean
-            else
-                false::boolean
-            end as five_thousand_flag
-        from fec_yr
-        group by cand_id, cand_status
     )
 select distinct on (fec_yr.cand_id, fec_yr.fec_election_yr)
     row_number() over () as idx,
@@ -59,7 +49,7 @@ select distinct on (fec_yr.cand_id, fec_yr.fec_election_yr)
     fec_yr.cand_ici as incumbent_challenge,
     expand_candidate_incumbent(fec_yr.cand_ici) as incumbent_challenge_full,
     fec_yr.cand_status as candidate_status,
-    five_thousand.five_thousand_flag,
+    aggregates.five_thousand_flag,
     inactive.cand_id is not null as candidate_inactive,
     fec_yr.cand_office as office,
     expand_office(fec_yr.cand_office) as office_full,
@@ -68,14 +58,13 @@ select distinct on (fec_yr.cand_id, fec_yr.fec_election_yr)
     fec_yr.cand_office_district::int as district_number,
     fec_yr.cand_pty_affiliation as party,
     clean_party(dp.party_affiliation_desc) as party_full,
-    cycles.cycles,
+    aggregates.cycles,
     elections.election_years,
     elections.election_districts,
     elections.active_through
 from fec_yr
-left join cycles using (cand_id)
 left join elections using (cand_id)
-left join five_thousand using (cand_id)
+left join aggregates using (cand_id)
 left join cand_inactive inactive on
     fec_yr.cand_id = inactive.cand_id and
     fec_yr.fec_election_yr < inactive.election_yr


### PR DESCRIPTION
As implemented, the statutory candidate flag includes a number of false
negatives due to a `group by` on `cand_status`, combined with a
`distinct` on `cand_id`. The `group by` yields potentially many rows per
candididate, with some `true` and some `false`; the `distinct` selects
just one of these rows, which could be a `false` when other rows are
`true`. This patch drops these two expressions. And now that the
grouping logic is the same as in a previous select, it also combines
selects to make the view slightly faster to build.

* Drop group by on `cand_status`
* Drop unnecesary distinct on `cand_id`
* Move status aggregate into existing select
* Simplify case to plain &&

BTW: any `case` statement that only yields `t` or `f` should be possible to simplify to a boolean operation.