### PR TITLE
New tests for sorting

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -89,6 +89,11 @@ class CommitteeHistoryFactory(BaseCommitteeFactory):
         model = models.CommitteeHistory
     cycle = 2016
 
+class CommitteeTotalsHouseSenateFactory(BaseCommitteeFactory):
+    class Meta:
+        model = models.CommitteeTotalsHouseSenate
+    cycle = 2016
+
 
 # Force linked factories to share sequence counters
 for each in BaseCandidateFactory.__subclasses__():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,8 @@ from tests.common import ApiBaseTest
 from webservices import args
 from webservices import rest
 from webservices import sorting
+from webservices.resources import candidate_aggregates
+
 from webservices.common import models
 
 
@@ -40,6 +42,34 @@ class TestSort(ApiBaseTest):
         self.assertEqual(query.all(), candidates)
         query, columns = sorting.sort(models.Candidate.query, 'district', model=models.Candidate, hide_null=True)
         self.assertEqual(query.all(), candidates[:2])
+
+    def test_hide_null_candidate_totals(self):
+        candidates = [
+            factories.CandidateFactory(candidate_id='C1234'),
+            factories.CandidateFactory(candidate_id='C5678'),
+
+        ]
+        candidateHistory = [
+            factories.CandidateHistoryFactory(candidate_id='C1234', two_year_period=2016),
+            factories.CandidateHistoryFactory(candidate_id='C5678', two_year_period=2016)
+        ]
+        candidateTotals = [
+            factories.CandidateTotalFactory(candidate_id='C1234', is_election=False, cycle=2016),
+            factories.CandidateTotalFactory(candidate_id='C5678', disbursements='9999.99', is_election=False, cycle=2016)
+        ]
+        candidateFlags = [
+            factories.CandidateFlagsFactory(candidate_id='C1234'),
+            factories.CandidateFlagsFactory(candidate_id='C5678')
+        ]
+
+        tcv = candidate_aggregates.TotalsCandidateView()
+        query, columns = sorting.sort(tcv.build_query(election_full=False), 'disbursements', model=None)
+        self.assertEqual(len(query.all()), len(candidates))
+        query, columns = sorting.sort(tcv.build_query(election_full=False), 'disbursements', model=None, hide_null=True)
+        self.assertEqual(len(query.all()), len(candidates) - 1)
+        self.assertTrue(candidates[1].candidate_id in query.all()[0])
+
+
 
 
 class TestArgs(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,8 +54,8 @@ class TestSort(ApiBaseTest):
 
         ]
         candidateHistory = [
-            factories.CandidateHistoryFactory(candidate_id='C1234', two_year_period=2016),
-            factories.CandidateHistoryFactory(candidate_id='C5678', two_year_period=2016)
+            factories.CandidateHistoryFactory(candidate_id='C1234', two_year_period=2016, election_years=[2016]),
+            factories.CandidateHistoryFactory(candidate_id='C5678', two_year_period=2016, election_years=[2016])
         ]
         candidateTotals = [
             factories.CandidateTotalFactory(candidate_id='C1234', is_election=False, cycle=2016),
@@ -79,25 +79,32 @@ class TestSort(ApiBaseTest):
             factories.CandidateFactory(candidate_id='C5678'),
         ]
         cmteFacorty = [
-            factories.CommitteeDetailFactory(committee_id='H1234')
+            factories.CommitteeDetailFactory(committee_id='H1234'),
+            factories.CommitteeDetailFactory(committee_id='H5678')
         ]
         db.session.flush()
         candidateHistory = [
-            factories.CandidateHistoryFactory(candidate_id='C1234', two_year_period=2016, state='MO', candidate_inactive=False, district='00', office='S'),
-            factories.CandidateHistoryFactory(candidate_id='C5678', two_year_period=2016, state='KS', candidate_inactive=False, district='00', office='S')
+            factories.CandidateHistoryFactory(candidate_id='C1234', two_year_period=2016, state='MO',
+                                              candidate_inactive=False, district='01', office='S', election_years=[2016]),
+            factories.CandidateHistoryFactory(candidate_id='C5678', two_year_period=2016, state='MO', election_years=[2016],
+                                              candidate_inactive=False, district='02', office='S')
         ]
         candidateCmteLinks = [
             factories.CandidateCommitteeLinkFactory(committee_id='H1234', candidate_id='C1234', fec_election_year=2016,committee_designation='P'),
-            factories.CandidateCommitteeLinkFactory(committee_id='H1234', candidate_id='C5678', fec_election_year=2016,committee_designation='P')
+            factories.CandidateCommitteeLinkFactory(committee_id='H5678', candidate_id='C5678', fec_election_year=2016,
+                                                    committee_designation='P')
+
         ]
         cmteTotalsFactory = [
             factories.CommitteeTotalsHouseSenateFactory(committee_id='H1234', cycle=2016),
             factories.CommitteeTotalsHouseSenateFactory(committee_id='H1234', cycle=2016, disbursements='9999.99'),
+            factories.CommitteeTotalsHouseSenateFactory(committee_id='H5678', cycle=2016)
+
         ]
         electionResults = [
-            factories.ElectionResultFactory(cand_id='C1234', election_yr=2016, cand_office='S', cand_office_st='MO', cand_office_district='00' ),
-            factories.ElectionResultFactory(cand_id='C5678', election_yr=2016, cand_office='S', cand_office_st='KS',
-                                            cand_office_district='00')
+            factories.ElectionResultFactory(cand_id='C1234', election_yr=2016, cand_office='S', cand_office_st='MO', cand_office_district='01' ),
+            factories.ElectionResultFactory(cand_id='C5678', election_yr=2016, cand_office='S', cand_office_st='MO',
+                                            cand_office_district='02')
 
         ]
         db.session.flush()
@@ -105,15 +112,17 @@ class TestSort(ApiBaseTest):
         arg_map['office'] = 'senate'
         arg_map['cycle'] = 2016
         arg_map['state'] = 'MO'
-        arg_map['district'] = '00'
+        #arg_map['district'] = '00'
 
         electionView = elections.ElectionView()
         query, columns = sorting.sort(electionView._get_records(arg_map), 'total_disbursements', model=None)
-        print(str(query.statement.compile(dialect=postgresql.dialect())))
+
+        #print(str(query.statement.compile(dialect=postgresql.dialect())))
         self.assertEqual(len(query.all()), len(candidates))
         query, columns = sorting.sort(electionView._get_records(arg_map), 'total_disbursements', model=None, hide_null=True)
         self.assertEqual(len(query.all()), len(candidates) - 1)
-        self.assertTrue(candidates[1].candidate_id in query.all()[0])
+
+        self.assertTrue(candidates[0].candidate_id in query.all()[0])
 
 
 


### PR DESCRIPTION
Currently added a new tests in test_utils to test hiding nulls for candidate totals.  This is to ensure that any changes to this endpoint doesn't not cause any regressions.

Still need to add a test for Elections, unfortunately I don't know of any easier ways of doing this, but it does work.