### PR TITLE
Address itemized downloads feedback

### DIFF
--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -250,7 +250,6 @@ ScheduleASchema = make_schema(
     },
     options={
         'exclude': (
-            'memo_code',
             'contributor_name_text',
             'contributor_employer_text',
             'contributor_occupation_text',
@@ -317,7 +316,6 @@ ScheduleBSchema = make_schema(
     },
     options={
         'exclude': (
-            'memo_code',
             'recipient_name_text',
             'disbursement_description_text'
         ),

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -108,7 +108,7 @@ def upload_s3(key, body):
 
 def make_manifest(resource, row_count, path):
     with open(os.path.join(path, 'manifest.txt'), 'w') as fp:
-        fp.write('Time: {}\n'.format(resource['timestamp']))
+        fp.write('Time: {} (UTC)\n'.format(resource['timestamp']))
         fp.write('Resource: {}\n'.format(resource['path']))
         fp.write('*Count: {}\n'.format(row_count))
         fp.write('Filters:\n\n')


### PR DESCRIPTION
This changeset addresses a few things that were flagged as needing to be changed based on the recent feedback we received.  These changes include the following:

* Enabling the display of the Memo Code field (memo_cd in the database) in the CSV output (this has the side effect of displaying it in the API as well)
* Displaying the time zone label with the timestamp given in the manifest (the timestamp is processed as UTC).

These modifications are a part of the full list in https://github.com/18F/openFEC/issues/1748

/cc @LindsayYoung, @jontours, @noahmanger