### PR TITLE
Add links to underlying logic for purpose

### DIFF
--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -363,6 +363,11 @@ Note: because the Schedule A data includes many records, counts for
 large result sets are approximate.
 '''
 
+SCHEDULE_B_BY_PURPOSE = '''
+Schedule B receipts aggregated by disbursement purpose category. To avoid double counting, memoed items are not included.
+Purpose is a combination of transaction codes, category codes and disbursement description.  See [the sql function](https://github.com/18F/openFEC/blob/7d2c058706f1b385b2cc18d75eb3ad0a1fba9d52/data/functions/purpose.sql)
+'''
+
 SCHEDULE_E_TAG = '''
 Schedule E covers the line item expenditures for independent expenditures. For example, if a super PAC
 bought and adds on TV to oppose a federal candidate, each ad purchase would be recorded here with


### PR DESCRIPTION
When adding this add the variable, SCHEDULE_B_BY_PURPOSE

``` /webservices/resources/aggregates.py

@doc(
    tags=['schedules/schedule_b'],
    description=(
        'Schedule B receipts aggregated by disbursement purpose category. To avoid double '
        'counting, memoed items are not included.' ```