### PR TITLE
returning all docs in ao

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -11,7 +11,7 @@ class AdvisoryOpinion(utils.Resource):
                           {"term": {"_type": "advisory_opinions"}}]}},
                           "_source": {"exclude": "text"}}
 
-        es_results = es.search(query)
+        es_results = es.search(query, size=200)
 
         results = {"docs": [r["_source"] for r in es_results["hits"]["hits"]]}
         return results


### PR DESCRIPTION
This fixes a bug when >10 docs are present in an AO. 