### PR TITLE
Adding back the committee id into the tsvector for recipient name

### DIFF
--- a/webservices/partition/sched_a.py
+++ b/webservices/partition/sched_a.py
@@ -28,7 +28,9 @@ class SchedAGroup(TableGroup):
     def column_factory(cls, parent):
         return [
             sa.func.image_pdf_url(parent.c.image_num).label('pdf_url'),
-            sa.func.to_tsvector(parent.c.contbr_nm).label('contributor_name_text'),
+            sa.func.to_tsvector(
+                sa.func.concat(parent.c.contbr_nm, ' ', parent.c.contbr_id),
+            ).label('contributor_name_text'),
             sa.func.to_tsvector(parent.c.contbr_employer).label('contributor_employer_text'),
             sa.func.to_tsvector(parent.c.contbr_occupation).label('contributor_occupation_text'),
             sa.func.is_individual(

--- a/webservices/partition/sched_b.py
+++ b/webservices/partition/sched_b.py
@@ -27,7 +27,9 @@ class SchedBGroup(TableGroup):
     def column_factory(cls, parent):
         return [
             sa.func.image_pdf_url(parent.c.image_num).label('pdf_url'),
-            sa.func.to_tsvector(parent.c.recipient_nm).label('recipient_name_text'),
+            sa.func.to_tsvector(
+                sa.func.concat(parent.c.recipient_nm, ' ', parent.c.recipient_cmte_id),
+            ).label('recipient_name_text'),
             sa.func.to_tsvector(parent.c.disb_desc).label('disbursement_description_text'),
             sa.func.disbursement_purpose(
                 parent.c.disb_tp,


### PR DESCRIPTION
closes #1756

This makes sure that you can find a recipient by ID if we have it.

I started writing a test, but it just checked that I setup the factory correctly, so I have nixed it. Tell me if you have a better idea for testing this.