### PR TITLE
Feature/move from warehouse tables

### DIFF
--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_employer.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_employer.sql
@@ -7,7 +7,7 @@ select
     contbr_employer as employer,
     sum(contb_receipt_amt) as total,
     count(contb_receipt_amt) as count
-from sched_a
+from fec_vsum_sched_a
 where rpt_yr >= :START_YEAR_AGGREGATE
 and contb_receipt_amt is not null
 and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_occupation.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_occupation.sql
@@ -7,7 +7,7 @@ select
     contbr_occupation as occupation,
     sum(contb_receipt_amt) as total,
     count(contb_receipt_amt) as count
-from sched_a
+from fec_vsum_sched_a
 where rpt_yr >= :START_YEAR_AGGREGATE
 and contb_receipt_amt is not null
 and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
@@ -19,7 +19,7 @@ select
     contribution_size(contb_receipt_amt) as size,
     sum(contb_receipt_amt) as total,
     count(contb_receipt_amt) as count
-from sched_a
+from fec_vsum_sched_a
 where rpt_yr >= :START_YEAR_AGGREGATE
 and contb_receipt_amt is not null
 and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_state.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_state.sql
@@ -7,7 +7,7 @@ select
     expand_state(contbr_st) as state_full,
     sum(contb_receipt_amt) as total,
     count(contb_receipt_amt) as count
-from sched_a
+from fec_vsum_sched_a
 where rpt_yr >= :START_YEAR_AGGREGATE
 and contb_receipt_amt is not null
 and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_zip.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_zip.sql
@@ -9,7 +9,7 @@ select
     expand_state(max(contbr_st)) as state_full,
     sum(contb_receipt_amt) as total,
     count(contb_receipt_amt) as count
-from sched_a
+from fec_vsum_sched_a
 where rpt_yr >= :START_YEAR_AGGREGATE
 and contb_receipt_amt is not null
 and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)

--- a/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_purpose.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_purpose.sql
@@ -6,7 +6,7 @@ select
     disbursement_purpose(disb_tp, disb_desc) as purpose,
     sum(disb_amt) as total,
     count(disb_amt) as count
-from sched_b
+from fec_vsum_sched_b
 where rpt_yr >= :START_YEAR_AGGREGATE
 and disb_amt is not null
 and (memo_cd != 'X' or memo_cd is null)

--- a/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient.sql
@@ -7,7 +7,7 @@ select
     recipient_nm,
     sum(disb_amt) as total,
     count(disb_amt) as count
-from sched_b
+from fec_vsum_sched_b
 where rpt_yr >= :START_YEAR_AGGREGATE
 and disb_amt is not null
 and (memo_cd != 'X' or memo_cd is null)

--- a/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient_committee.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient_committee.sql
@@ -8,7 +8,7 @@ select
     max(recipient_nm) as recipient_nm,
     sum(disb_amt) as total,
     count(disb_amt) as count
-from sched_b
+from fec_vsum_sched_b
 where rpt_yr >= :START_YEAR_AGGREGATE
 and disb_amt is not null
 and (memo_cd != 'X' or memo_cd is null)

--- a/data/sql_incremental_aggregates/update_schedule_a.sql
+++ b/data/sql_incremental_aggregates/update_schedule_a.sql
@@ -2,12 +2,12 @@ create or replace function ofec_sched_a_update() returns void as $$
 begin
     -- Drop all queued deletes
     delete from ofec_sched_a
-    where sched_a_sk = any(select sched_a_sk from ofec_sched_a_queue_old)
+    where sub_id = any(select sub_id from ofec_sched_a_queue_old)
     ;
     -- Insert all queued updates, unless a row with the same key exists in the
     -- delete queue with a later timestamp
     insert into ofec_sched_a(
-        select distinct on (sched_a_sk)
+        select distinct on (sub_id)
             new.*,
             image_pdf_url(new.image_num) as pdf_url,
             to_tsvector(new.contbr_nm) || to_tsvector(coalesce(new.contbr_id, ''))
@@ -18,9 +18,9 @@ begin
                 as is_individual,
             clean_repeated(new.contbr_id, new.cmte_id) as clean_contbr_id
         from ofec_sched_a_queue_new new
-        left join ofec_sched_a_queue_old old on new.sched_a_sk = old.sched_a_sk and old.timestamp > new.timestamp
-        where old.sched_a_sk is null
-        order by new.sched_a_sk, new.timestamp desc
+        left join ofec_sched_a_queue_old old on new.sub_id = old.sub_id and old.timestamp > new.timestamp
+        where old.sub_id is null
+        order by new.sub_id, new.timestamp desc
     );
 end
 $$ language plpgsql;

--- a/data/sql_incremental_aggregates/update_schedule_e.sql
+++ b/data/sql_incremental_aggregates/update_schedule_e.sql
@@ -2,7 +2,7 @@ create or replace function ofec_sched_e_update() returns void as $$
 begin
     -- Drop all queued deletes
     delete from ofec_sched_e
-    where sched_e_sk = any(select sched_e_sk from ofec_sched_e_queue_old)
+    where sub_id = any(select sub_id from ofec_sched_e_queue_old)
     ;
     -- Insert all queued updates, unless a row with the same key exists in the
     -- delete queue with a later timestamp
@@ -13,9 +13,9 @@ begin
             coalesce(new.rpt_tp, '') in ('24', '48') as is_notice,
             to_tsvector(new.pye_nm) as payee_name_text
         from ofec_sched_e_queue_new new
-        left join ofec_sched_e_queue_old old on new.sched_e_sk = old.sched_e_sk and old.timestamp > new.timestamp
-        where old.sched_e_sk is null
-        order by new.sched_e_sk, new.timestamp desc
+        left join ofec_sched_e_queue_old old on new.sub_id = old.sub_id and old.timestamp > new.timestamp
+        where old.sub_id is null
+        order by new.sub_id, new.timestamp desc
     );
 end
 $$ language plpgsql;

--- a/data/sql_setup/prepare_schedule_b.sql
+++ b/data/sql_setup/prepare_schedule_b.sql
@@ -10,36 +10,36 @@ select
     to_tsvector(disb_desc) as disbursement_description_text,
     disbursement_purpose(disb_tp, disb_desc) as disbursement_purpose_category,
     clean_repeated(recipient_cmte_id, cmte_id) as clean_recipient_cmte_id
-from sched_b
+from fec_vsum_sched_b
 where rpt_yr >= :START_YEAR_ITEMIZED
 ;
 
-alter table ofec_sched_b_tmp add primary key (sched_b_sk);
+alter table ofec_sched_b_tmp add primary key (sub_id);
 
 -- Create simple indices on filtered columns
 create index on ofec_sched_b_tmp (rpt_yr);
 create index on ofec_sched_b_tmp (image_num);
-create index on ofec_sched_b_tmp (sched_b_sk);
+create index on ofec_sched_b_tmp (sub_id);
 create index on ofec_sched_b_tmp (recipient_st);
 create index on ofec_sched_b_tmp (recipient_city);
 create index on ofec_sched_b_tmp (clean_recipient_cmte_id);
 create index on ofec_sched_b_tmp (disbursement_purpose_category);
 
 -- Create composite indices on sortable columns
-create index on ofec_sched_b_tmp (disb_dt, sched_b_sk);
-create index on ofec_sched_b_tmp (disb_amt, sched_b_sk);
+create index on ofec_sched_b_tmp (disb_dt, sub_id);
+create index on ofec_sched_b_tmp (disb_amt, sub_id);
 
 -- Create composite indices on `cmte_id`; else filtering by committee can be very slow
-create index on ofec_sched_b_tmp (cmte_id, sched_b_sk);
-create index on ofec_sched_b_tmp (cmte_id, disb_dt, sched_b_sk);
-create index on ofec_sched_b_tmp (cmte_id, disb_amt, sched_b_sk);
+create index on ofec_sched_b_tmp (cmte_id, sub_id);
+create index on ofec_sched_b_tmp (cmte_id, disb_dt, sub_id);
+create index on ofec_sched_b_tmp (cmte_id, disb_amt, sub_id);
 
 -- Create indices on fulltext columns
 create index on ofec_sched_b_tmp using gin (recipient_name_text);
 create index on ofec_sched_b_tmp using gin (disbursement_description_text);
 
 -- Create index for join on electioneering costs
-create index on sched_b (link_id);
+create index on fec_vsum_sched_b (link_id);
 
 -- Use smaller histogram bins on state column for faster queries on rare states (AS, PR)
 alter table ofec_sched_b_tmp alter column recipient_st set statistics 1000;
@@ -50,12 +50,12 @@ analyze ofec_sched_b_tmp;
 -- Create queue tables to hold changes to Schedule B
 drop table if exists ofec_sched_b_queue_new;
 drop table if exists ofec_sched_b_queue_old;
-create table ofec_sched_b_queue_new as select * from sched_b limit 0;
-create table ofec_sched_b_queue_old as select * from sched_b limit 0;
+create table ofec_sched_b_queue_new as select * from fec_vsum_sched_b limit 0;
+create table ofec_sched_b_queue_old as select * from fec_vsum_sched_b limit 0;
 alter table ofec_sched_b_queue_new add column timestamp timestamp;
 alter table ofec_sched_b_queue_old add column timestamp timestamp;
-create index on ofec_sched_b_queue_new (sched_b_sk);
-create index on ofec_sched_b_queue_old (sched_b_sk);
+create index on ofec_sched_b_queue_new (sub_id);
+create index on ofec_sched_b_queue_old (sub_id);
 create index on ofec_sched_b_queue_new (timestamp);
 create index on ofec_sched_b_queue_old (timestamp);
 
@@ -66,21 +66,21 @@ declare
 begin
     if tg_op = 'INSERT' then
         if new.rpt_yr >= start_year then
-            delete from ofec_sched_b_queue_new where sched_b_sk = new.sched_b_sk;
+            delete from ofec_sched_b_queue_new where sub_id = new.sub_id;
             insert into ofec_sched_b_queue_new values (new.*);
         end if;
         return new;
     elsif tg_op = 'UPDATE' then
         if new.rpt_yr >= start_year then
-            delete from ofec_sched_b_queue_new where sched_b_sk = new.sched_b_sk;
-            delete from ofec_sched_b_queue_old where sched_b_sk = old.sched_b_sk;
+            delete from ofec_sched_b_queue_new where sub_id = new.sub_id;
+            delete from ofec_sched_b_queue_old where sub_id = old.sub_id;
             insert into ofec_sched_b_queue_new values (new.*);
             insert into ofec_sched_b_queue_old values (old.*);
         end if;
         return new;
     elsif tg_op = 'DELETE' then
         if old.rpt_yr >= start_year then
-            delete from ofec_sched_b_queue_old where sched_b_sk = old.sched_b_sk;
+            delete from ofec_sched_b_queue_old where sub_id = old.sub_id;
             insert into ofec_sched_b_queue_old values (old.*);
         end if;
         return old;
@@ -88,9 +88,9 @@ begin
 end
 $$ language plpgsql;
 
-drop trigger if exists ofec_sched_b_queue_trigger on sched_b;
+drop trigger if exists ofec_sched_b_queue_trigger on fec_vsum_sched_b;
 create trigger ofec_sched_b_queue_trigger before insert or update or delete
-    on sched_b for each row execute procedure ofec_sched_b_update_queues(:START_YEAR_AGGREGATE)
+    on fec_vsum_sched_b for each row execute procedure ofec_sched_b_update_queues(:START_YEAR_AGGREGATE)
 ;
 
 drop table if exists ofec_sched_b;

--- a/data/sql_setup/prepare_schedule_e.sql
+++ b/data/sql_setup/prepare_schedule_e.sql
@@ -7,10 +7,9 @@ select
     image_pdf_url(image_num) as pdf_url,
     coalesce(rpt_tp, '') in ('24', '48') as is_notice,
     to_tsvector(pye_nm) as payee_name_text
-from sched_e
-;
+from fec_vsum_sched_e;
 
-alter table ofec_sched_e_tmp add primary key (sched_e_sk);
+alter table ofec_sched_e_tmp add primary key (sub_id);
 
 -- Create simple indices on filtered columns
 create index on ofec_sched_e_tmp (cmte_id);
@@ -23,9 +22,9 @@ create index on ofec_sched_e_tmp (get_cycle(rpt_yr));
 create index on ofec_sched_e_tmp (is_notice);
 
 -- Create composite indices on sortable columns
-create index on ofec_sched_e_tmp (exp_dt, sched_e_sk);
-create index on ofec_sched_e_tmp (exp_amt, sched_e_sk);
-create index on ofec_sched_e_tmp (cal_ytd_ofc_sought, sched_e_sk);
+create index on ofec_sched_e_tmp (exp_dt, sub_id);
+create index on ofec_sched_e_tmp (exp_amt, sub_id);
+create index on ofec_sched_e_tmp (cal_ytd_ofc_sought, sub_id);
 
 -- Create indices on filtered fulltext columns
 create index on ofec_sched_e_tmp using gin (payee_name_text);
@@ -36,12 +35,12 @@ analyze ofec_sched_e_tmp;
 -- Create queue tables to hold changes to Schedule E
 drop table if exists ofec_sched_e_queue_new;
 drop table if exists ofec_sched_e_queue_old;
-create table ofec_sched_e_queue_new as select * from sched_e limit 0;
-create table ofec_sched_e_queue_old as select * from sched_e limit 0;
+create table ofec_sched_e_queue_new as select * from fec_vsum_sched_e limit 0;
+create table ofec_sched_e_queue_old as select * from fec_vsum_sched_e limit 0;
 alter table ofec_sched_e_queue_new add column timestamp timestamp;
 alter table ofec_sched_e_queue_old add column timestamp timestamp;
-create index on ofec_sched_e_queue_new (sched_e_sk);
-create index on ofec_sched_e_queue_old (sched_e_sk);
+create index on ofec_sched_e_queue_new (sub_id);
+create index on ofec_sched_e_queue_old (sub_id);
 create index on ofec_sched_e_queue_new (timestamp);
 create index on ofec_sched_e_queue_old (timestamp);
 
@@ -51,26 +50,26 @@ declare
     start_year int = TG_ARGV[0]::int;
 begin
     if tg_op = 'INSERT' then
-        delete from ofec_sched_e_queue_new where sched_e_sk = new.sched_e_sk;
+        delete from ofec_sched_e_queue_new where sub_id = new.sub_id;
         insert into ofec_sched_e_queue_new values (new.*);
         return new;
     elsif tg_op = 'UPDATE' then
-        delete from ofec_sched_e_queue_new where sched_e_sk = new.sched_e_sk;
-        delete from ofec_sched_e_queue_old where sched_e_sk = old.sched_e_sk;
+        delete from ofec_sched_e_queue_new where sub_id = new.sub_id;
+        delete from ofec_sched_e_queue_old where sub_id = old.sub_id;
         insert into ofec_sched_e_queue_new values (new.*);
         insert into ofec_sched_e_queue_old values (old.*);
         return new;
     elsif tg_op = 'DELETE' then
-        delete from ofec_sched_e_queue_old where sched_e_sk = old.sched_e_sk;
+        delete from ofec_sched_e_queue_old where sub_id = old.sub_id;
         insert into ofec_sched_e_queue_old values (old.*);
         return old;
     end if;
 end
 $$ language plpgsql;
 
-drop trigger if exists ofec_sched_e_queue_trigger on sched_e;
+drop trigger if exists ofec_sched_e_queue_trigger on fec_vsum_sched_e;
 create trigger ofec_sched_e_queue_trigger before insert or update or delete
-    on sched_e for each row execute procedure ofec_sched_e_update_queues(:START_YEAR_AGGREGATE)
+    on fec_vsum_sched_e for each row execute procedure ofec_sched_e_update_queues(:START_YEAR_AGGREGATE)
 ;
 
 drop table if exists ofec_sched_e;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-     "swagger-ui": "git+https://github.com/18F/swagger-ui.git"
+    "swagger-tools": "^0.10.1",
+    "swagger-ui": "git+https://github.com/18F/swagger-ui.git"
   },
   "engines": {
     "node": "0.12.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "swagger-tools": "^0.10.1",
     "swagger-ui": "git+https://github.com/18F/swagger-ui.git"
   },
   "engines": {

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -157,8 +157,8 @@ class ReportsIEOnlyFactory(BaseFactory):
 class ScheduleAFactory(BaseFactory):
     class Meta:
         model = models.ScheduleA
-    load_date = datetime.datetime.utcnow()
-    sched_a_sk = factory.Sequence(lambda n: n)
+    #load_date = datetime.datetime.utcnow()
+    #sched_a_sk = factory.Sequence(lambda n: n)
     sub_id = factory.Sequence(lambda n: n)
     report_year = 2016
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -157,8 +157,6 @@ class ReportsIEOnlyFactory(BaseFactory):
 class ScheduleAFactory(BaseFactory):
     class Meta:
         model = models.ScheduleA
-    #load_date = datetime.datetime.utcnow()
-    #sched_a_sk = factory.Sequence(lambda n: n)
     sub_id = factory.Sequence(lambda n: n)
     report_year = 2016
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -181,7 +181,7 @@ class ScheduleBFactory(BaseFactory):
 class ScheduleEFactory(BaseFactory):
     class Meta:
         model = models.ScheduleE
-    sched_e_sk = factory.Sequence(lambda n: n)
+    sub_id = factory.Sequence(lambda n: n)
     report_year = 2016
 
     @factory.post_generation

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -170,8 +170,7 @@ class ScheduleAFactory(BaseFactory):
 class ScheduleBFactory(BaseFactory):
     class Meta:
         model = models.ScheduleB
-    sched_b_sk = factory.Sequence(lambda n: n)
-    load_date = datetime.datetime.utcnow()
+    sub_id = factory.Sequence(lambda n: n)
     report_year = 2016
 
     @factory.post_generation

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,13 +20,13 @@ from webservices.common import models
 def make_factory():
     automap = automap_base()
     automap.prepare(db.engine, reflect=True)
-
     class SchedAFactory(SQLAlchemyModelFactory):
         class Meta:
             sqlalchemy_session = db.session
-            model = automap.classes.sched_a
-        load_date = datetime.datetime.utcnow()
-        sched_a_sk = factory.Sequence(lambda n: n)
+            model = automap.classes.fec_vsum_sched_a
+        #load_date = datetime.datetime.utcnow()
+        #sched_a_sk = factory.Sequence(lambda n: n)
+        filing_form = '11'
         sub_id = factory.Sequence(lambda n: n)
         rpt_yr = 2016
 
@@ -143,13 +143,11 @@ class TestViews(common.IntegrationTestCase):
         row = self.SchedAFactory(
             rpt_yr=2014,
             contbr_nm='Sheldon Adelson',
-            load_date=datetime.datetime.now(),
-            sub_id=7,
         )
         db.session.commit()
         db.session.execute('select update_aggregates()')
         search = models.ScheduleA.query.filter(
-            models.ScheduleA.sched_a_sk == row.sched_a_sk
+            models.ScheduleA.sub_id == row.sub_id
         ).one()
         self.assertEqual(search.contributor_name_text, "'adelson':2 'sheldon':1")
 
@@ -159,7 +157,7 @@ class TestViews(common.IntegrationTestCase):
         db.session.commit()
         db.session.execute('select update_aggregates()')
         search = models.ScheduleA.query.filter(
-            models.ScheduleA.sched_a_sk == row.sched_a_sk
+            models.ScheduleA.sub_id == row.sub_id
         ).one()
         db.session.refresh(search)
         self.assertEqual(search.contributor_name_text, "'adelson':2 'shelli':1")
@@ -170,7 +168,7 @@ class TestViews(common.IntegrationTestCase):
         db.session.execute('select update_aggregates()')
         self.assertEqual(
             models.ScheduleA.query.filter(
-                models.ScheduleA.sched_a_sk == row.sched_a_sk
+                models.ScheduleA.sub_id == row.sub_id
             ).count(),
             0,
         )
@@ -189,7 +187,7 @@ class TestViews(common.IntegrationTestCase):
         db.session.execute('select update_aggregates()')
         self.assertEqual(
             models.ScheduleA.query.filter(
-                models.ScheduleA.sched_a_sk == row.sched_a_sk
+                models.ScheduleA.sub_id == row.sub_id
             ).count(),
             1,
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -24,8 +24,6 @@ def make_factory():
         class Meta:
             sqlalchemy_session = db.session
             model = automap.classes.fec_vsum_sched_a
-        #load_date = datetime.datetime.utcnow()
-        #sched_a_sk = factory.Sequence(lambda n: n)
         filing_form = '11'
         sub_id = factory.Sequence(lambda n: n)
         rpt_yr = 2016

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -75,7 +75,7 @@ class TestViews(common.IntegrationTestCase):
 
     def test_update_schemas(self):
         for model in db.Model._decl_class_registry.values():
-            print(model)
+            #print(model)
             if not hasattr(model, '__table__'):
                 continue
             self.assertGreater(model.query.count(), 0)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -31,9 +31,9 @@ def make_factory():
     class SchedBFactory(SQLAlchemyModelFactory):
         class Meta:
             sqlalchemy_session = db.session
-            model = automap.classes.sched_b
-        sched_b_sk = factory.Sequence(lambda n: n)
-        load_date = datetime.datetime.utcnow()
+            model = automap.classes.fec_vsum_sched_b
+        filing_form = '11'
+        sub_id = factory.Sequence(lambda n: n)
         rpt_yr = 2016
 
     return SchedAFactory, SchedBFactory
@@ -75,6 +75,7 @@ class TestViews(common.IntegrationTestCase):
 
     def test_update_schemas(self):
         for model in db.Model._decl_class_registry.values():
+            print(model)
             if not hasattr(model, '__table__'):
                 continue
             self.assertGreater(model.query.count(), 0)
@@ -362,6 +363,7 @@ class TestViews(common.IntegrationTestCase):
             cmte_id='C12345',
             disb_amt=538,
             disb_desc='CAMPAIGN BUTTONS',
+            filing_form='11'
         )
         db.session.commit()
         db.session.execute('select update_aggregates()')
@@ -369,6 +371,8 @@ class TestViews(common.IntegrationTestCase):
             cycle=2016,
             committee_id='C12345',
             purpose='MATERIALS',
+            # TODO: These can't be null, but maybe initialize to the correct form(s)
+            #filing_form='11'
         ).all()
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0].total, 538)

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -105,7 +105,6 @@ class TestItemized(ApiBaseTest):
         ]
         page1 = self._results(api.url_for(ScheduleAView))
         self.assertEqual(len(page1), 20)
-        #TODO: The int cast could be problematic here...why did this pass before?
         self.assertEqual(
             [int(each['sub_id']) for each in page1],
             [each.sub_id for each in filings[:20]],

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -40,7 +40,7 @@ class TestItemized(ApiBaseTest):
         self.assertEqual(
             response['pagination']['last_indexes'],
             {
-                'last_index': receipts[0].sched_a_sk,
+                'last_index': receipts[0].sub_id,
                 'last_contribution_receipt_date': receipts[0].contribution_receipt_date.isoformat(),
             }
         )
@@ -105,15 +105,16 @@ class TestItemized(ApiBaseTest):
         ]
         page1 = self._results(api.url_for(ScheduleAView))
         self.assertEqual(len(page1), 20)
+        #TODO: The int cast could be problematic here...why did this pass before?
         self.assertEqual(
-            [each['sched_a_sk'] for each in page1],
-            [each.sched_a_sk for each in filings[:20]],
+            [int(each['sub_id']) for each in page1],
+            [each.sub_id for each in filings[:20]],
         )
-        page2 = self._results(api.url_for(ScheduleAView, last_index=page1[-1]['sched_a_sk']))
+        page2 = self._results(api.url_for(ScheduleAView, last_index=page1[-1]['sub_id']))
         self.assertEqual(len(page2), 10)
         self.assertEqual(
-            [each['sched_a_sk'] for each in page2],
-            [each.sched_a_sk for each in filings[20:]],
+            [int(each['sub_id']) for each in page2],
+            [each.sub_id for each in filings[20:]],
         )
 
     def test_pagination_bad_per_page(self):

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -9,19 +9,27 @@ from .base import db
 class BaseItemized(db.Model):
     __abstract__ = True
 
+    """These weren't exposed in the API previously, although they were in the old tables
+    gonna leave uncommented until this is clarified
+
+    candidate_office = db.Column('cand_office', db.String)
+    candidate_office_description = db.Column('cand_office_desc', db.String)
+    candidate_office_district = db.Column('cand_office_district', db.String)
+    """
     committee_id = db.Column('cmte_id', db.String, doc=docs.COMMITTEE_ID)
     committee = utils.related_committee_history('committee_id', cycle_label='report_year')
     report_year = db.Column('rpt_yr', db.Integer, doc=docs.REPORT_YEAR)
     report_type = db.Column('rpt_tp', db.String, doc=docs.REPORT_TYPE)
     entity_type = db.Column('entity_tp', db.String)
-    image_number = db.Column('image_num', db.String, doc=docs.IMAGE_NUMBER)
-    memo_code = db.Column('memo_cd', db.String)
-    memo_text = db.Column(db.String)
+    entity_type_desc = db.column('entity_tp_desc', db.String)
+    election_type = db.Column('election_tp', db.String, doc=docs.ELECTION_TYPE)
+    election_type_full = db.Column('election_tp_desc', db.String, doc=docs.ELECTION_TYPE)
 
+    fec_election_type_desc = db.column('fec_election_tp_desc', db.String)
+    fec_election_year = db.column('fec_election_yr', db.String)
+    image_number = db.Column('image_num', db.String, doc=docs.IMAGE_NUMBER)
     filing_form = db.Column(db.String)
     link_id = db.Column(db.Integer)
-    sub_id = db.Column(db.Integer)
-    original_sub_id = db.Column('orig_sub_id', db.Integer)
     line_number = db.Column('line_num', db.String)
     tran_id = db.Column(db.String)
     file_number = db.Column('file_num', db.Integer)
@@ -34,9 +42,12 @@ class BaseItemized(db.Model):
 
 class ScheduleA(BaseItemized):
     __tablename__ = 'ofec_sched_a'
-    sub_id = db.Column(db.Integer, primary_key=True)
-    is_individual = db.Column(db.Boolean, index=True)
     action_cd = db.Column('action_cd', db.String)
+    action_cd_desc = db.Column('action_cd_desc', db.String)
+    back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
+    #back_reference_schedule_id = db.Column('back_ref_sched_id', db.String)
+
+    is_individual = db.Column(db.Boolean, index=True)
 
     contributor_id = db.Column('clean_contbr_id', db.String, doc=docs.CONTRIBUTOR_ID)
     contributor = db.relationship(
@@ -63,14 +74,23 @@ class ScheduleA(BaseItemized):
     contributor_aggregate_ytd = db.Column('contb_aggregate_ytd', db.Numeric(30, 2))
     contribution_receipt_date = db.Column('contb_receipt_dt', db.Date)
     contribution_receipt_amount = db.Column('contb_receipt_amt', db.Numeric(30, 2))
+    memo_code = db.Column('memo_cd', db.String)
+    memo_code_full = db.Column('memo_cd_desc', db.String)
+    memo_text = db.Column(db.String)
+    national_committee_nonfederal_account = db.Column('national_cmte_nonfed_acct', db.String)
+
     receipt_type = db.Column('receipt_tp', db.String)
     receipt_type_full = db.Column('receipt_desc', db.String)
-    election_type = db.Column('election_tp', db.String, doc=docs.ELECTION_TYPE)
-    election_type_full = db.Column('election_tp_desc', db.String, doc=docs.ELECTION_TYPE)
-    back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
-    back_reference_schedule_name = db.Column('back_ref_sched_nm', db.String)
-    national_committee_nonfederal_account = db.Column('national_cmte_nonfed_acct', db.String)
+
     increased_limit = db.Column(db.String)
+
+    sub_id = db.Column(db.Integer, primary_key=True)
+    schedule_type = db.Column('schedule_type', db.String)
+    schedule_type_full = db.Column('schedule_type_desc', db.String)
+    original_sub_id = db.Column('orig_sub_id', db.Integer)
+
+
+
 
     # Auxiliary fields
     contributor_name_text = db.Column(TSVECTOR)
@@ -80,8 +100,11 @@ class ScheduleA(BaseItemized):
 
 class ScheduleB(BaseItemized):
     __tablename__ = 'ofec_sched_b'
+    action_cd = db.Column('action_cd', db.String)
+    action_cd_desc = db.Column('action_cd_desc', db.String)
+    back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
+    back_reference_schedule_id = db.Column('back_ref_sched_id', db.String)
 
-    sched_b_sk = db.Column(db.Integer, primary_key=True)
     recipient_committee_id = db.Column('clean_recipient_cmte_id', db.String)
     recipient_committee = db.relationship(
         'CommitteeHistory',
@@ -94,33 +117,37 @@ class ScheduleB(BaseItemized):
     # Street address omitted per FEC policy
     # recipient_street_1 = db.Column('recipient_st1', db.String)
     # recipient_street_2 = db.Column('recipient_st2', db.String)
-    status = db.Column(db.String)
-    filing_type = db.Column(db.String)
     recipient_city = db.Column(db.String)
     recipient_state = db.Column('recipient_st', db.String)
     recipient_zip = db.Column(db.String)
     disbursement_type = db.Column('disb_tp', db.String)
     disbursement_description = db.Column('disb_desc', db.String)
-    disbursement_date = db.Column('disb_dt', db.Date)
+    disbursement_date = db.Column('disb_dt', db.TIMESTAMP(timezone=False))
     disbursement_amount = db.Column('disb_amt', db.Numeric(30, 2))
-    back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
-    back_reference_schedule_id = db.Column('back_ref_sched_id', db.String)
+    memo_code = db.Column('memo_cd', db.String)
+    memo_code_full = db.Column('memo_cd_desc', db.String)
+    memo_text = db.Column(db.String)
     national_committee_nonfederal_account = db.Column('national_cmte_nonfed_acct', db.String)
+
     election_type = db.Column('election_tp', db.String)
     election_type_full = db.Column('election_tp_desc', db.String)
-    record_number = db.Column('record_num', db.Integer)
-    report_primary_general = db.Column('rpt_pgi', db.String)
-    receipt_date = db.Column('receipt_dt', db.Date)
+    #record_number = db.Column('record_num', db.Integer)
+    #report_primary_general = db.Column('rpt_pgi', db.String)
+    #receipt_date = db.Column('receipt_dt', db.Date)
     beneficiary_committee_name = db.Column('benef_cmte_nm', db.String)
     semi_annual_bundled_refund = db.Column('semi_an_bundled_refund', db.Numeric(30, 2))
-    load_date = db.Column(db.DateTime)
-    update_date = db.Column(db.DateTime)
-    transaction_id = db.Column(db.Integer)
+    transaction_id = db.Column('tran_id', db.Integer)
+    original_sub_id = db.Column('orig_sub_id', db.Integer)
 
     # Auxiliary fields
     recipient_name_text = db.Column(TSVECTOR)
     disbursement_description_text = db.Column(TSVECTOR)
     disbursement_purpose_category = db.Column(db.String)
+    schedule_type = db.Column('schedule_type', db.String)
+    schedule_type_full = db.Column('schedule_type_desc', db.String)
+
+    sub_id = db.Column(db.Integer, primary_key=True)
+
 
 
 class ScheduleE(BaseItemized):
@@ -162,6 +189,7 @@ class ScheduleE(BaseItemized):
     notary_sign_name = db.Column('notary_sign_nm', db.String)
     notary_sign_date = db.Column('notary_sign_dt', db.Date)
     notary_commission_expiration_date = db.Column('notary_commission_exprtn_dt', db.Date)
+
     back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
     back_reference_schedule_name = db.Column('back_ref_sched_nm', db.String)
     receipt_date = db.Column('receipt_dt', db.Date)

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -13,21 +13,19 @@ class BaseItemized(db.Model):
     committee = utils.related_committee_history('committee_id', cycle_label='report_year')
     report_year = db.Column('rpt_yr', db.Integer, doc=docs.REPORT_YEAR)
     report_type = db.Column('rpt_tp', db.String, doc=docs.REPORT_TYPE)
-    form_type = db.Column('form_tp', db.String, doc=docs.FORM_TYPE)
+    #form_type = db.Column('form_tp', db.String, doc=docs.FORM_TYPE)
     entity_type = db.Column('entity_tp', db.String)
     image_number = db.Column('image_num', db.String, doc=docs.IMAGE_NUMBER)
     memo_code = db.Column('memo_cd', db.String)
     memo_text = db.Column(db.String)
-    filing_type = db.Column(db.String)
+
     filing_form = db.Column(db.String)
     link_id = db.Column(db.Integer)
     sub_id = db.Column(db.Integer)
     original_sub_id = db.Column('orig_sub_id', db.Integer)
-    amendment_indicator = db.Column('amndt_ind', db.String)
+    #amendment_indicator = db.Column('amndt_ind', db.String)
     line_number = db.Column('line_num', db.String)
     tran_id = db.Column(db.String)
-    transaction_id = db.Column(db.Integer)
-    status = db.Column(db.String)
     file_number = db.Column('file_num', db.Integer)
     pdf_url = db.Column(db.String)
 
@@ -38,8 +36,8 @@ class BaseItemized(db.Model):
 
 class ScheduleA(BaseItemized):
     __tablename__ = 'ofec_sched_a'
-
-    sched_a_sk = db.Column(db.Integer, primary_key=True)
+    sub_id = db.Column(db.Integer, primary_key=True)
+    #sched_a_sk = db.Column(db.Integer, primary_key=True)
     is_individual = db.Column(db.Boolean, index=True)
     contributor_id = db.Column('clean_contbr_id', db.String, doc=docs.CONTRIBUTOR_ID)
     contributor = db.relationship(
@@ -51,9 +49,9 @@ class ScheduleA(BaseItemized):
     )
     contributor_name = db.Column('contbr_nm', db.String, doc=docs.CONTRIBUTOR_NAME)
     contributor_prefix = db.Column('contbr_prefix', db.String)
-    contributor_first_name = db.Column('contbr_f_nm', db.String)
+    contributor_first_name = db.Column('contbr_nm_first', db.String)
     contributor_middle_name = db.Column('contbr_m_nm', db.String)
-    contributor_last_name = db.Column('contbr_l_nm', db.String)
+    contributor_last_name = db.Column('contbr_nm_last', db.String)
     contributor_suffix = db.Column('contbr_suffix', db.String)
     # Street address omitted per FEC policy
     # contributor_street_1 = db.Column('contbr_st1', db.String)
@@ -73,13 +71,13 @@ class ScheduleA(BaseItemized):
     back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
     back_reference_schedule_name = db.Column('back_ref_sched_nm', db.String)
     national_committee_nonfederal_account = db.Column('national_cmte_nonfed_acct', db.String)
-    record_number = db.Column('record_num', db.Integer)
-    report_primary_general = db.Column('rpt_pgi', db.String)
-    form_type_full = db.Column('form_tp_cd', db.String, doc=docs.FORM_TYPE)
-    receipt_date = db.Column('receipt_dt', db.Date, doc=docs.RECEIPT_DATE)
+    #record_number = db.Column('record_num', db.Integer)
+    #report_primary_general = db.Column('rpt_pgi', db.String)
+    #form_type_full = db.Column('form_tp_cd', db.String, doc=docs.FORM_TYPE)
+    #receipt_date = db.Column('receipt_dt', db.Date, doc=docs.RECEIPT_DATE)
     increased_limit = db.Column(db.String)
-    load_date = db.Column(db.DateTime, doc=docs.LOAD_DATE)
-    update_date = db.Column(db.DateTime, doc=docs.UPDATE_DATE)
+    #load_date = db.Column(db.DateTime, doc=docs.LOAD_DATE)
+    #update_date = db.Column(db.DateTime, doc=docs.UPDATE_DATE)
 
     # Auxiliary fields
     contributor_name_text = db.Column(TSVECTOR)
@@ -103,6 +101,8 @@ class ScheduleB(BaseItemized):
     # Street address omitted per FEC policy
     # recipient_street_1 = db.Column('recipient_st1', db.String)
     # recipient_street_2 = db.Column('recipient_st2', db.String)
+    status = db.Column(db.String)
+    filing_type = db.Column(db.String)
     recipient_city = db.Column(db.String)
     recipient_state = db.Column('recipient_st', db.String)
     recipient_zip = db.Column(db.String)
@@ -122,6 +122,7 @@ class ScheduleB(BaseItemized):
     semi_annual_bundled_refund = db.Column('semi_an_bundled_refund', db.Numeric(30, 2))
     load_date = db.Column(db.DateTime)
     update_date = db.Column(db.DateTime)
+    transaction_id = db.Column(db.Integer)
 
     # Auxiliary fields
     recipient_name_text = db.Column(TSVECTOR)

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -153,7 +153,7 @@ class ScheduleB(BaseItemized):
 class ScheduleE(BaseItemized):
     __tablename__ = 'ofec_sched_e'
 
-    sched_e_sk = db.Column(db.Integer, primary_key=True)
+    sub_id = db.Column(db.Integer, primary_key=True)
 
     committee_name = db.Column('cmte_nm', db.String, doc=docs.COMMITTEE_ID)
     payee_name = db.Column('pye_nm', db.String)
@@ -174,11 +174,11 @@ class ScheduleE(BaseItemized):
     candidate_id = db.Column('s_o_cand_id', db.String)
     candidate = utils.related_candidate_history('candidate_id', cycle_label='report_year')
     candidate_name = db.Column('s_o_cand_nm', db.String, doc=docs.CANDIDATE_NAME)
-    candidate_prefix = db.Column('s_0_cand_prefix', db.String)
-    candidate_first_name = db.Column('s_0_cand_f_nm', db.String)
-    candidate_middle_name = db.Column('s_0_cand_m_nm', db.String)
-    candidate_last_name = db.Column('s_0_cand_l_nm', db.String)
-    candidate_suffix = db.Column('s_0_cand_suffix', db.String)
+    candidate_prefix = db.Column('s_o_cand_prefix', db.String)
+    candidate_first_name = db.Column('s_o_cand_nm_first', db.String)
+    candidate_middle_name = db.Column('s_o_cand_m_nm', db.String)
+    candidate_last_name = db.Column('s_o_cand_nm_last', db.String)
+    candidate_suffix = db.Column('s_o_cand_suffix', db.String)
     candidate_office = db.Column('s_o_cand_office', db.String, doc=docs.OFFICE)
     cand_office_state = db.Column('s_o_cand_office_st', db.String, doc=docs.STATE_GENERIC)
     cand_office_district = db.Column('s_o_cand_office_district', db.String, doc=docs.DISTRICT)
@@ -192,9 +192,8 @@ class ScheduleE(BaseItemized):
 
     back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
     back_reference_schedule_name = db.Column('back_ref_sched_nm', db.String)
-    receipt_date = db.Column('receipt_dt', db.Date)
-    record_number = db.Column('record_num', db.Integer)
-    report_primary_general = db.Column('rpt_pgi', db.String)
+    #record_number = db.Column('record_num', db.Integer)
+    #report_primary_general = db.Column('rpt_pgi', db.String)
     office_total_ytd = db.Column('cal_ytd_ofc_sought', db.Float)
     category_code = db.Column('catg_cd', db.String)
     category_code_full = db.Column('catg_cd_desc', db.String)
@@ -204,8 +203,6 @@ class ScheduleE(BaseItemized):
     filer_last_name = db.Column('filer_l_nm', db.String)
     filer_suffix = db.Column(db.String)
     dissemination_date = db.Column('dissem_dt', db.Date)
-    load_date = db.Column(db.DateTime, doc=docs.LOAD_DATE)
-    update_date = db.Column(db.DateTime, doc=docs.UPDATE_DATE)
     is_notice = db.Column(db.Boolean, index=True)
 
     # Auxiliary fields

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -13,7 +13,6 @@ class BaseItemized(db.Model):
     committee = utils.related_committee_history('committee_id', cycle_label='report_year')
     report_year = db.Column('rpt_yr', db.Integer, doc=docs.REPORT_YEAR)
     report_type = db.Column('rpt_tp', db.String, doc=docs.REPORT_TYPE)
-    #form_type = db.Column('form_tp', db.String, doc=docs.FORM_TYPE)
     entity_type = db.Column('entity_tp', db.String)
     image_number = db.Column('image_num', db.String, doc=docs.IMAGE_NUMBER)
     memo_code = db.Column('memo_cd', db.String)
@@ -23,7 +22,6 @@ class BaseItemized(db.Model):
     link_id = db.Column(db.Integer)
     sub_id = db.Column(db.Integer)
     original_sub_id = db.Column('orig_sub_id', db.Integer)
-    #amendment_indicator = db.Column('amndt_ind', db.String)
     line_number = db.Column('line_num', db.String)
     tran_id = db.Column(db.String)
     file_number = db.Column('file_num', db.Integer)
@@ -37,8 +35,9 @@ class BaseItemized(db.Model):
 class ScheduleA(BaseItemized):
     __tablename__ = 'ofec_sched_a'
     sub_id = db.Column(db.Integer, primary_key=True)
-    #sched_a_sk = db.Column(db.Integer, primary_key=True)
     is_individual = db.Column(db.Boolean, index=True)
+    action_cd = db.Column('action_cd', db.String)
+
     contributor_id = db.Column('clean_contbr_id', db.String, doc=docs.CONTRIBUTOR_ID)
     contributor = db.relationship(
         'CommitteeHistory',
@@ -71,13 +70,7 @@ class ScheduleA(BaseItemized):
     back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
     back_reference_schedule_name = db.Column('back_ref_sched_nm', db.String)
     national_committee_nonfederal_account = db.Column('national_cmte_nonfed_acct', db.String)
-    #record_number = db.Column('record_num', db.Integer)
-    #report_primary_general = db.Column('rpt_pgi', db.String)
-    #form_type_full = db.Column('form_tp_cd', db.String, doc=docs.FORM_TYPE)
-    #receipt_date = db.Column('receipt_dt', db.Date, doc=docs.RECEIPT_DATE)
     increased_limit = db.Column(db.String)
-    #load_date = db.Column(db.DateTime, doc=docs.LOAD_DATE)
-    #update_date = db.Column(db.DateTime, doc=docs.UPDATE_DATE)
 
     # Auxiliary fields
     contributor_name_text = db.Column(TSVECTOR)

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -25,7 +25,7 @@ class ScheduleAView(ItemizedResource):
         return self.model.report_year
     @property
     def index_column(self):
-        return self.model.sched_a_sk
+        return self.model.sub_id
     @property
     def amount_column(self):
         return self.model.contribution_receipt_amount

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -24,7 +24,7 @@ class ScheduleBView(ItemizedResource):
         return self.model.report_year
     @property
     def index_column(self):
-        return self.model.sched_b_sk
+        return self.model.sub_id
 
     filter_multi_fields = [
         ('image_number', models.ScheduleB.image_number),

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -24,7 +24,7 @@ class ScheduleEView(ItemizedResource):
         return self.model.report_year
     @property
     def index_column(self):
-        return self.model.sched_e_sk
+        return self.model.sub_id
     @property
     def amount_column(self):
         return self.model.expenditure_amount


### PR DESCRIPTION
This is a pretty beefy pull request.  But I'll attempt at explaining the changes.

a) Changed the aggregates (prepare and update) sql to reference the new fec_vsum_sched_a table
b) Migrated test data from sched_a to fec_vsum_sched_a table in postgres using a sql insert statement (local test DB)
c) Regenerated the test data dump after this migration
d) Used this new subset to expose all breaking changes in the code using the integration tests
e) Modified the code to get all of the tests to pass

This pull request may be problematic if some fields are no longer being exposed with the new table, but from my inspection I couldn't find any.  And if anything the new table adds new columns that we aren't currently exposing (e.g. all the "desc" columns).  

Also the old sched_a table had a column named "sched_a_sk".  This was also used by us for the primary key on the "ofec_sched_a" table.  The new table uses sub_id as a primary key, therefore, any point in our code where "sched_a_sk" is referenced has been changed to "sub_id".  I think we'll need to discuss further if this key is indeed a proper unique constraint.

And finally, it's probably best to wait to merge these commits, and the upcoming sched_b table, after @ccostino finishes the partitioning task.  As this migration may affect that, we can discuss further at the sprint review.  However in the meantime if any one wants to pull this branch and check out the changes I made, and suggest feedback, we can commit changes.