### PR TITLE
small definition tweak

### DIFF
--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -248,13 +248,13 @@ years so this can differ from underlying form's receipt date.
 '''
 
 TRANSACTION_YEAR = '''
-This is a derived field for storing the year a transaction took place in the
-Itemized Schedule A and Schedule B tables. In cases where we have the date of
-the transaction (contb_receipt_dt in Schedule A, disb_dt in Schedule B), we
-make use of the year in that date and adjust it to fit within the appropriate
-cycle that it belongs to. If we do not have the date, we fall back to using the
-report year (rpt_yr in both tables) instead, making the same cycle adjustment
-as necessary. This defaults to the most current cycle.
+This is a two-year period that is derived from the year a transaction took place in the
+Itemized Schedule A and Schedule B tables. In cases where we have the date of the transaction 
+(contribution_receipt_date in schedules/schedule_a, disbursement_date in schedules/schedule_b) 
+the transaction_year is named after the ending, even-numbered year. If we do not have the date 
+of the transation, we fall back to using the report year (report_year in both tables) instead, 
+making the same cycle adjustment as necessary. If no transaction year is specified, the results 
+default to the most current cycle.
 '''
 
 TOTALS = '''

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -319,7 +319,7 @@ This is [the sql function](https://github.com/18F/openFEC/blob/develop/data/func
 
 SCHEDULE_A = SCHEDULE_A_TAG + '''
 
-The data is divided in two-year periods, called `transaction_year` this is derrived from
+The data is divided in two-year periods, called `transaction_year`, which is derived from
 the `contribution_receipt_date`. If no value is supplied, the results will default to the 
 most recent two-year period that is named after the ending, even-numbered year.
 
@@ -356,7 +356,7 @@ reported as part of forms F3, F3X and F3P.
 
 SCHEDULE_B = SCHEDULE_B_TAG + '''
 
-The data is divided in two-year periods, called `transaction_year` this is derrived from
+The data is divided in two-year periods, called `transaction_year`, which is derived from
 the `disbursement_date`. If no value is supplied, the results will default to the 
 most recent two-year period that is named after the ending, even-numbered year.
 

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -319,6 +319,10 @@ This is [the sql function](https://github.com/18F/openFEC/blob/develop/data/func
 
 SCHEDULE_A = SCHEDULE_A_TAG + '''
 
+The data is divided in two-year periods, called `transaction_year` this is derrived from
+the `contribution_receipt_date`. If no value is supplied, the results will default to the 
+most recent two-year period that is named after the ending, even-numbered year.
+
 Due to the large quantity of Schedule A filings, this endpoint is not paginated by
 page number. Instead, you can request the next page of results by adding the values in
 the `last_indexes` object from `pagination` to the URL of your last request. For
@@ -351,6 +355,11 @@ reported as part of forms F3, F3X and F3P.
 '''
 
 SCHEDULE_B = SCHEDULE_B_TAG + '''
+
+The data is divided in two-year periods, called `transaction_year` this is derrived from
+the `disbursement_date`. If no value is supplied, the results will default to the 
+most recent two-year period that is named after the ending, even-numbered year.
+
 
 Due to the large quantity of Schedule B filings, this endpoint is not paginated by
 page number. Instead, you can request the next page of results by adding the values in


### PR DESCRIPTION
I wanted to emphasize that it was a two-year period, so we don't assume they already know our two year cycle construct. Also I think it is more helpful to mention the field names by what they see in the API rather than the underlying SQL tables that users don't see. 

I ran it by @emileighoutlaw too get her opinion too. 

Thanks!