### PR TITLE
Fixes docs.py typos

### DIFF
--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -341,7 +341,7 @@ SCHEDULE_B = SCHEDULE_B_TAG + '''
 Due to the large quantity of Schedule B filings, this endpoint is not paginated by
 page number. Instead, you can request the next page of results by adding the values in
 the `last_indexes` object from `pagination` to the URL of your last request. For
-example, when sorting by `contribution_receipt_date`, you might receive a page of
+example, when sorting by `disbursement_date`, you might receive a page of
 results with the following pagination information:
 
 ```
@@ -359,13 +359,13 @@ pagination: {
 To fetch the next page of results, append "last_index=230906248&amp;last_disbursement_date=2014-07-04"
 to the URL.
 
-Note: because the Schedule A data includes many records, counts for
+Note: because the Schedule B data includes many records, counts for
 large result sets are approximate.
 '''
 
 SCHEDULE_E_TAG = '''
 Schedule E covers the line item expenditures for independent expenditures. For example, if a super PAC
-bought and adds on TV to oppose a federal candidate, each ad purchase would be recorded here with
+bought ads on TV to oppose a federal candidate, each ad purchase would be recorded here with
 the expenditure amount, name and id of the candidate, and whether the ad supported or opposed the candidate.
 
 An independent expenditure is an expenditure for a communication "expressly advocating the election or


### PR DESCRIPTION
Quick typos I found while working with the API and reading docs.