### PR TITLE
Fix Schedule A and B updates

### DIFF
--- a/data/sql_setup/prepare_schedule_b.sql
+++ b/data/sql_setup/prepare_schedule_b.sql
@@ -8,34 +8,43 @@ create table ofec_sched_b_queue_new as select * from sched_b limit 0;
 create table ofec_sched_b_queue_old as select * from sched_b limit 0;
 alter table ofec_sched_b_queue_new add column timestamp timestamp;
 alter table ofec_sched_b_queue_old add column timestamp timestamp;
+alter table ofec_sched_b_queue_new add column two_year_transaction_period smallint;
+alter table ofec_sched_b_queue_old add column two_year_transaction_period smallint;
 create index on ofec_sched_b_queue_new (sched_b_sk);
 create index on ofec_sched_b_queue_old (sched_b_sk);
 create index on ofec_sched_b_queue_new (timestamp);
 create index on ofec_sched_b_queue_old (timestamp);
+create index on ofec_sched_b_queue_new (two_year_transaction_period);
+create index on ofec_sched_b_queue_old (two_year_transaction_period);
 
 -- Create trigger to maintain Schedule B queues
 create or replace function ofec_sched_b_update_queues() returns trigger as $$
 declare
     start_year int = TG_ARGV[0]::int;
+    two_year_transaction_period_new smallint;
+    two_year_transaction_period_old smallint;
 begin
+    two_year_transaction_period_new = get_transaction_year(new.disb_dt, new.rpt_yr);
+    two_year_transaction_period_old = get_transaction_year(old.disb_dt, old.rpt_yr);
+
     if tg_op = 'INSERT' then
-        if new.rpt_yr >= start_year then
+        if two_year_transaction_period_new >= start_year then
             delete from ofec_sched_b_queue_new where sched_b_sk = new.sched_b_sk;
             insert into ofec_sched_b_queue_new values (new.*);
         end if;
         return new;
     elsif tg_op = 'UPDATE' then
-        if new.rpt_yr >= start_year then
+        if two_year_transaction_period_new >= start_year then
             delete from ofec_sched_b_queue_new where sched_b_sk = new.sched_b_sk;
             delete from ofec_sched_b_queue_old where sched_b_sk = old.sched_b_sk;
-            insert into ofec_sched_b_queue_new values (new.*);
-            insert into ofec_sched_b_queue_old values (old.*);
+            insert into ofec_sched_b_queue_new values (new.*, timestamp, two_year_transaction_period_new);
+            insert into ofec_sched_b_queue_old values (old.*, timestamp, two_year_transaction_period_old);
         end if;
         return new;
     elsif tg_op = 'DELETE' then
-        if old.rpt_yr >= start_year then
+        if two_year_transaction_period_old >= start_year then
             delete from ofec_sched_b_queue_old where sched_b_sk = old.sched_b_sk;
-            insert into ofec_sched_b_queue_old values (old.*);
+            insert into ofec_sched_b_queue_old values (old.*, timestamp, two_year_transaction_period_old);
         end if;
         return old;
     end if;

--- a/webservices/partition/base.py
+++ b/webservices/partition/base.py
@@ -158,8 +158,19 @@ class TableGroup:
         delete = sa.delete(child).where(child.c.get(cls.primary).in_(select))
         db.engine.execute(delete)
 
+        # The queue tables already have the two_year_transaction_period column
+        # set in them so that we can insert the records into the proper child
+        # table. Because of this, we need to exclude the function call in the
+        # column factory normally used when populating the child tables during
+        # normal partitioning. Otherwise, an error is thrown due more values
+        # being specified than there are columns to accept them.
+        columns = [
+            column for column in cls.column_factory(queue_new)
+            if column.name != 'two_year_transaction_period'
+        ]
+
         select = sa.select(
-            queue_new.columns + cls.column_factory(queue_new)
+            queue_new.columns + columns
         ).select_from(
             queue_new.join(
                 queue_old,
@@ -170,7 +181,7 @@ class TableGroup:
                 isouter=True,
             )
         ).where(
-            queue_new.c.rpt_yr.in_([start, stop])
+            queue_new.c.two_year_transaction_period.in_([start, stop])
         ).where(
             queue_old.c.get(cls.primary) == None  # noqa
         ).distinct(


### PR DESCRIPTION
Addresses #1760 

This changeset addresses an issue with failing updates for the Schedule A and B tables.  The update process did not take into account the table partitioning and was still basing the checks off of the report year (`rpt_yr`) instead of the new calculated value (`two_year_transaction_period`).  In order to fix this, I had to do the following:

* Add the `two_year_transaction_period` column to both sets of queue tables for Schedule A and B.
* Remove the `two_year_transaction_period` column from the column factory in the select statement generation for processing updates.
* Add full support for the `timestamp` column in the Schedule B queue tables.

I do not believe this is entirely straightforward so there is a comment in the code that refreshes the child tables during an update process to help explain the reasoning behind what is happening.

h/t to @LindsayYoung for working through the approach with me!

/cc @LindsayYoung, @jontours