### PR TITLE
Fix py.test warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ invoke remove_hooks
 ```
 
 #### Create local databases
-Before you can run this project locally, you'll need an API database and a test database. 
+Before you can run this project locally, you'll need a development database and a test database.
 
-To create your databases, run:
+To create these databases, run:
 
 ```
 createdb cfdm_test
@@ -182,6 +182,12 @@ celery worker --app webservices.tasks
 
 ## Testing
 This repo uses [pytest](http://pytest.org/latest/).
+
+If the test database server is *not* the default local Postgres instance, indicate it using:
+
+```
+export SQLA_TEST_CONN=<psql:address-to-box>
+```
 
 Running the tests:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,8 @@ git+https://github.com/18F/rdbms-subsetter
 
 # Testing
 mock>=1.3.0
-pytest>=2.6.4
-pytest-cov>=1.8.1
+pytest>=3.0.2
+pytest-cov>=2.3.1
 factory-boy>=2.5.2
 nplusone>=0.3.0
 webtest>=2.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 addopts=--cov webservices --cov-report term-missing
 
 [flake8]


### PR DESCRIPTION
With py.test >= 3.0, the section name should be [tool:pytest]
Pin to latest versions of pytest and pytest-cov