### PR TITLE
Adds committee names back into itemized schedule downloads

### DIFF
--- a/data/sql_updates/committee_history.sql
+++ b/data/sql_updates/committee_history.sql
@@ -102,6 +102,7 @@ order by fec_yr.cmte_id, fec_yr.fec_election_yr desc, dcp.rpt_yr desc
 
 create unique index on ofec_committee_history_mv_tmp(idx);
 
+create index on ofec_committee_history_mv_tmp(name);
 create index on ofec_committee_history_mv_tmp(cycle);
 create index on ofec_committee_history_mv_tmp(committee_id);
 create index on ofec_committee_history_mv_tmp(designation);

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -219,9 +219,6 @@ class ScheduleE(BaseItemized):
 
     sched_e_sk = db.Column(db.Integer, primary_key=True)
 
-    # Committe info
-    committee_name = db.Column('cmte_nm', db.String, doc=docs.COMMITTEE_ID)
-
     # Payee info
     payee_prefix = db.Column(db.String)
     payee_name = db.Column('pye_nm', db.String)

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -2,6 +2,8 @@
 import re
 import functools
 
+from collections import namedtuple
+
 import marshmallow as ma
 from marshmallow_sqlalchemy import ModelSchema
 from marshmallow_pagination import schemas as paging_schemas
@@ -18,6 +20,19 @@ from sqlalchemy import func
 spec.definition('OffsetInfo', schema=paging_schemas.OffsetInfoSchema)
 spec.definition('SeekInfo', schema=paging_schemas.SeekInfoSchema)
 
+# A namedtuple used to help capture any additional columns that should be
+# included with exported data:
+# field: the field object definining the relationship on a model, e.g.,
+#   models.ScheduleA.committee (an object)
+# column: the column object found in the related model, e.g.,
+#   models.CommitteeHistory.name (an object)
+# label: the label to use for the column in the query that will appear in the
+# header row of the output, e.g.,
+#   'committee_name' (a string)
+
+# Usage:  Define a custom attribute in a schema's Meta options object called
+# 'relationships' and set to a list of one or more relationships.
+Relationship = namedtuple('Relationship', ['field', 'column', 'label', ])
 
 class BaseSchema(ModelSchema):
 
@@ -405,6 +420,13 @@ ScheduleASchema = make_schema(
             'contributor_employer_text',
             'contributor_occupation_text',
         ),
+        'relationships': [
+            Relationship(
+                models.ScheduleA.committee,
+                models.CommitteeHistory.name,
+                'committee_name',
+            ),
+        ],
     }
 )
 
@@ -501,6 +523,13 @@ ScheduleBSchema = make_schema(
             'recipient_name_text',
             'disbursement_description_text'
         ),
+        'relationships': [
+            Relationship(
+                models.ScheduleB.committee,
+                models.CommitteeHistory.name,
+                'committee_name',
+            ),
+        ],
     }
 )
 ScheduleBPageSchema = make_page_schema(ScheduleBSchema, page_type=paging_schemas.SeekPageSchema)
@@ -522,6 +551,13 @@ ScheduleESchema = make_schema(
         'exclude': (
             'payee_name_text',
         ),
+        'relationships': [
+            Relationship(
+                models.ScheduleE.committee,
+                models.CommitteeHistory.name,
+                'committee_name',
+            ),
+        ],
     }
 )
 ScheduleEPageSchema = make_page_schema(ScheduleESchema, page_type=paging_schemas.SeekPageSchema)

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -29,10 +29,25 @@ spec.definition('SeekInfo', schema=paging_schemas.SeekInfoSchema)
 # label: the label to use for the column in the query that will appear in the
 # header row of the output, e.g.,
 #   'committee_name' (a string)
+# position: the spot within the list of columns that this should be inserted
+# at; defaults to -1 (end of the list), e.g.,
+#   1 (an integer, in this case the second spot in a list)
 
 # Usage:  Define a custom attribute in a schema's Meta options object called
 # 'relationships' and set to a list of one or more relationships.
-Relationship = namedtuple('Relationship', ['field', 'column', 'label', ])
+#
+# Note:  There is no clean way to provide default values for a namedtuple at
+# the moment. This wrapper is modeled after the following post:
+# https://ceasarjames.wordpress.com/2012/03/19/how-to-use-default-arguments-with-namedtuple/
+class Relationship(namedtuple('Relationship', 'field column label position')):
+    def __new__(cls, field, column, label, position=-1):
+        return super(Relationship, cls).__new__(
+            cls,
+            field,
+            column,
+            label,
+            position
+        )
 
 class BaseSchema(ModelSchema):
 
@@ -425,6 +440,7 @@ ScheduleASchema = make_schema(
                 models.ScheduleA.committee,
                 models.CommitteeHistory.name,
                 'committee_name',
+                1
             ),
         ],
     }
@@ -528,6 +544,7 @@ ScheduleBSchema = make_schema(
                 models.ScheduleB.committee,
                 models.CommitteeHistory.name,
                 'committee_name',
+                1
             ),
         ],
     }
@@ -556,6 +573,7 @@ ScheduleESchema = make_schema(
                 models.ScheduleE.committee,
                 models.CommitteeHistory.name,
                 'committee_name',
+                1
             ),
         ],
     }

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -71,7 +71,7 @@ def parse_kwargs(resource, qs):
         kwargs = flaskparser.parser.parse(fields)
     return fields, kwargs
 
-def query_with_labels(query, schema, sorted=False):
+def query_with_labels(query, schema, sort_columns=False):
     """Create a new query that labels columns according to the SQLAlchemy
     model.  Properties that are excluded by `schema` will be ignored.
 
@@ -83,7 +83,7 @@ def query_with_labels(query, schema, sorted=False):
 
     :param query: Original SQLAlchemy query
     :param schema: Optional schema specifying properties to exclude
-    :param sorted: Optional flag to sort the column labels by name
+    :param sort_columns: Optional flag to sort the column labels by name
     :returns: Query with labeled entities
     """
     exclude = getattr(schema.Meta, 'exclude', ())
@@ -100,7 +100,7 @@ def query_with_labels(query, schema, sorted=False):
         if relationship.field not in joins:
             joins.append(relationship.field)
 
-    if sorted:
+    if sort_columns:
         entities.sort(key=lambda x: x.name)
 
     if joins:
@@ -166,7 +166,7 @@ def make_bundle(resource):
             query = query_with_labels(
                 resource['query'],
                 resource['schema'],
-                sorted=True
+                sort_columns=True
             )
             copy_to(
                 query,

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -95,7 +95,13 @@ def query_with_labels(query, schema, sort_columns=False):
     ]
 
     for relationship in relationships:
-        entities.append(relationship.column.label(relationship.label))
+        if relationship.position == -1:
+            entities.append(relationship.column.label(relationship.label))
+        else:
+            entities.insert(
+                relationship.position,
+                relationship.column.label(relationship.label)
+            )
 
         if relationship.field not in joins:
             joins.append(relationship.field)
@@ -165,8 +171,7 @@ def make_bundle(resource):
         with open(csv_path, 'w') as fp:
             query = query_with_labels(
                 resource['query'],
-                resource['schema'],
-                sort_columns=True
+                resource['schema']
             )
             copy_to(
                 query,


### PR DESCRIPTION
Closes #1940 

This changeset addresses #1940 by adding support for related fields back into our exports on the itemized tables.  It does this by defining an extra attribute in our schema Meta objects that is ignored by everything but our export code.  This extra attribute allows you to set additional columns that are found in nested models related to the parent model you are trying to export.  If any are defined, the export functionality will follow the relationship to pull the information out and display it in the output with the specified label.  Documentation in the schema provides more information on how to do this.

This changeset also modifies our Schedule E model by removing the `committee_name` field set directly to the `cmte_nm` field in the table.  This field can sometimes be `null`, so we should be pulling it from the related `CommitteeHistory` model instead, just like the Schedule A and B models already do.

Lastly, this also supports an option to sort the columns in the output alphabetically.  This is disabled for now, but there is support to insert these additional conditional columns into specific positions as opposed to just the end.  This is used for the new `committee_name` column added back in for this PR.

/cc @LindsayYoung and @jontours