### PR TITLE
Address issue with celerybeat-schedule

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -62,3 +62,6 @@ data/subset.dump
 
 # DO include the swagger-ui dist dir
 !/static/swagger-ui/dist/
+
+# Celery artifacts
+celerybeat-schedule

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Celery artifacts
+celerybeat-schedule

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,6 @@ git+https://github.com/jmcarp/marshmallow-pagination@master
 boto3==1.2.2
 
 # Task queue
-celery==3.1.19
+celery==3.1.23
 celery-once==0.1.4
 redis==2.10.5


### PR DESCRIPTION
This changeset updates Celery to the latest patch level version and addresses a small problem we ran into during recent deploys.  If you have a local copy of the `celerybeat-schedule` file, it will go up with the deploy to cloud.gov and cause the `celery-beat` app to error out upon starting.  Adding this file to the `.gitignore` and `.cfignore` files will prevent this from happening.

/cc @LindsayYoung, @jontours 

h/t to @jmcarp for helping troubleshoot, thank you!