### PR TITLE
Small fix to npm install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ pip install -r requirements-dev.txt
 Use npm to install JavaScript dependencies:
 
 ```
+npm install -g swagger-tools
 npm install
 ```
 


### PR DESCRIPTION
This changeset accounts for a missing installation step in the README that we accidentally removed during our cleanup.

h/t to @jontours for finding the missing step!