### PR TITLE
Feature/add mur no endpoint

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -9,14 +9,17 @@ from webservices.utils import use_kwargs
 
 es = utils.get_elasticsearch_connection()
 
-class AdvisoryOpinion(utils.Resource):
+class GetLegalDocument(utils.Resource):
     @property
     def args(self):
-        return {"ao_no": fields.Str(required=True, description='Advisory opinion number to fetch.')}
+        return {"no": fields.Str(required=True, description='Document number to fetch.'),
+                "doc_type": fields.Str(required=True, description='Document type to fetch.')}
 
-    def get(self, ao_no, **kwargs):
+    def get(self, doc_type, no, **kwargs):
+        print(no)
+        print(doc_type)
         es_results = Search().using(es) \
-          .query('bool', must=[Q('term', no=ao_no), Q('term', _type='advisory_opinions')]) \
+          .query('bool', must=[Q('term', no=no), Q('term', _type=doc_type)]) \
           .source(exclude='text') \
           .extra(size=200) \
           .execute()

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -16,8 +16,6 @@ class GetLegalDocument(utils.Resource):
                 "doc_type": fields.Str(required=True, description='Document type to fetch.')}
 
     def get(self, doc_type, no, **kwargs):
-        print(no)
-        print(doc_type)
         es_results = Search().using(es) \
           .query('bool', must=[Q('term', no=no), Q('term', _type=doc_type)]) \
           .source(exclude='text') \

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -237,7 +237,8 @@ api.add_resource(filings.FilingsList, '/filings/')
 api.add_resource(download.DownloadView, '/download/<path:path>/')
 
 api.add_resource(legal.UniversalSearch, '/legal/search/')
-api.add_resource(legal.AdvisoryOpinion, '/legal/advisory_opinion/<ao_no>')
+print('*' * 50)
+api.add_resource(legal.GetLegalDocument, '/legal/docs/<doc_type>/<no>')
 api.add_resource(load.Legal, '/load/legal/')
 
 app.config.update({

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -237,7 +237,6 @@ api.add_resource(filings.FilingsList, '/filings/')
 api.add_resource(download.DownloadView, '/download/<path:path>/')
 
 api.add_resource(legal.UniversalSearch, '/legal/search/')
-print('*' * 50)
 api.add_resource(legal.GetLegalDocument, '/legal/docs/<doc_type>/<no>')
 api.add_resource(load.Legal, '/load/legal/')
 


### PR DESCRIPTION
This makes the AdvisoryOpinions endpoint generic to fetch any doc by its `no`. Updates AO test and adds one for getting mur by `no`.