### PR TITLE
Feature/totals flag extension

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -468,6 +468,8 @@ candidate_totals = {
     'max_cash_on_hand_end_period': Currency(description='Maximum cash on hand'),
     'min_debts_owed_by_committee': Currency(description='Minimum debt'),
     'max_debts_owed_by_committee': Currency(description='Maximum debt'),
+    'federal_funds_flag': fields.Bool(description=docs.FEDERAL_FUNDS_FLAG),
+    'has_raised_funds': fields.Bool(description=docs.HAS_RAISED_FUNDS),
 }
 
 totals_committee_aggregate = {

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -174,6 +174,20 @@ class TotalsCandidateView(ApiResource):
                 models.CandidateSearch,
                 history.candidate_id == models.CandidateSearch.id,
             )
+        #The .filter methods may be able to moved to the filters methods, will investigate
+        if kwargs.get('has_raised_funds') or kwargs.get('federal_funds_flag'):
+            query = query.join(
+                models.Candidate,
+                history.candidate_id == models.Candidate.candidate_id,
+            )
+        if kwargs.get('has_raised_funds'):
+            query = query.filter(
+                models.Candidate.flags.has(models.CandidateFlags.has_raised_funds == kwargs['has_raised_funds'])
+            )
+        if kwargs.get('federal_funds_flag'):
+            query = query.filter(
+                models.Candidate.flags.has(models.CandidateFlags.federal_funds_flag == kwargs['federal_funds_flag'])
+            )
         query = filters.filter_multi(query, kwargs, self.filter_multi_fields(history, models.CandidateTotal))
         query = filters.filter_range(query, kwargs, self.filter_range_fields(models.CandidateTotal))
         query = filters.filter_fulltext(query, kwargs, self.filter_fulltext_fields)


### PR DESCRIPTION
Added the has_raised_funds and federal_funds_flag to the "/candidate/totals" endpoint.  At first, I thought my code was wrong because there were some candidates being shown in the results with negative receipts for certain cycles.  However after taking a look at the candidate_flags table, they indeed were listed as 'true' for has_raised, but, the summation over all cycles put them over 0 dollars.

Which is how the filter works for the currently implemented "/candidates" endpoint as well.  I don't see this as an issue other than if a user takes a look at certain cycles in isolation and sees a negative or zero amount.  From an outside user I don't know if the language conveys that the candidate has raised more than zero dollars for all time.  

With that being said I did play around with the api and verify that the users are being properly filtered, but not an official test or anything, although that may be something worth writing.  Also, for the candidates/{candidateType} endpoints on the web app there are no selections for these filters, so if it's to be presented those will have to be added.
