### PR TITLE
Eager-load flags on candidate views and restore nplusone.

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -5,7 +5,7 @@ import unittest
 import subprocess
 
 from webtest import TestApp
-# from nplusone.ext.flask_sqlalchemy import NPlusOne
+from nplusone.ext.flask_sqlalchemy import NPlusOne
 
 import manage
 from webservices import rest
@@ -14,8 +14,8 @@ from webservices import __API_VERSION__
 
 TEST_CONN = os.getenv('SQLA_TEST_CONN', 'postgresql:///cfdm-unit-test')
 
-# rest.app.config['NPLUSONE_RAISE'] = True
-# NPlusOne(rest.app)
+rest.app.config['NPLUSONE_RAISE'] = True
+NPlusOne(rest.app)
 
 
 def _reset_schema():

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -22,7 +22,6 @@ def filter_multi_fields(model):
     ]
 
 
-
 @doc(
     tags=['candidate'],
     description=docs.CANDIDATE_LIST,
@@ -99,6 +98,7 @@ class CandidateSearch(CandidateList):
     schema = schemas.CandidateSearchSchema
     page_schema = schemas.CandidateSearchPageSchema
     query_options = [
+        sa.orm.joinedload(models.Candidate.flags),
         sa.orm.subqueryload(models.Candidate.principal_committees),
     ]
 
@@ -117,6 +117,10 @@ class CandidateView(ApiResource):
     schema = schemas.CandidateDetailSchema
     page_schema = schemas.CandidateDetailPageSchema
     filter_multi_fields = filter_multi_fields(models.CandidateDetail)
+
+    query_options = [
+        sa.orm.joinedload(models.CandidateDetail.flags),
+    ]
 
     @property
     def args(self):
@@ -168,8 +172,6 @@ class CandidateHistoryView(ApiResource):
     query_options = [
         sa.orm.joinedload(models.CandidateHistory.flags),
     ]
-
-
 
     @property
     def args(self):

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -162,8 +162,12 @@ CandidateHistoryTotalPageSchema = make_page_schema(CandidateHistoryTotalSchema)
 
 CandidateSearchSchema = make_schema(
     models.Candidate,
-    options={'exclude': ('idx', )},
-    fields={'principal_committees': ma.fields.Nested(schemas['CommitteeSchema'], many=True)},
+    options={'exclude': ('idx', 'flags')},
+    fields={
+        'principal_committees': ma.fields.Nested(schemas['CommitteeSchema'], many=True),
+        'federal_funds_flag': ma.fields.Boolean(attribute='flags.federal_funds_flag'),
+        'five_thousand_flag': ma.fields.Boolean(attribute='flags.five_thousand_flag'),
+    },
 )
 CandidateSearchPageSchema = make_page_schema(CandidateSearchSchema)
 register_schema(CandidateSearchSchema)


### PR DESCRIPTION
We introduced a handful of lazy-loaded relationships in #1548. For
example, loading N records via `CandidateView` currently runs one query
(to fetch candidate detail rows) followed by N additional queries (one
to fetch the flags row for each candidate row). This patch uses eager
loading for all candidate views that expose related attributes via
flags, and restores `nplusone` to prevent future performance
regressions.