### PR TITLE
Build assets on CI.

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/cloudfoundry/python-buildpack#v1.5.1
-https://github.com/cloudfoundry/nodejs-buildpack.git#v1.5.0

--- a/.cfignore
+++ b/.cfignore
@@ -1,7 +1,5 @@
 cache
-node_modules
 
-data/bin/set_env_vars.real.sh
 .DS_Store
 
 # Byte-compiled / optimized / DLL files
@@ -59,8 +57,4 @@ docs/_build/
 target/
 
 # PG dumps, DDL, etc.
-data/*dump*
-data/ddl/
-data/tuning
-
-documentation/notebooks/
+data/subset.dump

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 cache
 node_modules
 
-data/bin/set_env_vars.real.sh
 .DS_Store
 
 # Byte-compiled / optimized / DLL files
@@ -57,6 +56,3 @@ docs/_build/
 
 # PyBuilder
 target/
-
-# CloudFoundry
-cf-ssh.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,11 @@ before_deploy:
   - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0"
   - tar xzvf $HOME/cf.tgz -C $HOME
   - travis_retry cf install-plugin autopilot -f -r CF-Community
+  - npm install
 
 deploy:
   provider: script
+  skip_cleanup: true
   script: invoke deploy --branch $TRAVIS_BRANCH --yes
   on:
     all_branches: true

--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -2,8 +2,8 @@
 path: .
 memory: 1G
 stack: cflinuxfs2
+buildpack: python_buildpack
 domain: 18f.gov
-buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
 env:
   NEW_RELIC_CONFIG_FILE: newrelic.ini
   NEW_RELIC_LOG: stdout
@@ -15,10 +15,8 @@ applications:
   memory: 256M
   no-route: true
   command: celery beat --app webservices.tasks
-  buildpack: https://github.com/cloudfoundry/python-buildpack#v1.5.1
 - name: celery-worker
   instances: 1
   memory: 512M
   no-route: true
   command: celery worker --app webservices.tasks --loglevel INFO --concurrency 2
-  buildpack: https://github.com/cloudfoundry/python-buildpack#v1.5.1


### PR DESCRIPTION
* Switch to vetted python buildpack
* Install swagger-ui on travis and include in deploy
* Remove `node_modules` from `.cfignore`

Part of https://github.com/18F/openFEC/issues/1643.

Note--we could simplify this further and `git clone` swagger-ui instead of `npm install`-ing it, since I'm guessing this repo isn't going to accumulate more npm requirements. I don't have a preference about this--just thought I'd mention the possibility.