### PR TITLE
Feature/reorder-columns

### DIFF
--- a/webservices/common/models/candidates.py
+++ b/webservices/common/models/candidates.py
@@ -28,22 +28,22 @@ class CandidateFlags(db.Model):
 class BaseCandidate(BaseModel):
     __abstract__ = True
 
-    load_date = db.Column(db.Date, index=True, doc=docs.LOAD_DATE)
-    candidate_status = db.Column(db.String(1), index=True, doc=docs.CANDIDATE_STATUS)
-    # ? difference between district and district_number
-    district = db.Column(db.String(2), index=True, doc=docs.DISTRICT)
-    district_number = db.Column(db.Integer, index=True, doc=docs.CANDIDATE_STATUS)
-    election_years = db.Column(ARRAY(db.Integer), index=True, doc='Years in which a candidate ran for office.')
-    election_districts = db.Column(ARRAY(db.String), index=True, doc=docs.DISTRICT)
-    cycles = db.Column(ARRAY(db.Integer), index=True, doc=docs.CANDIDATE_CYCLE)
-    incumbent_challenge = db.Column(db.String(1), index=True, doc=docs.INCUMBENT_CHALLENGE)
-    incumbent_challenge_full = db.Column(db.String(10), doc=docs.INCUMBENT_CHALLENGE_FULL)
+    name = db.Column(db.String(100), index=True, doc=docs.CANDIDATE_NAME)
     office = db.Column(db.String(1), index=True, doc=docs.OFFICE)
     office_full = db.Column(db.String(9), doc=docs.OFFICE_FULL)
     party = db.Column(db.String(3), index=True, doc=docs.PARTY)
     party_full = db.Column(db.String(255), doc=docs.PARTY_FULL)
     state = db.Column(db.String(2), index=True, doc=docs.STATE)
-    name = db.Column(db.String(100), index=True, doc=docs.CANDIDATE_NAME)
+    district = db.Column(db.String(2), index=True, doc=docs.DISTRICT)
+    # ? difference between district and district_number
+    district_number = db.Column(db.Integer, index=True, doc=docs.CANDIDATE_STATUS)
+    election_districts = db.Column(ARRAY(db.String), index=True, doc=docs.DISTRICT)
+    election_years = db.Column(ARRAY(db.Integer), index=True, doc='Years in which a candidate ran for office.')
+    cycles = db.Column(ARRAY(db.Integer), index=True, doc=docs.CANDIDATE_CYCLE)
+    candidate_status = db.Column(db.String(1), index=True, doc=docs.CANDIDATE_STATUS)
+    incumbent_challenge = db.Column(db.String(1), index=True, doc=docs.INCUMBENT_CHALLENGE)
+    incumbent_challenge_full = db.Column(db.String(10), doc=docs.INCUMBENT_CHALLENGE_FULL)
+    load_date = db.Column(db.Date, index=True, doc=docs.LOAD_DATE)
 
     @declared_attr
     def flags(self):

--- a/webservices/common/models/committees.py
+++ b/webservices/common/models/committees.py
@@ -17,22 +17,22 @@ class CommitteeSearch(BaseModel):
 class BaseCommittee(BaseModel):
     __abstract__ = True
 
+    name = db.Column(db.String(100), index=True, doc=docs.COMMITTEE_NAME)
     committee_id = db.Column(db.String, primary_key=True, index=True, doc=docs.COMMITTEE_ID)
     cycles = db.Column(ARRAY(db.Integer), index=True, doc=docs.COMMITTEE_CYCLE)
-    designation = db.Column(db.String(1), index=True, doc=docs.DESIGNATION)
-    designation_full = db.Column(db.String(25), index=True, doc=docs.DESIGNATION)
     treasurer_name = db.Column(db.String(100), index=True, doc=docs.TREASURER_NAME)
     treasurer_text = db.Column(TSVECTOR)
-    organization_type = db.Column(db.String(1), index=True, doc=docs.ORGANIZATION_TYPE)
-    organization_type_full = db.Column(db.String(100), index=True, doc=docs.ORGANIZATION_TYPE)
-    state = db.Column(db.String(2), index=True, doc=docs.COMMITTEE_STATE)
     committee_type = db.Column(db.String(1), index=True, doc=docs.COMMITTEE_TYPE)
     committee_type_full = db.Column(db.String(50), index=True, doc=docs.COMMITTEE_TYPE)
-    # ? how to explain
-    expire_date = db.Column(db.DateTime())
+    designation = db.Column(db.String(1), index=True, doc=docs.DESIGNATION)
+    designation_full = db.Column(db.String(25), index=True, doc=docs.DESIGNATION)
+    organization_type = db.Column(db.String(1), index=True, doc=docs.ORGANIZATION_TYPE)
+    organization_type_full = db.Column(db.String(100), index=True, doc=docs.ORGANIZATION_TYPE)
     party = db.Column(db.String(3), index=True, doc=docs.PARTY)
     party_full = db.Column(db.String(50), doc=docs.PARTY)
-    name = db.Column(db.String(100), index=True, doc=docs.COMMITTEE_NAME)
+    state = db.Column(db.String(2), index=True, doc=docs.COMMITTEE_STATE)
+    # ? how to explain
+    expire_date = db.Column(db.DateTime())
 
 
 class BaseConcreteCommittee(BaseCommittee):

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -59,6 +59,8 @@ class ScheduleA(BaseItemized):
     contributor_occupation = db.Column('contbr_occupation', db.String, doc=docs.CONTRIBUTOR_OCCUPATION)
     contributor_occupation_text = db.Column(TSVECTOR)
     contributor_id = db.Column('clean_contbr_id', db.String, doc=docs.CONTRIBUTOR_ID)
+    contributor_aggregate_ytd = db.Column('contb_aggregate_ytd', db.Numeric(30, 2))
+    is_individual = db.Column(db.Boolean, index=True)
 
     # Primary transaction info
     receipt_type = db.Column('receipt_tp', db.String)
@@ -82,7 +84,6 @@ class ScheduleA(BaseItemized):
     amendment_indicator_desc = db.Column('action_cd_desc', db.String)
     schedule_type = db.Column('schedule_type', db.String)
     schedule_type_full = db.Column('schedule_type_desc', db.String)
-    is_individual = db.Column(db.Boolean, index=True)
     increased_limit = db.Column(db.String)
     load_date = db.Column('pg_date', db.DateTime)
     transaction_id = db.Column('tran_id', db.Integer)

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -9,8 +9,8 @@ from .base import db
 class BaseItemized(db.Model):
     __abstract__ = True
 
-    committee_id = db.Column('cmte_id', db.String, doc=docs.COMMITTEE_ID)
     committee = utils.related_committee_history('committee_id', cycle_label='report_year')
+    committee_id = db.Column('cmte_id', db.String, doc=docs.COMMITTEE_ID)
     report_year = db.Column('rpt_yr', db.Integer, doc=docs.REPORT_YEAR)
     report_type = db.Column('rpt_tp', db.String, doc=docs.REPORT_TYPE)
     election_type = db.Column('election_tp', db.String, doc=docs.ELECTION_TYPE)
@@ -31,14 +31,10 @@ class BaseItemized(db.Model):
 class ScheduleA(BaseItemized):
     __tablename__ = 'ofec_sched_a_master'
 
-    sub_id = db.Column(db.Integer, primary_key=True)
-    amendment_indicator = db.Column('action_cd', db.String)
-    amendment_indicator_desc = db.Column('action_cd_desc', db.String)
-    is_individual = db.Column(db.Boolean, index=True)
-    candidate_office = db.Column('cand_office', db.String)
-    candidate_office_description = db.Column('cand_office_desc', db.String)
-    candidate_office_district = db.Column('cand_office_district', db.String)
-    contributor_id = db.Column('clean_contbr_id', db.String, doc=docs.CONTRIBUTOR_ID)
+    # Contributor info
+    entity_type = db.Column('entity_tp', db.String)
+    entity_type_desc = db.Column('entity_tp_desc', db.String)
+    contributor_prefix = db.Column('contbr_prefix', db.String)
     contributor = db.relationship(
         'CommitteeHistory',
         primaryjoin='''and_(
@@ -47,7 +43,7 @@ class ScheduleA(BaseItemized):
         )'''
     )
     contributor_name = db.Column('contbr_nm', db.String, doc=docs.CONTRIBUTOR_NAME)
-    contributor_prefix = db.Column('contbr_prefix', db.String)
+    contributor_name_text = db.Column(TSVECTOR)
     contributor_first_name = db.Column('contbr_nm_first', db.String)
     contributor_middle_name = db.Column('contbr_m_nm', db.String)
     contributor_last_name = db.Column('contbr_nm_last', db.String)
@@ -59,43 +55,49 @@ class ScheduleA(BaseItemized):
     contributor_state = db.Column('contbr_st', db.String, doc=docs.CONTRIBUTOR_STATE)
     contributor_zip = db.Column('contbr_zip', db.String, doc=docs.CONTRIBUTOR_ZIP)
     contributor_employer = db.Column('contbr_employer', db.String, doc=docs.CONTRIBUTOR_EMPLOYER)
+    contributor_employer_text = db.Column(TSVECTOR)
     contributor_occupation = db.Column('contbr_occupation', db.String, doc=docs.CONTRIBUTOR_OCCUPATION)
-    contributor_aggregate_ytd = db.Column('contb_aggregate_ytd', db.Numeric(30, 2))
-    contribution_receipt_date = db.Column('contb_receipt_dt', db.Date)
-    entity_type = db.Column('entity_tp', db.String)
-    entity_type_desc = db.Column('entity_tp_desc', db.String)
-    contribution_receipt_amount = db.Column('contb_receipt_amt', db.Numeric(30, 2))
-    fec_election_type_desc = db.Column('fec_election_tp_desc', db.String)
-    fec_election_year = db.Column('fec_election_yr', db.String)
+    contributor_occupation_text = db.Column(TSVECTOR)
+    contributor_id = db.Column('clean_contbr_id', db.String, doc=docs.CONTRIBUTOR_ID)
+
+    # Primary transaction info
+    receipt_type = db.Column('receipt_tp', db.String)
+    receipt_type_full = db.Column('receipt_desc', db.String)
     memo_code = db.Column('memo_cd', db.String)
     memo_code_full = db.Column('memo_cd_desc', db.String)
     memo_text = db.Column(db.String)
-    receipt_type = db.Column('receipt_tp', db.String)
-    receipt_type_full = db.Column('receipt_desc', db.String)
-    back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
-    back_reference_schedule_name = db.Column('back_ref_sched_nm', db.String)
-    increased_limit = db.Column(db.String)
-    load_date = db.Column('pg_date', db.DateTime)
+    contribution_receipt_date = db.Column('contb_receipt_dt', db.Date)
+    contribution_receipt_amount = db.Column('contb_receipt_amt', db.Numeric(30, 2))
+
+    # Related candidate info
+    candidate_office = db.Column('cand_office', db.String)
+    candidate_office_description = db.Column('cand_office_desc', db.String)
+    candidate_office_district = db.Column('cand_office_district', db.String)
+
+    # Transaction meta info
+    fec_election_type_desc = db.Column('fec_election_tp_desc', db.String)
+    fec_election_year = db.Column('fec_election_yr', db.String)
     two_year_transaction_period = db.Column(db.SmallInteger, doc=docs.TWO_YEAR_TRANSACTION_PERIOD)
+    amendment_indicator = db.Column('action_cd', db.String)
+    amendment_indicator_desc = db.Column('action_cd_desc', db.String)
     schedule_type = db.Column('schedule_type', db.String)
     schedule_type_full = db.Column('schedule_type_desc', db.String)
-    original_sub_id = db.Column('orig_sub_id', db.Integer)
+    is_individual = db.Column(db.Boolean, index=True)
+    increased_limit = db.Column(db.String)
+    load_date = db.Column('pg_date', db.DateTime)
     transaction_id = db.Column('tran_id', db.Integer)
-    # Auxiliary fields
-    contributor_name_text = db.Column(TSVECTOR)
-    contributor_employer_text = db.Column(TSVECTOR)
-    contributor_occupation_text = db.Column(TSVECTOR)
+    sub_id = db.Column(db.Integer, primary_key=True)
+    original_sub_id = db.Column('orig_sub_id', db.Integer)
+    back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
+    back_reference_schedule_name = db.Column('back_ref_sched_nm', db.String)
 
 
 class ScheduleB(BaseItemized):
     __tablename__ = 'ofec_sched_b_master'
 
-    sub_id = db.Column(db.Integer, primary_key=True)
-    amendment_indicator = db.Column('action_cd', db.String)
-    amendment_indicator_desc = db.Column('action_cd_desc', db.String)
-    candidate_office = db.Column('cand_office', db.String)
-    candidate_office_description = db.Column('cand_office_desc', db.String)
-    candidate_office_district = db.Column('cand_office_district', db.String)
+    # Recipient info
+    entity_type = db.Column('entity_tp', db.String)
+    entity_type_desc = db.Column('entity_tp_desc', db.String)
     recipient_committee_id = db.Column('clean_recipient_cmte_id', db.String)
     recipient_committee = db.relationship(
         'CommitteeHistory',
@@ -105,44 +107,49 @@ class ScheduleB(BaseItemized):
         )'''
     )
     recipient_name = db.Column('recipient_nm', db.String)
+    recipient_name_text = db.Column(TSVECTOR)
     # Street address omitted per FEC policy
     # recipient_street_1 = db.Column('recipient_st1', db.String)
     # recipient_street_2 = db.Column('recipient_st2', db.String)
     recipient_city = db.Column(db.String)
     recipient_state = db.Column('recipient_st', db.String)
     recipient_zip = db.Column(db.String)
+    beneficiary_committee_name = db.Column('benef_cmte_nm', db.String)
+    national_committee_nonfederal_account = db.Column('national_cmte_nonfed_acct', db.String)
+
+    # Primary transaction info
     disbursement_type = db.Column('disb_tp', db.String)
     disbursement_description = db.Column('disb_desc', db.String)
-    disbursement_date = db.Column('disb_dt', db.Date)
-    disbursement_amount = db.Column('disb_amt', db.Numeric(30, 2))
-    election_type = db.Column('election_tp', db.String)
-    election_type_full = db.Column('election_tp_desc', db.String)
-    entity_type = db.Column('entity_tp', db.String)
-    entity_type_desc = db.Column('entity_tp_desc', db.String)
-    back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
-    back_reference_schedule_id = db.Column('back_ref_sched_id', db.String)
+    disbursement_description_text = db.Column(TSVECTOR)
+    disbursement_purpose_category = db.Column(db.String)
     memo_code = db.Column('memo_cd', db.String)
     memo_code_full = db.Column('memo_cd_desc', db.String)
     memo_text = db.Column(db.String)
-    national_committee_nonfederal_account = db.Column('national_cmte_nonfed_acct', db.String)
-    original_sub_id = db.Column('orig_sub_id', db.Integer)
+    disbursement_date = db.Column('disb_dt', db.Date)
+    disbursement_amount = db.Column('disb_amt', db.Numeric(30, 2))
+
+    # Related candidate info
+    candidate_office = db.Column('cand_office', db.String)
+    candidate_office_description = db.Column('cand_office_desc', db.String)
+    candidate_office_district = db.Column('cand_office_district', db.String)
+
+    # Transaction meta info
+    election_type = db.Column('election_tp', db.String) # ? election_type looks like it's included in BaseItemized already
+    election_type_full = db.Column('election_tp_desc', db.String)
     fec_election_type_desc = db.Column('fec_election_tp_desc', db.String)
     fec_election_year = db.Column('fec_election_tp_year', db.String)
-    beneficiary_committee_name = db.Column('benef_cmte_nm', db.String)
+    two_year_transaction_period = db.Column(db.SmallInteger, doc=docs.TWO_YEAR_TRANSACTION_PERIOD)
+    amendment_indicator = db.Column('action_cd', db.String)
+    amendment_indicator_desc = db.Column('action_cd_desc', db.String)
     schedule_type = db.Column('schedule_type', db.String)
     schedule_type_full = db.Column('schedule_type_desc', db.String)
     load_date = db.Column('pg_date', db.DateTime)
-
-
-    semi_annual_bundled_refund = db.Column('semi_an_bundled_refund', db.Numeric(30, 2))
     transaction_id = db.Column('tran_id', db.Integer)
-
-    two_year_transaction_period = db.Column(db.SmallInteger, doc=docs.TWO_YEAR_TRANSACTION_PERIOD)
-
-    # Auxiliary fields
-    recipient_name_text = db.Column(TSVECTOR)
-    disbursement_description_text = db.Column(TSVECTOR)
-    disbursement_purpose_category = db.Column(db.String)
+    sub_id = db.Column(db.Integer, primary_key=True)
+    original_sub_id = db.Column('orig_sub_id', db.Integer)
+    back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
+    back_reference_schedule_id = db.Column('back_ref_sched_id', db.String)
+    semi_annual_bundled_refund = db.Column('semi_an_bundled_refund', db.Numeric(30, 2))
 
 
 class ScheduleE(BaseItemized):
@@ -150,26 +157,39 @@ class ScheduleE(BaseItemized):
 
     sched_e_sk = db.Column(db.Integer, primary_key=True)
 
+    # Committe info
     committee_name = db.Column('cmte_nm', db.String, doc=docs.COMMITTEE_ID)
+
+    # Payee info
+    payee_prefix = db.Column(db.String)
     payee_name = db.Column('pye_nm', db.String)
+    payee_name_text = db.Column(TSVECTOR)
+    payee_first_name = db.Column('payee_f_nm', db.String)
+    payee_middle_name = db.Column('payee_m_nm', db.String)
+    payee_last_name = db.Column('payee_l_nm', db.String)
+    payee_suffix = db.Column(db.String)
     payee_street_1 = db.Column('pye_st1', db.String)
     payee_street_2 = db.Column('pye_st2', db.String)
     payee_city = db.Column('pye_city', db.String)
     payee_state = db.Column('pye_st', db.String)
     payee_zip = db.Column('pye_zip', db.String)
-    payee_prefix = db.Column(db.String)
-    payee_first_name = db.Column('payee_f_nm', db.String)
-    payee_middle_name = db.Column('payee_m_nm', db.String)
-    payee_last_name = db.Column('payee_l_nm', db.String)
-    payee_suffix = db.Column(db.String)
+
+    # Primary transaction info
+    is_notice = db.Column(db.Boolean, index=True)
     expenditure_description = db.Column('exp_desc', db.String)
     expenditure_date = db.Column('exp_dt', db.Date)
+    dissemination_date = db.Column('dissem_dt', db.Date)
     expenditure_amount = db.Column('exp_amt', db.Float)
+    office_total_ytd = db.Column('cal_ytd_ofc_sought', db.Float)
+    category_code = db.Column('catg_cd', db.String)
+    category_code_full = db.Column('catg_cd_desc', db.String)
     support_oppose_indicator = db.Column('s_o_ind', db.String)
+
+    # Candidate info
     candidate_id = db.Column('s_o_cand_id', db.String)
     candidate = utils.related_candidate_history('candidate_id', cycle_label='report_year')
-    candidate_name = db.Column('s_o_cand_nm', db.String, doc=docs.CANDIDATE_NAME)
     candidate_prefix = db.Column('s_0_cand_prefix', db.String)
+    candidate_name = db.Column('s_o_cand_nm', db.String, doc=docs.CANDIDATE_NAME)
     candidate_first_name = db.Column('s_0_cand_f_nm', db.String)
     candidate_middle_name = db.Column('s_0_cand_m_nm', db.String)
     candidate_last_name = db.Column('s_0_cand_l_nm', db.String)
@@ -179,6 +199,8 @@ class ScheduleE(BaseItemized):
     cand_office_district = db.Column('s_o_cand_office_district', db.String, doc=docs.DISTRICT)
     election_type = db.Column('election_tp', db.String, doc=docs.ELECTION_TYPE)
     election_type_full = db.Column('fec_election_tp_desc', db.String, doc=docs.ELECTION_TYPE)
+
+    # Transaction meta info
     independent_sign_name = db.Column('indt_sign_nm', db.String)
     independent_sign_date = db.Column('indt_sign_dt', db.Date)
     notary_sign_name = db.Column('notary_sign_nm', db.String)
@@ -186,21 +208,15 @@ class ScheduleE(BaseItemized):
     notary_commission_expiration_date = db.Column('notary_commission_exprtn_dt', db.Date)
     back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
     back_reference_schedule_name = db.Column('back_ref_sched_nm', db.String)
-    receipt_date = db.Column('receipt_dt', db.Date)
     record_number = db.Column('record_num', db.Integer)
     report_primary_general = db.Column('rpt_pgi', db.String)
-    office_total_ytd = db.Column('cal_ytd_ofc_sought', db.Float)
-    category_code = db.Column('catg_cd', db.String)
-    category_code_full = db.Column('catg_cd_desc', db.String)
     filer_prefix = db.Column(db.String)
     filer_first_name = db.Column('filer_f_nm', db.String)
     filer_middle_name = db.Column('filer_m_nm', db.String)
     filer_last_name = db.Column('filer_l_nm', db.String)
     filer_suffix = db.Column(db.String)
-    dissemination_date = db.Column('dissem_dt', db.Date)
+    receipt_date = db.Column('receipt_dt', db.Date)
     load_date = db.Column(db.DateTime, doc=docs.LOAD_DATE)
     update_date = db.Column(db.DateTime, doc=docs.UPDATE_DATE)
-    is_notice = db.Column(db.Boolean, index=True)
 
-    # Auxiliary fields
-    payee_name_text = db.Column(TSVECTOR)
+


### PR DESCRIPTION
I offered to take this task off @LindsayYoung 's plate, so here it is: my first API PR!

This re-orders the properties of the models in order to have the columns of the downloads be ordered in a more logical way. 

Over the course of doing this, I realized it's impossible to really get it feeling 100% right, since there will always be a lot of empty columns for certain rows and there will always be differences of opinion about the best order, but nonetheless, I tried to add some rhyme and reason to the order. 

Here's the order for itemized A, B and E (with questions & explanation):
- **Committee name & ID**: Currently only committee IDs are showing up. Is there a reason committee names aren't? It looks like they're in the model.
- **Report info**: Basic info about the report the transaction was filed on. AFAICT, because this is in the base model, it needs to come first, though there's certain columns that are showing up out of order (like `pdf_url` which shows up near the end). Is there a way to control this? I think ideally it would all be near the end.
- **Contributor (sched A) / Recipient (sched B) / Payee (sched E) info**: All pertinent info related to the other party of the transaction.
- **Primary transaction info:** The date, amount, and any description and memo data for the transaction
- **Transaction meta info:** This is the stuff that seemed to be more secondary info that wasn't crucial to understanding the transaction

In general, I also organized like properties to always be by like (e.g. `sub_id` next to `original_sub_id`). This was the case for most things, but in some places I shuffled things around.

I also tweaked the candidates and committee models to be organized in a more natural way as well. I found filings and the costs models to not really need anything. 

Last, I'm finding there's certain columns throughout that just aren't showing up and others that are still showing up out of order. I can go through and document which ones aren't, but wanted to see if that's expected first.

Resolves https://github.com/18F/openFEC/issues/1581