### PR TITLE
Added document_description and pdf_url to all efile reports summaries

### DIFF
--- a/webservices/common/models/reports.py
+++ b/webservices/common/models/reports.py
@@ -4,6 +4,11 @@ from .base import db, BaseModel
 
 from sqlalchemy.ext.hybrid import hybrid_property
 
+from webservices.common.models.dates import ReportType
+from sqlalchemy.ext.declarative import declared_attr
+
+from webservices.common.models.dates import clean_report_type
+
 
 class PdfMixin(object):
 
@@ -286,7 +291,7 @@ class BaseFilingSummary(db.Model):
     column_a = db.Column('cola', db.Float)
     column_b = db.Column('colb', db.Float)
 
-class BaseFiling(db.Model):
+class BaseFiling(PdfMixin,db.Model):
     __abstract__ = True
     file_number = db.Column('repid', db.Integer, index=True, primary_key=True)
     committee_id = db.Column('comid', db.String, index=True, doc=docs.COMMITTEE_ID)
@@ -302,9 +307,19 @@ class BaseFiling(db.Model):
     zip = db.Column(db.String)
     election_date = db.Column('el_date', db.Date)
     election_state = db.Column('el_state', db.String)
-    #create_date = db.Column('create_dt', db.Date)
     receipt_date = db.Column('create_dt', db.Date)
     sign_date = db.Column(db.Date)
+    @property
+    def document_description(self):
+        return utils.document_description(
+            self.coverage_end_date.year,
+            clean_report_type(self.report.report_type_full),
+            None,
+            None,
+        )
+    @property
+    def report_year(self):
+        return self.coverage_end_date.year
 
 
 def name_generator(*args):
@@ -357,6 +372,12 @@ class BaseF3PFiling(TreasurerMixin, BaseFiling):
         uselist=True,
     )
 
+    @declared_attr
+    def report(self):
+        return db.relationship(ReportType,
+                               primaryjoin="and_(BaseF3PFiling.report_type==ReportType.report_type)",
+                               foreign_keys=self.report_type,)
+
 
 
 class BaseF3Filing(TreasurerMixin, BaseFiling):
@@ -403,6 +424,12 @@ class BaseF3Filing(TreasurerMixin, BaseFiling):
         uselist=True,
     )
 
+    @declared_attr
+    def report(self):
+        return db.relationship(ReportType,
+                               primaryjoin="and_(BaseF3Filing.report_type==ReportType.report_type)",
+                               foreign_keys=self.report_type, )
+
 class BaseF3XFiling(BaseFiling):
     __tablename__ = 'real_efile_f3x'
     file_number = db.Column('repid', db.Integer, index=True, primary_key=True)
@@ -410,7 +437,7 @@ class BaseF3XFiling(BaseFiling):
     committee_name = db.Column('com_name', db.String, index=True, doc=docs.COMMITTEE_NAME)
     sign_date = db.Column('date_signed', db.Date)
     amend_address = db.Column('amend_addr', db.String)
-    qual = db.Column(db.String)
+    qualified_multicandidate_committee = db.Column('qual', db.String)
 
 
     summary_lines = db.relationship(
@@ -421,3 +448,9 @@ class BaseF3XFiling(BaseFiling):
         foreign_keys=file_number,
         uselist=True,
     )
+
+    @declared_attr
+    def report(self):
+        return db.relationship(ReportType,
+                               primaryjoin="and_(BaseF3XFiling.report_type==ReportType.report_type)",
+                               foreign_keys=self.report_type, )

--- a/webservices/common/models/reports.py
+++ b/webservices/common/models/reports.py
@@ -100,7 +100,7 @@ class CommitteeReports(PdfMixin, BaseModel):
     def document_description(self):
         return utils.document_description(
             self.coverage_end_date.year,
-            clean_report_type(self.report.report_type_full),
+            clean_report_type(str(self.report_type_full)),
             None,
             None,
         )
@@ -161,12 +161,6 @@ class CommitteeReportsHouseSenate(CommitteeReports):
                 committee.committee_type == 'S' and self.report_year >= 2000
             )
         )
-
-    @declared_attr
-    def report(self):
-        return db.relationship(ReportType,
-                               primaryjoin="and_(CommitteeReportsHouseSenate.report_type==ReportType.report_type)",
-                               foreign_keys=self.report_type, )
 
 
 class CommitteeReportsPacParty(CommitteeReports):
@@ -234,12 +228,6 @@ class CommitteeReportsPacParty(CommitteeReports):
     transfers_to_affilitated_committees_ytd = db.Column(db.Numeric(30, 2))#mapped
     report_form = 'Form 3X'
 
-    @declared_attr
-    def report(self):
-        return db.relationship(ReportType,
-                               primaryjoin="and_(CommitteeReportsPacParty.report_type==ReportType.report_type)",
-                               foreign_keys=self.report_type, )
-
 
 class CommitteeReportsPresidential(CommitteeReports):
     __tablename__ = 'ofec_reports_presidential_mv'
@@ -287,11 +275,6 @@ class CommitteeReportsPresidential(CommitteeReports):
     net_operating_expenditures_cycle_to_date = db.Column(db.Numeric(30, 2))#mapped
     report_form = 'Form 3P'#do we want this for the efile tables?
 
-    @declared_attr
-    def report(self):
-        return db.relationship(ReportType,
-                               primaryjoin="and_(CommitteeReportsPresidential.report_type==ReportType.report_type)",
-                               foreign_keys=self.report_type, )
 
 class CommitteeReportsIEOnly(PdfMixin, BaseModel):
     __tablename__ = 'ofec_reports_ie_only_mv'
@@ -309,12 +292,6 @@ class CommitteeReportsIEOnly(PdfMixin, BaseModel):
     report_form = 'Form 5'
     is_amended = db.Column(db.Boolean, doc='False indicates that a report is the most recent. True indicates that the report has been superseded by an amendment.')
     receipt_date = db.Column(db.Date, doc=docs.RECEIPT_DATE)
-
-    @declared_attr
-    def report(self):
-        return db.relationship(ReportType,
-                               primaryjoin="and_(CommitteeReportsIEOnly.report_type==ReportType.report_type)",
-                               foreign_keys=self.report_type, )
 
 
 class BaseFilingSummary(db.Model):

--- a/webservices/common/models/reports.py
+++ b/webservices/common/models/reports.py
@@ -96,6 +96,15 @@ class CommitteeReports(PdfMixin, BaseModel):
     is_amended = db.Column(db.Boolean, doc='False indicates that a report is the most recent. True indicates that the report has been superseded by an amendment.')
     receipt_date = db.Column('receipt_date', db.Date, doc=docs.RECEIPT_DATE)
 
+    @property
+    def document_description(self):
+        return utils.document_description(
+            self.coverage_end_date.year,
+            clean_report_type(self.report.report_type_full),
+            None,
+            None,
+        )
+
 
 class CommitteeReportsHouseSenate(CommitteeReports):
     __tablename__ = 'ofec_reports_house_senate_mv'
@@ -152,6 +161,12 @@ class CommitteeReportsHouseSenate(CommitteeReports):
                 committee.committee_type == 'S' and self.report_year >= 2000
             )
         )
+
+    @declared_attr
+    def report(self):
+        return db.relationship(ReportType,
+                               primaryjoin="and_(CommitteeReportsHouseSenate.report_type==ReportType.report_type)",
+                               foreign_keys=self.report_type, )
 
 
 class CommitteeReportsPacParty(CommitteeReports):
@@ -219,6 +234,12 @@ class CommitteeReportsPacParty(CommitteeReports):
     transfers_to_affilitated_committees_ytd = db.Column(db.Numeric(30, 2))#mapped
     report_form = 'Form 3X'
 
+    @declared_attr
+    def report(self):
+        return db.relationship(ReportType,
+                               primaryjoin="and_(CommitteeReportsPacParty.report_type==ReportType.report_type)",
+                               foreign_keys=self.report_type, )
+
 
 class CommitteeReportsPresidential(CommitteeReports):
     __tablename__ = 'ofec_reports_presidential_mv'
@@ -266,6 +287,11 @@ class CommitteeReportsPresidential(CommitteeReports):
     net_operating_expenditures_cycle_to_date = db.Column(db.Numeric(30, 2))#mapped
     report_form = 'Form 3P'#do we want this for the efile tables?
 
+    @declared_attr
+    def report(self):
+        return db.relationship(ReportType,
+                               primaryjoin="and_(CommitteeReportsPresidential.report_type==ReportType.report_type)",
+                               foreign_keys=self.report_type, )
 
 class CommitteeReportsIEOnly(PdfMixin, BaseModel):
     __tablename__ = 'ofec_reports_ie_only_mv'
@@ -283,6 +309,13 @@ class CommitteeReportsIEOnly(PdfMixin, BaseModel):
     report_form = 'Form 5'
     is_amended = db.Column(db.Boolean, doc='False indicates that a report is the most recent. True indicates that the report has been superseded by an amendment.')
     receipt_date = db.Column(db.Date, doc=docs.RECEIPT_DATE)
+
+    @declared_attr
+    def report(self):
+        return db.relationship(ReportType,
+                               primaryjoin="and_(CommitteeReportsIEOnly.report_type==ReportType.report_type)",
+                               foreign_keys=self.report_type, )
+
 
 class BaseFilingSummary(db.Model):
     __tablename__ = 'real_efile_summary'

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -20,9 +20,6 @@ spec.definition('SeekInfo', schema=paging_schemas.SeekInfoSchema)
 
 
 class BaseSchema(ModelSchema):
-    report_year = ma.fields.Int()
-    pdf_url = ma.fields.Str()
-    document_description = ma.fields.Str()
 
     def get_attribute(self, attr, obj, default):
         if '.' in attr:
@@ -31,6 +28,9 @@ class BaseSchema(ModelSchema):
 
 class BaseEfileSchema(BaseSchema):
     summary_lines = ma.fields.Method("parse_summary_rows")
+    report_year = ma.fields.Int()
+    pdf_url = ma.fields.Str()
+    document_description = ma.fields.Str()
 
     @post_dump
     def extract_summary_rows(self, obj):

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -20,6 +20,9 @@ spec.definition('SeekInfo', schema=paging_schemas.SeekInfoSchema)
 
 
 class BaseSchema(ModelSchema):
+    report_year = ma.fields.Int()
+    pdf_url = ma.fields.Str()
+    document_description = ma.fields.Str()
 
     def get_attribute(self, attr, obj, default):
         if '.' in attr:
@@ -244,7 +247,8 @@ make_efiling_schema = functools.partial(
     make_schema,
     options={'exclude': ('idx', 'total_disbursements', 'total_receipts' )},
     fields={
-
+        'pdf_url': ma.fields.Str(),
+        'report_year': ma.fields.Int(),
     }
 )
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -322,6 +322,7 @@ make_reports_schema = functools.partial(
     fields={
         'pdf_url': ma.fields.Str(),
         'report_form': ma.fields.Str(),
+        'document_description': ma.fields.Str(),
         'committee_type': ma.fields.Str(attribute='committee.committee_type'),
         'committee_name': ma.fields.Str(attribute='committee.name'),
         'beginning_image_number': ma.fields.Str(),


### PR DESCRIPTION
@noahmanger @ccostino @LindsayYoung, this PR adds the missing fields needed to the efiling summaries: document_description and pdf_url.  Verified that the urls exist, also fixed an ambiguous column name: qual -> qualified_muliticandidate_committee.  Gleaned that from the linked form!!  Yay information!