### PR TITLE
Use pre-computed election ranges to round up to next election.

### DIFF
--- a/data/functions/utils.sql
+++ b/data/functions/utils.sql
@@ -4,3 +4,14 @@ begin
     return year + year % 2;
 end
 $$ language plpgsql immutable;
+
+create or replace function election_duration(office text)
+returns integer as $$
+begin
+    return case office
+        when 'S' then 6
+        when 'P' then 4
+        else 2
+    end;
+end
+$$ language plpgsql;

--- a/data/sql_updates/create_candidate_history_view.sql
+++ b/data/sql_updates/create_candidate_history_view.sql
@@ -115,7 +115,10 @@ with years as (
 select distinct on (years.candidate_id, years.cand_election_year)
     years.candidate_id,
     years.cand_election_year,
-    prev.cand_election_year as prev_election_year
+    greatest(
+        prev.cand_election_year,
+        years.cand_election_year - election_duration(substr(years.candidate_id, 1, 1))
+    ) as prev_election_year
 from years
 left join years prev on
     years.candidate_id = prev.candidate_id and

--- a/data/sql_updates/create_candidate_history_view.sql
+++ b/data/sql_updates/create_candidate_history_view.sql
@@ -144,7 +144,7 @@ from ofec_candidate_history_mv_tmp cand
 join ofec_candidate_election_mv_tmp election on
     cand.candidate_id = election.candidate_id and
     cand.two_year_period <= election.cand_election_year and
-    (election.prev_election_year is null or cand.two_year_period > election.prev_election_year)
+    cand.two_year_period > election.prev_election_year
 order by
     cand.candidate_id,
     election.cand_election_year,

--- a/data/sql_updates/post_totals_create_candidate_aggregates.sql
+++ b/data/sql_updates/post_totals_create_candidate_aggregates.sql
@@ -38,7 +38,7 @@ cycle_totals as (
     left join ofec_candidate_election_mv_tmp election on
         link.cand_id = election.candidate_id and
         totals.cycle <= election.cand_election_year and
-        (election.prev_election_year is null or totals.cycle > election.prev_election_year)
+        totals.cycle > election.prev_election_year
     where
         link.cmte_dsgn in ('P', 'A')
     group by

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -178,6 +178,7 @@ class TestCandidateAggregates(ApiBaseTest):
         ]
         factories.CandidateHistoryLatestFactory(
             candidate_id=self.candidate.candidate_id,
+            cand_election_year=2012,
             two_year_period=2012,
         )
         factories.CandidateDetailFactory(

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -212,10 +212,12 @@ class TestCandidateHistory(ApiBaseTest):
             factories.CandidateElectionFactory(
                 candidate_id=self.candidates[0].candidate_id,
                 cand_election_year=2012,
+                prev_election_year=2008,
             ),
             factories.CandidateElectionFactory(
                 candidate_id=self.candidates[1].candidate_id,
                 cand_election_year=2012,
+                prev_election_year=2008,
             ),
         ]
 

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -1,7 +1,6 @@
 import datetime
 
 import sqlalchemy as sa
-from marshmallow.utils import isoformat
 
 from tests import factories
 from tests.common import ApiBaseTest
@@ -342,6 +341,7 @@ class TestCommitteeHistory(ApiBaseTest):
         self.election = factories.CandidateElectionFactory(
             candidate_id=self.candidate.candidate_id,
             cand_election_year=2012,
+            prev_election_year=2008,
         )
 
     def test_candidate_cycle(self):

--- a/webservices/common/models/candidates.py
+++ b/webservices/common/models/candidates.py
@@ -92,6 +92,7 @@ class CandidateHistoryLatest(BaseCandidate):
 
     candidate_id = db.Column(db.String, primary_key=True, index=True)
     two_year_period = db.Column(db.Integer, primary_key=True, index=True)
+    cand_election_year = db.Column(db.Integer, index=True)
     address_city = db.Column(db.String(100))
     address_state = db.Column(db.String(2))
     address_street_1 = db.Column(db.String(200))

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -148,11 +148,12 @@ class TotalsCandidateView(ApiResource):
         ]
 
     def build_query(self, **kwargs):
-        history = (
-            models.CandidateHistoryLatest
-            if kwargs['election_full']
-            else models.CandidateHistory
-        )
+        if kwargs['election_full']:
+            history = models.CandidateHistoryLatest
+            year_column = history.cand_election_year
+        else:
+            history = models.CandidateHistory
+            year_column = history.two_year_period
         query = db.session.query(
             history.__table__,
             models.CandidateTotal.__table__,
@@ -160,7 +161,7 @@ class TotalsCandidateView(ApiResource):
             models.CandidateTotal,
             sa.and_(
                 history.candidate_id == models.CandidateTotal.candidate_id,
-                history.two_year_period == models.CandidateTotal.cycle,
+                year_column == models.CandidateTotal.cycle,
             )
         ).filter(
             models.CandidateTotal.is_election == kwargs['election_full'],

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -182,17 +182,17 @@ class CandidateHistoryView(ApiResource):
         return query
 
     def _filter_elections(self, query, cycle):
-        election_duration = utils.get_election_duration(sa.func.left(models.CandidateHistory.candidate_id, 1))
+        """Round up to the next election including `cycle`."""
         return query.join(
             models.CandidateElection,
             sa.and_(
                 models.CandidateHistory.candidate_id == models.CandidateElection.candidate_id,
-                models.CandidateHistory.two_year_period > models.CandidateElection.cand_election_year - election_duration,
                 models.CandidateHistory.two_year_period <= models.CandidateElection.cand_election_year,
+                models.CandidateHistory.two_year_period > models.CandidateElection.prev_election_year,
             ),
         ).filter(
-            models.CandidateElection.cand_election_year >= cycle,
-            models.CandidateElection.cand_election_year < cycle + election_duration,
+            cycle <= models.CandidateElection.cand_election_year,
+            cycle > models.CandidateElection.prev_election_year,
         ).order_by(
             models.CandidateHistory.candidate_id,
             sa.desc(models.CandidateHistory.two_year_period),


### PR DESCRIPTION
* Use pre-computed election ranges for `election_full` flag
* Limit election ranges to maximum office duration

[Resolves https://github.com/18F/openFEC-web-app/issues/1107]