### PR TITLE
Fix transaction id in schedules and sort bug fixes

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,5 +1,3 @@
-import datetime
-
 import sqlalchemy as sa
 
 import factory

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -188,19 +188,6 @@ class TestItemized(ApiBaseTest):
         results = self._results(api.url_for(ScheduleAView, min_image_number='2', max_image_number='3'))
         self.assertTrue(all('2' <= each['image_number'] <= '3' for each in results))
 
-    def test_memoed(self):
-        params = [
-            (factories.ScheduleAFactory, ScheduleAView),
-            (factories.ScheduleBFactory, ScheduleBView),
-        ]
-        for factory, resource in params:
-            [
-                factory(),
-                factory(memo_code='X'),
-            ]
-            results = self._results(api.url_for(resource))
-            self.assertFalse(results[0]['memoed_subtotal'])
-            self.assertTrue(results[1]['memoed_subtotal'])
 
     def test_filter_individual_sched_a(self):
         individuals = [

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -19,7 +19,7 @@ class BaseItemized(db.Model):
     filing_form = db.Column(db.String)
     link_id = db.Column(db.Integer)
     line_number = db.Column('line_num', db.String)
-    tran_id = db.Column(db.String)
+    transaction_id = db.Column('tran_id', db.String)
     file_number = db.Column('file_num', db.Integer)
     pdf_url = db.Column(db.String)
 
@@ -86,7 +86,7 @@ class ScheduleA(BaseItemized):
     schedule_type_full = db.Column('schedule_type_desc', db.String)
     increased_limit = db.Column(db.String)
     load_date = db.Column('pg_date', db.DateTime)
-    transaction_id = db.Column('tran_id', db.Integer)
+    # transaction_id = db.Column('tran_id', db.Integer)
     sub_id = db.Column(db.Integer, primary_key=True)
     original_sub_id = db.Column('orig_sub_id', db.Integer)
     back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
@@ -145,7 +145,7 @@ class ScheduleB(BaseItemized):
     schedule_type = db.Column('schedule_type', db.String)
     schedule_type_full = db.Column('schedule_type_desc', db.String)
     load_date = db.Column('pg_date', db.DateTime)
-    transaction_id = db.Column('tran_id', db.Integer)
+    # transaction_id = db.Column('tran_id', db.Integer)
     sub_id = db.Column(db.Integer, primary_key=True)
     original_sub_id = db.Column('orig_sub_id', db.Integer)
     back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
@@ -202,6 +202,7 @@ class ScheduleE(BaseItemized):
     election_type_full = db.Column('fec_election_tp_desc', db.String, doc=docs.ELECTION_TYPE)
 
     # Transaction meta info
+    # transaction_id = db.Column('tran_id', db.Integer)
     independent_sign_name = db.Column('indt_sign_nm', db.String)
     independent_sign_date = db.Column('indt_sign_dt', db.Date)
     notary_sign_name = db.Column('notary_sign_nm', db.String)

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -63,6 +63,7 @@ class ScheduleAView(ItemizedResource):
             args.schedule_a,
             args.make_seek_args(),
             args.make_sort_args(
+                default='contribution_receipt_date',
                 validator=args.OptionValidator([
                     'contribution_receipt_date',
                     'contribution_receipt_amount',

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -54,6 +54,7 @@ class ScheduleBView(ItemizedResource):
             args.schedule_b,
             args.make_seek_args(),
             args.make_sort_args(
+                default='-disbursement_date',
                 validator=args.OptionValidator(['disbursement_date', 'disbursement_amount']),
             ),
         )

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -58,6 +58,7 @@ class ScheduleEView(ItemizedResource):
             args.schedule_e,
             args.make_seek_args(),
             args.make_sort_args(
+                default='-expenditure_date',
                 validator=args.OptionValidator([
                     'expenditure_date',
                     'expenditure_amount',


### PR DESCRIPTION
The sort errors are fixed by adding a default sort order

For the transaction id, we had it going twice and the transaction_id was always null. Now we just have the string version going.