### PR TITLE
Adds support for exporting more itemized schedule endpoints

### DIFF
--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -14,8 +14,8 @@ from webservices import utils
 from webservices.common import counts
 from webservices.common.models import db
 from webservices.resources import (
-    candidates, candidate_aggregates, committees, costs, filings, reports,
-    sched_a, sched_b, sched_e
+    aggregates, candidates, candidate_aggregates, committees, costs, filings,
+    reports, sched_a, sched_b, sched_e
 )
 
 from webservices.tasks import app
@@ -25,6 +25,14 @@ logger = logging.getLogger(__name__)
 
 IGNORE_FIELDS = {'page', 'per_page', 'sort', 'sort_hide_null'}
 RESOURCE_WHITELIST = {
+    aggregates.ScheduleABySizeView,
+    aggregates.ScheduleAByStateView,
+    aggregates.ScheduleAByZipView,
+    aggregates.ScheduleAByEmployerView,
+    aggregates.ScheduleAByOccupationView,
+    aggregates.ScheduleBByRecipientView,
+    aggregates.ScheduleBByRecipientIDView,
+    aggregates.ScheduleBByPurposeView,
     candidates.CandidateList,
     committees.CommitteeList,
     costs.CommunicationCostView,

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -15,7 +15,7 @@ from webservices.common import counts
 from webservices.common.models import db
 from webservices.resources import (
     aggregates, candidates, candidate_aggregates, committees, costs, filings,
-    reports, sched_a, sched_b, sched_e
+    reports, sched_a, sched_b, sched_d, sched_e, sched_f
 )
 
 from webservices.tasks import app
@@ -45,7 +45,9 @@ RESOURCE_WHITELIST = {
     reports.EFilingSummaryView,
     sched_a.ScheduleAView,
     sched_b.ScheduleBView,
+    sched_d.ScheduleDView,
     sched_e.ScheduleEView,
+    sched_f.ScheduleFView
 }
 
 COUNT_NOTE = (


### PR DESCRIPTION
Closes #1947

This changeset enables support to export most of our remaining itemized schedule endpoints.

I'm keeping this open for now in case we want to add more, right now I've only enabled all of what we have for schedule A and B as well as the main schedule D and F endpoints.

/cc @LindsayYoung and @jontours 