### PR TITLE
Add support for renaming indexes

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -228,8 +228,12 @@ def update_all(processes=1):
     update_itemized('a')
     update_itemized('b')
     update_itemized('e')
+    logger.info('Partitioning Schedule A...')
     partition.SchedAGroup.run()
+    logger.info('Finished partitioning Schedule A.')
+    logger.info('Partitioning Schedule B...')
     partition.SchedBGroup.run()
+    logger.info('Finished partitioning Schedule B.')
     rebuild_aggregates(processes=processes)
     update_schemas(processes=processes)
 


### PR DESCRIPTION
Part of #1838 
Fixes #1840 

When partitioning the itemized Schedule A and B tables, the indexes of the existing tables were being dropped and recreated, but this impacted the existing tables before they were replaced.  As partitioning these tables takes a long time with the full FEC data set, this has huge impact on database performance if anyone or anything is accessing the data in these tables.

This changeset alleviates this by renaming the indexes once the tables themselves are renamed so that they are not removed too early.

It also adds just a bit of logging information to help and get a head start there.

/cc @LindsayYoung, @jontours