### PR TITLE
Fix for flask import warning statements

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -14,8 +14,9 @@ from flask import render_template
 from flask import Flask
 from flask import Blueprint
 
-from flask.ext import cors
-from flask.ext import restful
+import flask_cors as cors
+import flask_restful as restful
+
 from raven.contrib.flask import Sentry
 from werkzeug.contrib.fixers import ProxyFix
 import sqlalchemy as sa


### PR DESCRIPTION
Fixed this problem using the "import x as z" statement, so as not to break all the references to restful and cors.  Warnings can be verified as gone by starting up the api server.