### PR TITLE
Adjust aggregate table processing to make use of temporary tables

### DIFF
--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_employer.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_employer.sql
@@ -1,6 +1,6 @@
 -- Create initial aggregate
-drop table if exists ofec_sched_a_aggregate_employer;
-create table ofec_sched_a_aggregate_employer as
+drop table if exists ofec_sched_a_aggregate_employer_tmp;
+create table ofec_sched_a_aggregate_employer_tmp as
 select
     cmte_id,
     rpt_yr + rpt_yr % 2 as cycle,
@@ -14,14 +14,18 @@ and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
 group by cmte_id, cycle, employer
 ;
 
-alter table ofec_sched_a_aggregate_employer add column idx serial primary key;
+alter table ofec_sched_a_aggregate_employer_tmp add column idx serial primary key;
 
 -- Create indices on aggregate
-create index on ofec_sched_a_aggregate_employer (cmte_id, idx);
-create index on ofec_sched_a_aggregate_employer (cycle, idx);
-create index on ofec_sched_a_aggregate_employer (employer, idx);
-create index on ofec_sched_a_aggregate_employer (total, idx);
-create index on ofec_sched_a_aggregate_employer (count, idx);
+create index on ofec_sched_a_aggregate_employer_tmp (cmte_id, idx);
+create index on ofec_sched_a_aggregate_employer_tmp (cycle, idx);
+create index on ofec_sched_a_aggregate_employer_tmp (employer, idx);
+create index on ofec_sched_a_aggregate_employer_tmp (total, idx);
+create index on ofec_sched_a_aggregate_employer_tmp (count, idx);
+
+-- Remove previous aggregate and rename new aggregate
+drop table if exists ofec_sched_a_aggregate_employer;
+alter table ofec_sched_a_aggregate_employer_tmp rename to ofec_sched_a_aggregate_employer;
 
 -- Create update function
 create or replace function ofec_sched_a_update_aggregate_employer() returns void as $$

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_occupation.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_occupation.sql
@@ -1,6 +1,6 @@
 -- Create initial aggregate
-drop table if exists ofec_sched_a_aggregate_occupation;
-create table ofec_sched_a_aggregate_occupation as
+drop table if exists ofec_sched_a_aggregate_occupation_tmp;
+create table ofec_sched_a_aggregate_occupation_tmp as
 select
     cmte_id,
     rpt_yr + rpt_yr % 2 as cycle,
@@ -14,14 +14,18 @@ and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
 group by cmte_id, cycle, occupation
 ;
 
-alter table ofec_sched_a_aggregate_occupation add column idx serial primary key;
+alter table ofec_sched_a_aggregate_occupation_tmp add column idx serial primary key;
 
 -- Create indices on aggregate
-create index on ofec_sched_a_aggregate_occupation (cmte_id, idx);
-create index on ofec_sched_a_aggregate_occupation (cycle, idx);
-create index on ofec_sched_a_aggregate_occupation (occupation, idx);
-create index on ofec_sched_a_aggregate_occupation (total, idx);
-create index on ofec_sched_a_aggregate_occupation (count, idx);
+create index on ofec_sched_a_aggregate_occupation_tmp (cmte_id, idx);
+create index on ofec_sched_a_aggregate_occupation_tmp (cycle, idx);
+create index on ofec_sched_a_aggregate_occupation_tmp (occupation, idx);
+create index on ofec_sched_a_aggregate_occupation_tmp (total, idx);
+create index on ofec_sched_a_aggregate_occupation_tmp (count, idx);
+
+-- Remove previous aggregate and rename new aggregate
+drop table if exists ofec_sched_a_aggregate_occupation;
+alter table ofec_sched_a_aggregate_occupation_tmp rename to ofec_sched_a_aggregate_occupation;
 
 -- Create update function
 create or replace function ofec_sched_a_update_aggregate_occupation() returns void as $$

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
@@ -11,8 +11,8 @@ end
 $$ language plpgsql;
 
 -- Create initial aggregate
-drop table if exists ofec_sched_a_aggregate_size cascade;
-create table ofec_sched_a_aggregate_size as
+drop table if exists ofec_sched_a_aggregate_size_tmp cascade;
+create table ofec_sched_a_aggregate_size_tmp as
 select
     cmte_id,
     rpt_yr + rpt_yr % 2 as cycle,
@@ -27,11 +27,15 @@ group by cmte_id, cycle, size
 ;
 
 -- Create indices on aggregate
-create index on ofec_sched_a_aggregate_size (cmte_id);
-create index on ofec_sched_a_aggregate_size (cycle);
-create index on ofec_sched_a_aggregate_size (size);
-create index on ofec_sched_a_aggregate_size (total);
-create index on ofec_sched_a_aggregate_size (count);
+create index on ofec_sched_a_aggregate_size_tmp (cmte_id);
+create index on ofec_sched_a_aggregate_size_tmp (cycle);
+create index on ofec_sched_a_aggregate_size_tmp (size);
+create index on ofec_sched_a_aggregate_size_tmp (total);
+create index on ofec_sched_a_aggregate_size_tmp (count);
+
+-- Remove previous aggregate and rename new aggregate
+drop table if exists ofec_sched_a_aggregate_size cascade;
+alter table ofec_sched_a_aggregate_size_tmp rename to ofec_sched_a_aggregate_size;
 
 -- Create update function
 create or replace function ofec_sched_a_update_aggregate_size() returns void as $$

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
@@ -34,7 +34,10 @@ create index on ofec_sched_a_aggregate_size_tmp (total);
 create index on ofec_sched_a_aggregate_size_tmp (count);
 
 -- Remove previous aggregate and rename new aggregate
-drop table if exists ofec_sched_a_aggregate_size cascade;
+-- ofec_sched_a_aggregate_size_old is removed when the dependent materialized
+-- view (ofec_sched_a_aggregate_size_merged_mv) is recreated to prevent
+-- missing data impacting the API during a refresh/rebuild.
+alter table ofec_sched_a_aggregate_size rename to ofec_sched_a_aggregate_size_old;
 alter table ofec_sched_a_aggregate_size_tmp rename to ofec_sched_a_aggregate_size;
 
 -- Create update function

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
@@ -37,7 +37,7 @@ create index on ofec_sched_a_aggregate_size_tmp (count);
 -- ofec_sched_a_aggregate_size_old is removed when the dependent materialized
 -- view (ofec_sched_a_aggregate_size_merged_mv) is recreated to prevent
 -- missing data impacting the API during a refresh/rebuild.
-alter table ofec_sched_a_aggregate_size rename to ofec_sched_a_aggregate_size_old;
+alter table if exists ofec_sched_a_aggregate_size rename to ofec_sched_a_aggregate_size_old;
 alter table ofec_sched_a_aggregate_size_tmp rename to ofec_sched_a_aggregate_size;
 
 -- Create update function

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_state.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_state.sql
@@ -1,5 +1,6 @@
-drop table if exists ofec_sched_a_aggregate_state;
-create table ofec_sched_a_aggregate_state as
+-- Create initial aggregate
+drop table if exists ofec_sched_a_aggregate_state_tmp;
+create table ofec_sched_a_aggregate_state_tmp as
 select
     cmte_id,
     rpt_yr + rpt_yr % 2 as cycle,
@@ -14,14 +15,19 @@ and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
 group by cmte_id, cycle, state
 ;
 
-alter table ofec_sched_a_aggregate_state add column idx serial primary key;
+alter table ofec_sched_a_aggregate_state_tmp add column idx serial primary key;
 
-create index on ofec_sched_a_aggregate_state (cmte_id, idx);
-create index on ofec_sched_a_aggregate_state (cycle, idx);
-create index on ofec_sched_a_aggregate_state (state, idx);
-create index on ofec_sched_a_aggregate_state (state_full, idx);
-create index on ofec_sched_a_aggregate_state (total, idx);
-create index on ofec_sched_a_aggregate_state (count, idx);
+-- Create indices on aggregate
+create index on ofec_sched_a_aggregate_state_tmp (cmte_id, idx);
+create index on ofec_sched_a_aggregate_state_tmp (cycle, idx);
+create index on ofec_sched_a_aggregate_state_tmp (state, idx);
+create index on ofec_sched_a_aggregate_state_tmp (state_full, idx);
+create index on ofec_sched_a_aggregate_state_tmp (total, idx);
+create index on ofec_sched_a_aggregate_state_tmp (count, idx);
+
+-- Remove previous aggregate and rename new aggregate
+drop table if exists ofec_sched_a_aggregate_state;
+alter table ofec_sched_a_aggregate_state_tmp rename to ofec_sched_a_aggregate_state;
 
 -- Create update function
 create or replace function ofec_sched_a_update_aggregate_state() returns void as $$

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_zip.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_zip.sql
@@ -1,6 +1,6 @@
 -- Create initial aggregate
-drop table if exists ofec_sched_a_aggregate_zip;
-create table ofec_sched_a_aggregate_zip as
+drop table if exists ofec_sched_a_aggregate_zip_tmp;
+create table ofec_sched_a_aggregate_zip_tmp as
 select
     cmte_id,
     rpt_yr + rpt_yr % 2 as cycle,
@@ -16,16 +16,20 @@ and is_individual(contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text)
 group by cmte_id, cycle, zip
 ;
 
-alter table ofec_sched_a_aggregate_zip add column idx serial primary key;
+alter table ofec_sched_a_aggregate_zip_tmp add column idx serial primary key;
 
 -- Create indices on aggregate
-create index on ofec_sched_a_aggregate_zip (cmte_id, idx);
-create index on ofec_sched_a_aggregate_zip (cycle, idx);
-create index on ofec_sched_a_aggregate_zip (zip, idx);
-create index on ofec_sched_a_aggregate_zip (state, idx);
-create index on ofec_sched_a_aggregate_zip (state_full, idx);
-create index on ofec_sched_a_aggregate_zip (total, idx);
-create index on ofec_sched_a_aggregate_zip (count, idx);
+create index on ofec_sched_a_aggregate_zip_tmp (cmte_id, idx);
+create index on ofec_sched_a_aggregate_zip_tmp (cycle, idx);
+create index on ofec_sched_a_aggregate_zip_tmp (zip, idx);
+create index on ofec_sched_a_aggregate_zip_tmp (state, idx);
+create index on ofec_sched_a_aggregate_zip_tmp (state_full, idx);
+create index on ofec_sched_a_aggregate_zip_tmp (total, idx);
+create index on ofec_sched_a_aggregate_zip_tmp (count, idx);
+
+-- Remove previous aggregate and rename new aggregate
+drop table if exists ofec_sched_a_aggregate_zip;
+alter table ofec_sched_a_aggregate_zip_tmp rename to ofec_sched_a_aggregate_zip;
 
 -- Create update function
 create or replace function ofec_sched_a_update_aggregate_zip() returns void as $$

--- a/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_purpose.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_purpose.sql
@@ -1,5 +1,6 @@
-drop table if exists ofec_sched_b_aggregate_purpose;
-create table ofec_sched_b_aggregate_purpose as
+-- Create initial aggregate
+drop table if exists ofec_sched_b_aggregate_purpose_tmp;
+create table ofec_sched_b_aggregate_purpose_tmp as
 select
     cmte_id,
     rpt_yr + rpt_yr % 2 as cycle,
@@ -13,13 +14,18 @@ and (memo_cd != 'X' or memo_cd is null)
 group by cmte_id, cycle, purpose
 ;
 
-alter table ofec_sched_b_aggregate_purpose add column idx serial primary key;
+alter table ofec_sched_b_aggregate_purpose_tmp add column idx serial primary key;
 
-create index on ofec_sched_b_aggregate_purpose (cmte_id, idx);
-create index on ofec_sched_b_aggregate_purpose (cycle, idx);
-create index on ofec_sched_b_aggregate_purpose (purpose, idx);
-create index on ofec_sched_b_aggregate_purpose (total, idx);
-create index on ofec_sched_b_aggregate_purpose (count, idx);
+-- Create indices on aggregate
+create index on ofec_sched_b_aggregate_purpose_tmp (cmte_id, idx);
+create index on ofec_sched_b_aggregate_purpose_tmp (cycle, idx);
+create index on ofec_sched_b_aggregate_purpose_tmp (purpose, idx);
+create index on ofec_sched_b_aggregate_purpose_tmp (total, idx);
+create index on ofec_sched_b_aggregate_purpose_tmp (count, idx);
+
+-- Remove previous aggregate and rename new aggregate
+drop table if exists ofec_sched_b_aggregate_purpose;
+alter table ofec_sched_b_aggregate_purpose_tmp rename to ofec_sched_b_aggregate_purpose;
 
 -- Create update function
 create or replace function ofec_sched_b_update_aggregate_purpose() returns void as $$

--- a/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient.sql
@@ -1,6 +1,6 @@
 -- Create initial aggregate
-drop table if exists ofec_sched_b_aggregate_recipient;
-create table ofec_sched_b_aggregate_recipient as
+drop table if exists ofec_sched_b_aggregate_recipient_tmp;
+create table ofec_sched_b_aggregate_recipient_tmp as
 select
     cmte_id,
     rpt_yr + rpt_yr % 2 as cycle,
@@ -14,14 +14,18 @@ and (memo_cd != 'X' or memo_cd is null)
 group by cmte_id, cycle, recipient_nm
 ;
 
-alter table ofec_sched_b_aggregate_recipient add column idx serial primary key;
+alter table ofec_sched_b_aggregate_recipient_tmp add column idx serial primary key;
 
 -- Create indices on aggregate
-create index on ofec_sched_b_aggregate_recipient (cmte_id, idx);
-create index on ofec_sched_b_aggregate_recipient (cycle, idx);
-create index on ofec_sched_b_aggregate_recipient (recipient_nm, idx);
-create index on ofec_sched_b_aggregate_recipient (total, idx);
-create index on ofec_sched_b_aggregate_recipient (count, idx);
+create index on ofec_sched_b_aggregate_recipient_tmp (cmte_id, idx);
+create index on ofec_sched_b_aggregate_recipient_tmp (cycle, idx);
+create index on ofec_sched_b_aggregate_recipient_tmp (recipient_nm, idx);
+create index on ofec_sched_b_aggregate_recipient_tmp (total, idx);
+create index on ofec_sched_b_aggregate_recipient_tmp (count, idx);
+
+-- Remove previous aggregate and rename new aggregate
+drop table if exists ofec_sched_b_aggregate_recipient;
+alter table ofec_sched_b_aggregate_recipient_tmp rename to ofec_sched_b_aggregate_recipient;
 
 -- Create update function
 create or replace function ofec_sched_b_update_aggregate_recipient() returns void as $$

--- a/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient_committee.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient_committee.sql
@@ -1,6 +1,6 @@
 -- Create initial aggregate
-drop table if exists ofec_sched_b_aggregate_recipient_id;
-create table ofec_sched_b_aggregate_recipient_id as
+drop table if exists ofec_sched_b_aggregate_recipient_id_tmp;
+create table ofec_sched_b_aggregate_recipient_id_tmp as
 select
     cmte_id,
     rpt_yr + rpt_yr % 2 as cycle,
@@ -16,14 +16,18 @@ and clean_repeated(recipient_cmte_id, cmte_id) is not null
 group by cmte_id, cycle, clean_repeated(recipient_cmte_id, cmte_id)
 ;
 
-alter table ofec_sched_b_aggregate_recipient_id add column idx serial primary key;
+alter table ofec_sched_b_aggregate_recipient_id_tmp add column idx serial primary key;
 
 -- Create indices on aggregate
-create index on ofec_sched_b_aggregate_recipient_id (cmte_id, idx);
-create index on ofec_sched_b_aggregate_recipient_id (cycle, idx);
-create index on ofec_sched_b_aggregate_recipient_id (recipient_cmte_id, idx);
-create index on ofec_sched_b_aggregate_recipient_id (total, idx);
-create index on ofec_sched_b_aggregate_recipient_id (count, idx);
+create index on ofec_sched_b_aggregate_recipient_id_tmp (cmte_id, idx);
+create index on ofec_sched_b_aggregate_recipient_id_tmp (cycle, idx);
+create index on ofec_sched_b_aggregate_recipient_id_tmp (recipient_cmte_id, idx);
+create index on ofec_sched_b_aggregate_recipient_id_tmp (total, idx);
+create index on ofec_sched_b_aggregate_recipient_id_tmp (count, idx);
+
+-- Remove previous aggregate and rename new aggregate
+drop table if exists ofec_sched_b_aggregate_recipient_id;
+alter table ofec_sched_b_aggregate_recipient_id_tmp rename to ofec_sched_b_aggregate_recipient_id;
 
 -- Create update function
 create or replace function ofec_sched_b_update_aggregate_recipient_id() returns void as $$

--- a/data/sql_updates/sched_a_by_size_merged.sql
+++ b/data/sql_updates/sched_a_by_size_merged.sql
@@ -1,5 +1,11 @@
+-- Drop original table referenced in the creation of this view.
+-- This is done here in order to prevent missing data impacting the API during
+-- a refresh/rebuild.
+drop table if exists ofec_sched_a_aggregate_size_old cascade;
+
 -- Merge aggregated Schedule A receipts with committee totals views
 drop materialized view if exists ofec_sched_a_aggregate_size_merged_mv_tmp;
+
 create materialized view ofec_sched_a_aggregate_size_merged_mv_tmp as
 with grouped as (
     select


### PR DESCRIPTION
Fixes #1775

This changeset adjusts the processing for the aggregate tables to make use of temporary tables first. Prior to this, any updates to the aggregates in the database would cause the site to not yield the data that we expect to see.  We would like to achieve as little downtime as possible and the rest of our database processing makes use of creating temporary tables and views to accomplish this, so we are making use of them here as well.

For the initial approach I opted to do the renaming inline with the table processing.  Most of our materialized views are renamed separately at the end of processing, but if we want to follow those steps we'll need to move the creation of all of the triggers for each of these tables.

There is one instance of a table that has dependent objects, the `ofec_sched_a_aggregate_size` table and its corresponding `ofec_sched_a_aggregate_size_merged_mv` materialized view.  In order to address the downtime and renaming dance I modified the table reconstruction to just rename the existing table and shift the dropping of it to when the materialized view itself is reconstructed.  It's an added step in the materialized view recreation that deals with a different relation, but I've noted this with comments.

/cc @LindsayYoung, @jontours 