### PR TITLE
Install swagger-ui fork using git+https.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-     "swagger-ui": "git://github.com/18F/swagger-ui.git"
+     "swagger-ui": "git+https://github.com/18F/swagger-ui.git"
   },
   "engines": {
     "node": "0.12.7",


### PR DESCRIPTION
Cloning swagger-ui using `git://` broke deploys when outgoing traffic on cloud.gov was limited earlier today. Use `git+https://` instead.