### PR TITLE
Replace missing delete statements

### DIFF
--- a/data/sql_setup/prepare_schedule_a.sql
+++ b/data/sql_setup/prepare_schedule_a.sql
@@ -26,24 +26,31 @@ begin
         two_year_transaction_period_new = get_transaction_year(new.contb_receipt_dt, new.rpt_yr);
 
         if two_year_transaction_period_new >= start_year then
+            delete from ofec_sched_a_queue_new where sub_id = new.sub_id;
             insert into ofec_sched_a_queue_new values (new.*, timestamp, two_year_transaction_period_new);
         end if;
+
         return new;
     elsif tg_op = 'UPDATE' then
         two_year_transaction_period_new = get_transaction_year(new.contb_receipt_dt, new.rpt_yr);
         two_year_transaction_period_old = get_transaction_year(old.contb_receipt_dt, old.rpt_yr);
 
         if two_year_transaction_period_new >= start_year then
+            delete from ofec_sched_a_queue_new where sub_id = new.sub_id;
+            delete from ofec_sched_a_queue_old where sub_id = old.sub_id;
             insert into ofec_sched_a_queue_new values (new.*, timestamp, two_year_transaction_period_new);
             insert into ofec_sched_a_queue_old values (old.*, timestamp, two_year_transaction_period_old);
         end if;
+
         return new;
     elsif tg_op = 'DELETE' then
         two_year_transaction_period_old = get_transaction_year(old.contb_receipt_dt, old.rpt_yr);
 
         if two_year_transaction_period_old >= start_year then
+            delete from ofec_sched_a_queue_old where sub_id = old.sub_id;
             insert into ofec_sched_a_queue_old values (old.*, timestamp, two_year_transaction_period_old);
         end if;
+
         return old;
     end if;
 end

--- a/data/sql_setup/prepare_schedule_b.sql
+++ b/data/sql_setup/prepare_schedule_b.sql
@@ -1,5 +1,6 @@
 -- Create index for join on electioneering costs
-create index on fec_vsum_sched_b (link_id);
+drop index if exists fec_vsum_sched_b_link_id_idx;
+create index fec_vsum_sched_b_link_id_idx on fec_vsum_sched_b (link_id);
 
 -- Create queue tables to hold changes to Schedule B
 drop table if exists ofec_sched_b_queue_new;
@@ -32,6 +33,7 @@ begin
             delete from ofec_sched_b_queue_new where sub_id = new.sub_id;
             insert into ofec_sched_b_queue_new values (new.*, timestamp, two_year_transaction_period_new);
         end if;
+
         return new;
     elsif tg_op = 'UPDATE' then
         two_year_transaction_period_new = get_transaction_year(new.disb_dt, new.rpt_yr);
@@ -43,6 +45,7 @@ begin
             insert into ofec_sched_b_queue_new values (new.*, timestamp, two_year_transaction_period_new);
             insert into ofec_sched_b_queue_old values (old.*, timestamp, two_year_transaction_period_old);
         end if;
+
         return new;
     elsif tg_op = 'DELETE' then
         two_year_transaction_period_old = get_transaction_year(old.disb_dt, old.rpt_yr);
@@ -51,6 +54,7 @@ begin
             delete from ofec_sched_b_queue_old where sub_id = old.sub_id;
             insert into ofec_sched_b_queue_old values (old.*, timestamp, two_year_transaction_period_old);
         end if;
+
         return old;
     end if;
 end


### PR DESCRIPTION
Part of #1820 

This changeset replaces the delete statements that went missing from the schedule A queue processing we have.  This has caused an issue where multiple records with the same `sub_id` might exist in these tables and therefore might result in insert errors in the main `ofec_sched_a_*` tables due to existing primary keys from records already processed.

This changeset also addresses an issue where an index being created on the `fec_vsum_sched_b` table was being duplicated due to not being dropped first.

/cc @LindsayYoung, @jontours