### PR TITLE
Add manifest files for cf-ssh access

### DIFF
--- a/ssh_manifest_dev.yml
+++ b/ssh_manifest_dev.yml
@@ -1,0 +1,31 @@
+---
+path: .
+memory: 512M
+stack: cflinuxfs2
+domain: 18f.gov
+buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
+env:
+  NEW_RELIC_CONFIG_FILE: newrelic.ini
+  NEW_RELIC_LOG: stdout
+  WEB_CONCURRENCY: 4
+  NEW_RELIC_APP_NAME: OpenFEC API (development)
+  NEW_RELIC_ENV: development
+applications:
+- name: api
+- name: celery-beat
+  instances: 1
+  memory: 256M
+  no-route: true
+  command: celery beat --app webservices.tasks
+  buildpack: https://github.com/cloudfoundry/python-buildpack#v1.5.1
+- name: celery-worker
+  instances: 1
+  memory: 512M
+  no-route: true
+  command: celery worker --app webservices.tasks --loglevel INFO --concurrency 2
+  buildpack: https://github.com/cloudfoundry/python-buildpack#v1.5.1
+host: fec-dev-api
+services:
+  - fec-creds-dev
+  - fec-redis-dev
+  - fec-s3-dev

--- a/ssh_manifest_prod.yml
+++ b/ssh_manifest_prod.yml
@@ -1,0 +1,34 @@
+---
+path: .
+memory: 512M
+stack: cflinuxfs2
+domain: 18f.gov
+buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
+env:
+  NEW_RELIC_CONFIG_FILE: newrelic.ini
+  NEW_RELIC_LOG: stdout
+  WEB_CONCURRENCY: 4
+  PRODUCTION: True
+  NEW_RELIC_APP_NAME: OpenFEC API (production)
+  NEW_RELIC_ENV: development
+  FEC_API_WHITELIST_IPS: true
+  FEC_CACHE_AGE: 3600
+applications:
+- name: api
+- name: celery-beat
+  instances: 1
+  memory: 256M
+  no-route: true
+  command: celery beat --app webservices.tasks
+  buildpack: https://github.com/cloudfoundry/python-buildpack#v1.5.1
+- name: celery-worker
+  instances: 1
+  memory: 512M
+  no-route: true
+  command: celery worker --app webservices.tasks --loglevel INFO --concurrency 2
+  buildpack: https://github.com/cloudfoundry/python-buildpack#v1.5.1
+host: fec-prod-api
+services:
+  - fec-creds-prod
+  - fec-redis-prod
+  - fec-s3-prod

--- a/ssh_manifest_stage.yml
+++ b/ssh_manifest_stage.yml
@@ -1,0 +1,32 @@
+---
+path: .
+memory: 512M
+stack: cflinuxfs2
+domain: 18f.gov
+buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
+env:
+  NEW_RELIC_CONFIG_FILE: newrelic.ini
+  NEW_RELIC_LOG: stdout
+  WEB_CONCURRENCY: 4
+  NEW_RELIC_APP_NAME: OpenFEC API (staging)
+  NEW_RELIC_ENV: staging
+  FEC_API_WHITELIST_IPS: "false"
+applications:
+- name: api
+- name: celery-beat
+  instances: 1
+  memory: 256M
+  no-route: true
+  command: celery beat --app webservices.tasks
+  buildpack: https://github.com/cloudfoundry/python-buildpack#v1.5.1
+- name: celery-worker
+  instances: 1
+  memory: 512M
+  no-route: true
+  command: celery worker --app webservices.tasks --loglevel INFO --concurrency 2
+  buildpack: https://github.com/cloudfoundry/python-buildpack#v1.5.1
+host: fec-stage-api
+services:
+  - fec-creds-stage
+  - fec-redis-stage
+  - fec-s3-stage


### PR DESCRIPTION
This changeset adds additional manifest files so that we are able to use the `cf-ssh` cli tool in order to connect directly to our servers.

**NOTE:**  This is just a stop-gap measure fow now, we will want to improve this in the near future, but we need to be able to access these machines now.  The current problem appears to be that you are unable to use a manifest that inherits from another one when using the `cf-ssh` cli-tool, so that will be a place to start investigating further.

**USAGE:**  Just to be sure things work as expected I make sure that CF is configured to access the same target space I want to use `cf-ssh` with:

`cf target -o fec -s <space>`

And then to use these with `cf-ssh`:

`cf-ssh -f <ssh manifest file for desired space>`

After a few moments of deploying an `api-ssh` app, you should be presented with a `tmate` window in your terminal for the remote app.

/cc @LindsayYoung