### PR TITLE
Feature/build swagger on ci

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/cloudfoundry/python-buildpack#v1.5.1
-https://github.com/cloudfoundry/nodejs-buildpack.git#v1.5.0

--- a/.cfignore
+++ b/.cfignore
@@ -1,5 +1,4 @@
 cache
-node_modules
 
 .DS_Store
 

--- a/.cfignore
+++ b/.cfignore
@@ -1,4 +1,5 @@
 cache
+node_modules/
 
 .DS_Store
 
@@ -58,3 +59,6 @@ target/
 
 # PG dumps, DDL, etc.
 data/subset.dump
+
+# DO include the swagger-ui dist dir
+!/static/swagger-ui/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,3 @@ docs/_build/
 
 # PyBuilder
 target/
-
-# CloudFoundry
-cf-ssh.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_deploy:
   - tar xzvf $HOME/cf.tgz -C $HOME
   - travis_retry cf install-plugin autopilot -f -r CF-Community
   - npm install
+  - npm run build
 
 deploy:
   provider: script

--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -2,7 +2,7 @@
 path: .
 memory: 1G
 stack: cflinuxfs2
-buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
+buildpack: python_buildpack
 domain: 18f.gov
 env:
   NEW_RELIC_CONFIG_FILE: newrelic.ini

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "dependencies": {
      "swagger-ui": "git+https://github.com/18F/swagger-ui.git"
   },
+  "scripts": {
+    "build": "mkdir -p static/swagger-ui && cp -R node_modules/swagger-ui/dist static/swagger-ui/"
+  },
   "engines": {
     "node": "0.12.7",
     "npm": "2.11.3"

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -275,7 +275,7 @@ here, _ = os.path.split(__file__)
 docs = Blueprint(
     'docs',
     __name__,
-    static_folder=os.path.join(here, os.pardir, 'node_modules', 'swagger-ui', 'dist'),
+    static_folder=os.path.join(here, os.pardir, 'static', 'swagger-ui', 'dist'),
     static_url_path='/docs/static',
 )
 


### PR DESCRIPTION
This get's us off of the multibuildpack which is deprecated. Thanks to @jmcarp for getting most of it done. The last piece is getting swagger-ui out of node_modules so we're not shipping any dev dependencies to cloud.gov. This reverts the last fix which saved us from a broken swagger docs page and adds a quick build step to pull the built swagger-ui assets out of `node_modules`.

I tested this via [travis](https://travis-ci.org/18F/openFEC/builds/143403613) on the feature space, so hopefully there's no more surprises.

Fixes #1770 