### PR TITLE
Add flags to JSON returned by candidate/totals endpoint.

### DIFF
--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -208,6 +208,9 @@ class TestCandidateAggregates(ApiBaseTest):
             is_election=False,
             receipts=75,
         )
+        factories.CandidateFlagsFactory(
+            candidate_id = self.candidate.candidate_id
+        )
         db.session.flush()
         # Create two-year totals for both the target period (2011-2012) and the
         # previous period (2009-2010) for testing the `election_full` flag
@@ -310,6 +313,7 @@ class TestCandidateAggregates(ApiBaseTest):
         assert_dicts_subset(results[0], {'cycle': 2012, 'receipts': 75})
 
     def test_totals_full(self):
+        print(self.candidate.candidate_id)
         results = self._results(
             api.url_for(
                 TotalsCandidateView,

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -166,6 +166,12 @@ class TotalsCandidateView(ApiResource):
                 history.candidate_id == models.CandidateTotal.candidate_id,
                 year_column == models.CandidateTotal.cycle,
             )
+        ).join(
+            models.Candidate,
+            history.candidate_id == models.Candidate.candidate_id,
+        ).join(
+            models.CandidateFlags,
+            history.candidate_id == models.CandidateFlags.candidate_id,
         ).filter(
             models.CandidateTotal.is_election == kwargs['election_full'],
         )
@@ -175,11 +181,13 @@ class TotalsCandidateView(ApiResource):
                 history.candidate_id == models.CandidateSearch.id,
             )
         #The .filter methods may be able to moved to the filters methods, will investigate
+        """
         if kwargs.get('has_raised_funds') or kwargs.get('federal_funds_flag'):
             query = query.join(
                 models.Candidate,
                 history.candidate_id == models.Candidate.candidate_id,
             )
+        """
         if kwargs.get('has_raised_funds'):
             query = query.filter(
                 models.Candidate.flags.has(models.CandidateFlags.has_raised_funds == kwargs['has_raised_funds'])

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -161,11 +161,9 @@ class TotalsCandidateView(ApiResource):
         if kwargs['election_full']:
             history = models.CandidateHistoryLatest
             year_column = history.cand_election_year
-            #sa.orm.joinedload(history.flags)
         else:
             history = models.CandidateHistory
             year_column = history.two_year_period
-            #sa.orm.joinedload(history.flags)
         query = db.session.query(
             history.__table__,
             models.CandidateTotal.__table__,
@@ -192,12 +190,6 @@ class TotalsCandidateView(ApiResource):
             )
         #The .filter methods may be able to moved to the filters methods, will investigate
 
-        """if kwargs.get('has_raised_funds') or kwargs.get('federal_funds_flag'):
-            query = query.join(
-                models.Candidate,
-                history.candidate_id == models.Candidate.candidate_id,
-            )
-        """
         if kwargs.get('has_raised_funds'):
             query = query.filter(
                 models.Candidate.flags.has(models.CandidateFlags.has_raised_funds == kwargs['has_raised_funds'])
@@ -209,8 +201,6 @@ class TotalsCandidateView(ApiResource):
         query = filters.filter_multi(query, kwargs, self.filter_multi_fields(history, models.CandidateTotal))
         query = filters.filter_range(query, kwargs, self.filter_range_fields(models.CandidateTotal))
         query = filters.filter_fulltext(query, kwargs, self.filter_fulltext_fields)
-        queryString = self.compile_query(query)
-        print(queryString)
         return query
 
     """
@@ -218,7 +208,7 @@ class TotalsCandidateView(ApiResource):
         why totals were missing the flags.  They were missing from the sql select statement.
         Referenced from here:
         http://stackoverflow.com/questions/4617291/how-do-i-get-a-raw-compiled-sql-query-from-a-sqlalchemy-expression
-    """
+
     def compile_query(self,query):
         dialect = query.session.bind.dialect
         statement = query.statement
@@ -231,4 +221,5 @@ class TotalsCandidateView(ApiResource):
                 v = v.encode(enc)
             params[k] = sqlescape(v)
         return (comp.string.encode(enc) % params).decode(enc)
+    """
 

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -1,10 +1,4 @@
 import sqlalchemy as sa
-"""
-For debugging
-vvvvvvvvvvvvv
-"""
-from sqlalchemy.sql import compiler
-from psycopg2.extensions import adapt as sqlescape
 
 from flask_apispec import doc, marshal_with
 
@@ -203,23 +197,4 @@ class TotalsCandidateView(ApiResource):
         query = filters.filter_fulltext(query, kwargs, self.filter_fulltext_fields)
         return query
 
-    """
-        Helper method that prints out what the actual SQL query is, I had problems figuring out
-        why totals were missing the flags.  They were missing from the sql select statement.
-        Referenced from here:
-        http://stackoverflow.com/questions/4617291/how-do-i-get-a-raw-compiled-sql-query-from-a-sqlalchemy-expression
-
-    def compile_query(self,query):
-        dialect = query.session.bind.dialect
-        statement = query.statement
-        comp = compiler.SQLCompiler(dialect, statement)
-        comp.compile()
-        enc = dialect.encoding
-        params = {}
-        for k, v in comp.params.items():
-            if isinstance(v, unicode):
-                v = v.encode(enc)
-            params[k] = sqlescape(v)
-        return (comp.string.encode(enc) % params).decode(enc)
-    """
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -140,7 +140,7 @@ augment_models(
 
 make_candidate_schema = functools.partial(
     make_schema,
-    options={'exclude': ('idx', 'principal_committees', 'flags')},
+    options={'exclude': ('idx', 'principal_committees')},
     fields={
         'federal_funds_flag': ma.fields.Boolean(attribute='flags.federal_funds_flag'),
         'has_raised_funds': ma.fields.Boolean(attribute='flags.has_raised_funds'),
@@ -151,11 +151,17 @@ augment_models(
     make_candidate_schema,
     models.Candidate,
     models.CandidateDetail,
-    models.CandidateHistory,
-    models.CandidateTotal
-)
 
-class CandidateHistoryTotalSchema(schemas['CandidateHistorySchema'], schemas['CandidateTotalSchema']):
+)
+#built these schemas without make_candidate_schema, as it was filtering out the flags
+augment_models(
+    make_schema,
+    models.CandidateHistory,
+    models.CandidateTotal,
+    models.CandidateFlags
+
+)
+class CandidateHistoryTotalSchema(schemas['CandidateHistorySchema'], schemas['CandidateTotalSchema'],schemas['CandidateFlagsSchema']):
     pass
 
 CandidateHistoryTotalPageSchema = make_page_schema(CandidateHistoryTotalSchema)

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -152,7 +152,7 @@ augment_models(
     models.Candidate,
     models.CandidateDetail,
     models.CandidateHistory,
-    models.CandidateTotal,
+    models.CandidateTotal
 )
 
 class CandidateHistoryTotalSchema(schemas['CandidateHistorySchema'], schemas['CandidateTotalSchema']):


### PR DESCRIPTION
Related to this PR: https://github.com/18F/openFEC-web-app/pull/1295.  The flags are now present on the totals/candidate endpoint.  At the end of the day it was a fairly easy fix, it helps to dig into SqlAlchemy and see what query is actually being ran against the database.  Ready for review and merge.