### PR TITLE
Add support for renaming indexes

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -229,8 +229,12 @@ def update_all(processes=1):
     update_itemized('a')
     update_itemized('b')
     update_itemized('e')
+    logger.info('Partitioning Schedule A...')
     partition.SchedAGroup.run()
+    logger.info('Finished partitioning Schedule A.')
+    logger.info('Partitioning Schedule B...')
     partition.SchedBGroup.run()
+    logger.info('Finished partitioning Schedule B.')
     rebuild_aggregates(processes=processes)
     update_schemas(processes=processes)
 


### PR DESCRIPTION
Part of #1838 
Fixes #1840

When partitioning the itemized Schedule A and B tables, the indexes of the existing tables were being dropped and recreated, but this impacted the existing tables before they were replaced. As partitioning these tables takes a long time with the full FEC data set, this can cause problems if the partitioning is taking place during normal usage times.  Without indexes on these tables for the columns that we expose for searching and filtering, the database performance grinds to an absolute halt and queries back up.

This changeset alleviates this issue by renaming the indexes once the tables themselves are renamed so that they are not removed too early.  The `create_index` method still attempts to drop the indexes like before, but it will only do so if they still have `_tmp` in their name.  This is to account for a situation when the partition fails to complete and the processing is left in an unfinished state.

This changeset also adds a bit of logging information around the partitioning events.

/cc @LindsayYoung, @jontours