### PR TITLE
Removed flask.ext imports

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -8,8 +8,8 @@ import multiprocessing
 
 import networkx as nx
 import sqlalchemy as sa
-from flask.ext.script import Server
-from flask.ext.script import Manager
+from flask_script import Server
+from flask_script import Manager
 
 from webservices import flow
 from webservices.env import env

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask==0.11
 Flask-Cors==2.1.0
 Flask-Script==2.0.5
 Flask-RESTful==0.3.5
-Flask-SQLAlchemy==2.0
+Flask-SQLAlchemy==2.1
 python-dateutil==2.4.2
 sqlalchemy-postgres-copy==0.1.0
 networkx==1.9.1

--- a/webservices/common/models/base.py
+++ b/webservices/common/models/base.py
@@ -1,8 +1,8 @@
 import random
 
 import celery
-from flask.ext.sqlalchemy import SQLAlchemy
-from flask.ext.sqlalchemy import SignallingSession
+from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SignallingSession
 
 
 class RoutingSession(SignallingSession):

--- a/webservices/common/models/candidates.py
+++ b/webservices/common/models/candidates.py
@@ -62,6 +62,7 @@ class BaseConcreteCandidate(BaseCandidate):
 
 class Candidate(BaseConcreteCandidate):
     __table_args__ = {'extend_existing': True}
+    __tablename__ = 'ofec_candidate_detail_mv'
 
     active_through = db.Column(db.Integer, doc=docs.ACTIVE_THROUGH)
 
@@ -82,6 +83,7 @@ class Candidate(BaseConcreteCandidate):
 
 class CandidateDetail(BaseConcreteCandidate):
     __table_args__ = {'extend_existing': True}
+    __tablename__ = 'ofec_candidate_detail_mv'
 
     address_city = db.Column(db.String(100), doc='City of candidate\'s address, as reported on their Form 2.')
     address_state = db.Column(db.String(2), doc='State of candidate\'s address, as reported on their Form 2.')

--- a/webservices/common/models/committees.py
+++ b/webservices/common/models/committees.py
@@ -44,6 +44,7 @@ class BaseConcreteCommittee(BaseCommittee):
 
 class Committee(BaseConcreteCommittee):
     __table_args__ = {'extend_existing': True}
+    __tablename__ = 'ofec_committee_detail_mv'
 
     first_file_date = db.Column(db.Date, doc=docs.FIRST_FILE_DATE)
     last_file_date = db.Column(db.Date, doc=docs.LAST_FILE_DATE)
@@ -63,6 +64,7 @@ class CommitteeHistory(BaseCommittee):
 
 class CommitteeDetail(BaseConcreteCommittee):
     __table_args__ = {'extend_existing': True}
+    __tablename__ = 'ofec_committee_detail_mv'
 
     first_file_date = db.Column(db.Date, doc=docs.FIRST_FILE_DATE)
     last_file_date = db.Column(db.Date, doc=docs.LAST_FILE_DATE)

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -62,6 +62,7 @@ app = Flask(__name__)
 app.debug = True
 app.config['SQLALCHEMY_DATABASE_URI'] = sqla_conn_string()
 app.config['APISPEC_FORMAT_RESPONSE'] = None
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = True
 
 app.config['SQLALCHEMY_REPLICA_TASKS'] = [
     'webservices.tasks.download.export_query',

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from webservices.env import env
 from pyelasticsearch import ElasticSearch
 
-from flask.ext import restful
+import flask_restful as restful
 from marshmallow_pagination import paginators
 
 from webargs import fields


### PR DESCRIPTION
Turns out there were some of the`flask.ext` import statements hanging around.  All of our imports are now current with Flask 0.11.  However there is still one deprecation warning, and I think that's originating from NPlusOne.  @jmcarp would it be all right if we open a issue with that and potentially submit a pull request?  