### PR TITLE
Use full-text column for full-text search.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -101,6 +101,17 @@ class OverallTest(ApiBaseTest):
         assert all('bartlet' in each['name'].lower() for each in results)
         assert all(each['office_sought'] == 'P' for each in results)
 
+    def test_typeahead_candidate_search_id(self):
+        row = factories.CandidateSearchFactory(
+            name='Bartlet',
+            fulltxt=sa.func.to_tsvector('Bartlet P0123'),
+        )
+        decoy = factories.CandidateSearchFactory()  # noqa
+        rest.db.session.flush()
+        results = self._results(api.url_for(CandidateNameSearch, q='P0123'))
+        assert len(results) == 1
+        assert results[0]['name'] == row.name
+
     def test_typeahead_committee_search(self):
         rows = [
             factories.CommitteeSearchFactory(

--- a/webservices/resources/search.py
+++ b/webservices/resources/search.py
@@ -18,7 +18,7 @@ from webservices.utils import use_kwargs
 class CandidateNameSearch(utils.Resource):
 
     filter_fulltext_fields = [
-        ('q', models.CandidateSearch.name),
+        ('q', models.CandidateSearch.fulltxt),
     ]
 
     @use_kwargs(args.names)
@@ -38,7 +38,7 @@ class CandidateNameSearch(utils.Resource):
 class CommitteeNameSearch(utils.Resource):
 
     filter_fulltext_fields = [
-        ('q', models.CommitteeSearch.name),
+        ('q', models.CommitteeSearch.fulltxt),
     ]
 
     @use_kwargs(args.names)


### PR DESCRIPTION
Fixes a typo on typeahead search resources and adds a regression test.