### PR TITLE
Fix for election sorting

### DIFF
--- a/webservices/sorting.py
+++ b/webservices/sorting.py
@@ -32,6 +32,7 @@ def parse_option(option, model=None, aliases=None, join_columns=None, query=None
             if entity._label_name == column:
                 single_model = get_class_by_tablename(entity.namespace)
                 if not single_model:
+                    column = entity.column
                     break
                 column = getattr(single_model, column)
                 break


### PR DESCRIPTION
This is a fix for the election sorting endpoint.  I thought that maybe the logic I wrote caused this problem, but after doing some inspection of the code, in this case the logic I wrote in sorting.py was returning the same sorting column it did in the past.  So this gets back to something that broke the logic.  

Did we update sql alchemy at some point?  I know when we updated to flask 11 some of the import statements changed, but the library at the core of those imports _should_ have stayed the same.  However, it does seem to be that just using the raw sort string itself no longer works on queries that aren't simple entity model mappings.

Anyway, this fix accounts for columns that are aliased by SqlAlchemy.  I think that should be all the edge cases for the different queries that are passed to these utility methods.