### PR TITLE
[DON'T MERGE YET] Rename transaction_year field

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -161,7 +161,7 @@ class ScheduleAFactory(BaseFactory):
     sched_a_sk = factory.Sequence(lambda n: n)
     sub_id = factory.Sequence(lambda n: n)
     report_year = 2016
-    transaction_year = 2016
+    two_year_transaction_period = 2016
 
     @factory.post_generation
     def update_fulltext(obj, create, extracted, **kwargs):
@@ -176,7 +176,7 @@ class ScheduleBFactory(BaseFactory):
     sched_b_sk = factory.Sequence(lambda n: n)
     load_date = datetime.datetime.utcnow()
     report_year = 2016
-    transaction_year = 2016
+    two_year_transaction_period = 2016
 
     @factory.post_generation
     def update_fulltext(obj, create, extracted, **kwargs):

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -32,12 +32,12 @@ class TestItemized(ApiBaseTest):
             factories.ScheduleAFactory(
                 report_year=2016,
                 contribution_receipt_date=datetime.date(2016, 1, 1),
-                transaction_year=2016
+                two_year_transaction_period=2016
             ),
             factories.ScheduleAFactory(
                 report_year=2015,
                 contribution_receipt_date=datetime.date(2015, 1, 1),
-                transaction_year=2016
+                two_year_transaction_period=2016
             ),
         ]
         response = self._response(api.url_for(ScheduleAView, sort='contribution_receipt_date'))
@@ -53,38 +53,40 @@ class TestItemized(ApiBaseTest):
             }
         )
 
-    def test_transaction_year_default_supplied_automatically(self):
+    def test_two_year_transaction_period_default_supplied_automatically(self):
         receipts = [
             factories.ScheduleAFactory(
                 report_year=2014,
                 contribution_receipt_date=datetime.date(2014, 1, 1),
-                transaction_year=2014
+                two_year_transaction_period=2014
             ),
             factories.ScheduleAFactory(
                 report_year=2016,
                 contribution_receipt_date=datetime.date(2016, 1, 1),
-                transaction_year=2016
+                two_year_transaction_period=2016
             ),
         ]
 
         response = self._response(api.url_for(ScheduleAView))
         self.assertEqual(len(response['results']), 1)
 
-    def test_transaction_year_limits_results_per_cycle(self):
+    def test_two_year_transaction_period_limits_results_per_cycle(self):
         receipts = [
             factories.ScheduleAFactory(
                 report_year=2014,
                 contribution_receipt_date=datetime.date(2014, 1, 1),
-                transaction_year=2014
+                two_year_transaction_period=2014
             ),
             factories.ScheduleAFactory(
                 report_year=2012,
                 contribution_receipt_date=datetime.date(2012, 1, 1),
-                transaction_year=2012
+                two_year_transaction_period=2012
             ),
         ]
 
-        response = self._response(api.url_for(ScheduleAView, transaction_year=2014))
+        response = self._response(
+            api.url_for(ScheduleAView, two_year_transaction_period=2014)
+        )
         self.assertEqual(len(response['results']), 1)
 
     def test_sorting_bad_column(self):

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -328,8 +328,8 @@ schedule_a = {
         fields.Str(validate=validate.OneOf(['individual', 'committee'])),
         description='Filters individual or committee contributions based on line number'
     ),
-    'transaction_year': fields.Int(
-        description=docs.TRANSACTION_YEAR,
+    'two_year_transaction_period': fields.Int(
+        description=docs.TWO_YEAR_TRANSACTION_PERIOD,
         required=True,
         missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
     ),
@@ -387,8 +387,8 @@ schedule_b = {
     'disbursement_purpose_category': fields.List(IStr, description='Disbursement purpose category'),
     'last_disbursement_date': fields.Date(missing=None, description='When sorting by `disbursement_date`, use the `disbursement_date` of the last result and pass it here as `last_disbursement_date` to page through Schedule B data. You’ll also need to pass the index of that last result to `last_index` to get the next page.'),
     'last_disbursement_amount': fields.Float(missing=None, description='When sorting by `disbursement_amount`, use the `disbursement_amount` of the last result and pass it here as `last_disbursement_amount` to page through Schedule B data. You’ll also need to pass the index of that last result to `last_index` to get the next page.'),
-    'transaction_year': fields.Int(
-        description=docs.TRANSACTION_YEAR,
+    'two_year_transaction_period': fields.Int(
+        description=docs.TWO_YEAR_TRANSACTION_PERIOD,
         required=True,
         missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
     ),

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -80,7 +80,7 @@ class ScheduleA(BaseItemized):
     increased_limit = db.Column(db.String)
     load_date = db.Column(db.DateTime, doc=docs.LOAD_DATE)
     update_date = db.Column(db.DateTime, doc=docs.UPDATE_DATE)
-    transaction_year = db.Column(db.SmallInteger, doc=docs.TRANSACTION_YEAR)
+    two_year_transaction_period = db.Column(db.SmallInteger, doc=docs.TWO_YEAR_TRANSACTION_PERIOD)
 
     # Auxiliary fields
     contributor_name_text = db.Column(TSVECTOR)
@@ -123,7 +123,7 @@ class ScheduleB(BaseItemized):
     semi_annual_bundled_refund = db.Column('semi_an_bundled_refund', db.Numeric(30, 2))
     load_date = db.Column(db.DateTime)
     update_date = db.Column(db.DateTime)
-    transaction_year = db.Column(db.SmallInteger, doc=docs.TRANSACTION_YEAR)
+    two_year_transaction_period = db.Column(db.SmallInteger, doc=docs.TWO_YEAR_TRANSACTION_PERIOD)
 
     # Auxiliary fields
     recipient_name_text = db.Column(TSVECTOR)

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -247,14 +247,14 @@ Year that the record applies to. Sometimes records are amended in subsequent
 years so this can differ from underlying form's receipt date.
 '''
 
-TRANSACTION_YEAR = '''
+TWO_YEAR_TRANSACTION_PERIOD = '''
 This is a two-year period that is derived from the year a transaction took place in the
-Itemized Schedule A and Schedule B tables. In cases where we have the date of the transaction 
-(contribution_receipt_date in schedules/schedule_a, disbursement_date in schedules/schedule_b) 
-the transaction_year is named after the ending, even-numbered year. If we do not have the date 
-of the transation, we fall back to using the report year (report_year in both tables) instead, 
-making the same cycle adjustment as necessary. If no transaction year is specified, the results 
-default to the most current cycle.
+Itemized Schedule A and Schedule B tables. In cases where we have the date of the transaction
+(contribution_receipt_date in schedules/schedule_a, disbursement_date in schedules/schedule_b)
+the two_year_transaction_period is named after the ending, even-numbered year. If we do not
+have the date  of the transation, we fall back to using the report year (report_year in both
+tables) instead,  making the same cycle adjustment as necessary. If no transaction year is
+specified, the results default to the most current cycle.
 '''
 
 TOTALS = '''
@@ -319,9 +319,10 @@ This is [the sql function](https://github.com/18F/openFEC/blob/develop/data/func
 
 SCHEDULE_A = SCHEDULE_A_TAG + '''
 
-The data is divided in two-year periods, called `transaction_year`, which is derived from
-the `contribution_receipt_date`. If no value is supplied, the results will default to the 
-most recent two-year period that is named after the ending, even-numbered year.
+The data is divided in two-year periods, called `two_year_transaction_period`, which
+is derived from the `contribution_receipt_date`. If no value is supplied, the results
+will default to the most recent two-year period that is named after the ending,
+even-numbered year.
 
 Due to the large quantity of Schedule A filings, this endpoint is not paginated by
 page number. Instead, you can request the next page of results by adding the values in
@@ -356,9 +357,10 @@ reported as part of forms F3, F3X and F3P.
 
 SCHEDULE_B = SCHEDULE_B_TAG + '''
 
-The data is divided in two-year periods, called `transaction_year`, which is derived from
-the `disbursement_date`. If no value is supplied, the results will default to the 
-most recent two-year period that is named after the ending, even-numbered year.
+The data is divided in two-year periods, called `two_year_transaction_period`, which
+is derived from the `disbursement_date`. If no value is supplied, the results will
+default to the most recent two-year period that is named after the ending,
+even-numbered year.
 
 
 Due to the large quantity of Schedule B filings, this endpoint is not paginated by

--- a/webservices/partition/base.py
+++ b/webservices/partition/base.py
@@ -106,7 +106,7 @@ class TableGroup:
         cmds = [
             'alter table {child} alter column {primary} set not null',
             'alter table {child} alter column load_date set not null',
-            'alter table {child} add constraint check_transaction_year check (transaction_year in ({start}, {stop}))',
+            'alter table {child} add constraint check_two_year_transaction_period check (two_year_transaction_period in ({start}, {stop}))',  # noqa
             'alter table {child} inherit {master}'
         ]
         params = {

--- a/webservices/partition/sched_a.py
+++ b/webservices/partition/sched_a.py
@@ -21,7 +21,7 @@ class SchedAGroup(TableGroup):
         sa.Column('contributor_occupation_text', TSVECTOR),
         sa.Column('is_individual', sa.Boolean),
         sa.Column('clean_contbr_id', sa.String),
-        sa.Column('transaction_year', sa.SmallInteger),
+        sa.Column('two_year_transaction_period', sa.SmallInteger),
     ]
 
     @classmethod
@@ -45,7 +45,7 @@ class SchedAGroup(TableGroup):
             sa.func.get_transaction_year(
                 parent.c[cls.transaction_date_column],
                 parent.c.rpt_yr
-            ).label('transaction_year'),
+            ).label('two_year_transaction_period'),
         ]
 
     @classmethod
@@ -60,7 +60,7 @@ class SchedAGroup(TableGroup):
             sa.Index(None, c.contbr_city),
             sa.Index(None, c.is_individual),
             sa.Index(None, c.clean_contbr_id),
-            sa.Index(None, c.transaction_year),
+            sa.Index(None, c.two_year_transaction_period),
 
             sa.Index(None, c.contb_receipt_amt, child.c[cls.primary]),
             sa.Index(None, c.contb_receipt_dt, child.c[cls.primary]),

--- a/webservices/partition/sched_b.py
+++ b/webservices/partition/sched_b.py
@@ -20,7 +20,7 @@ class SchedBGroup(TableGroup):
         sa.Column('disbursement_description_text', TSVECTOR),
         sa.Column('disbursement_purpose_category', sa.String),
         sa.Column('clean_recipient_cmte_id', sa.String),
-        sa.Column('transaction_year', sa.SmallInteger),
+        sa.Column('two_year_transaction_period', sa.SmallInteger),
     ]
 
     @classmethod
@@ -40,7 +40,7 @@ class SchedBGroup(TableGroup):
             sa.func.get_transaction_year(
                 parent.c[cls.transaction_date_column],
                 parent.c.rpt_yr
-            ).label('transaction_year'),
+            ).label('two_year_transaction_period'),
         ]
 
     @classmethod
@@ -53,7 +53,7 @@ class SchedBGroup(TableGroup):
             sa.Index(None, c.recipient_st),
             sa.Index(None, c.recipient_city),
             sa.Index(None, c.clean_recipient_cmte_id),
-            sa.Index(None, c.transaction_year),
+            sa.Index(None, c.two_year_transaction_period),
 
             sa.Index(None, c.disb_dt, c[cls.primary]),
             sa.Index(None, c.disb_amt, c[cls.primary]),

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -22,7 +22,7 @@ class ScheduleAView(ItemizedResource):
 
     @property
     def year_column(self):
-        return self.model.transaction_year
+        return self.model.two_year_transaction_period
     @property
     def index_column(self):
         return self.model.sched_a_sk
@@ -39,7 +39,7 @@ class ScheduleAView(ItemizedResource):
     ]
     filter_match_fields = [
         ('is_individual', models.ScheduleA.is_individual),
-        ('transaction_year', models.ScheduleA.transaction_year),
+        ('two_year_transaction_period', models.ScheduleA.two_year_transaction_period),
     ]
     filter_range_fields = [
         (('min_date', 'max_date'), models.ScheduleA.contribution_receipt_date),

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -21,7 +21,7 @@ class ScheduleBView(ItemizedResource):
 
     @property
     def year_column(self):
-        return self.model.transaction_year
+        return self.model.two_year_transaction_period
     @property
     def index_column(self):
         return self.model.sched_b_sk
@@ -35,7 +35,7 @@ class ScheduleBView(ItemizedResource):
         ('disbursement_purpose_category', models.ScheduleB.disbursement_purpose_category),
     ]
     filter_match_fields = [
-        ('transaction_year', models.ScheduleB.transaction_year),
+        ('two_year_transaction_period', models.ScheduleB.two_year_transaction_period),
     ]
     filter_fulltext_fields = [
         ('recipient_name', models.ScheduleB.recipient_name_text),


### PR DESCRIPTION
**DON'T MERGE YET**

Part of #1735

This changeset renames the field we originally went with for partitioning the itemized schedule A and B tables. We had received feedback that `transaction_year` was a bit confusing and have decided to go with `two_year_transaction_period` instead to be more descriptive of what this value represents.

/cc @LindsayYoung, @jontours