### PR TITLE
prioritizing final opinion document category

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -18,6 +18,7 @@ class Search(utils.Resource):
             query = {"query": {"bool": {
                      "must": [{"match": {"_all": q}}, {"term": {"_type": type}}],
                                "should": [{"match": {"no": q}},
+                                          {"match": {"category": "Final Opinion"}},
                                                {"match_phrase": {"_all": {"query": q,
                                                                           "slop": 50}
                                                                  }


### PR DESCRIPTION
This commit prioritizes Final Opinions in the search results for advisory opinions. It does not exclude other document types. 