### PR TITLE
Fixes date tests

### DIFF
--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -109,19 +109,20 @@ class TestCalendarDates(ApiBaseTest):
 
 
 class TestCalendarExport(ApiBaseTest):
-
+    today = datetime.datetime.now()
     def setUp(self):
         super().setUp()
+
         self.dates = [
             factories.CalendarDateFactory(
                 category='election',
-                start_date=datetime.datetime(2015, 10, 1),
+                start_date=datetime.datetime(self.today.year, 10, 1),
                 all_day=True,
             ),
             factories.CalendarDateFactory(
                 category='Roundtables',
-                start_date=datetime.datetime(2015, 10, 31, 2),
-                end_date=datetime.datetime(2015, 10, 31, 3)
+                start_date=datetime.datetime(self.today.year, 10, 31, 2),
+                end_date=datetime.datetime(self.today.year, 10, 31, 3)
             ),
         ]
 
@@ -140,5 +141,5 @@ class TestCalendarExport(ApiBaseTest):
         assert len(components) == 2
         assert str(components[0]['CATEGORIES']) == 'election'
         timezone = pytz.timezone('US/Eastern')
-        assert components[0]['DTSTART'].dt == datetime.date(2015, 10, 1)
-        assert components[1]['DTSTART'].dt == timezone.localize(datetime.datetime(2015, 10, 31, 2))
+        assert components[0]['DTSTART'].dt == datetime.date(self.today.year, 10, 1)
+        assert components[1]['DTSTART'].dt == timezone.localize(datetime.datetime(self.today.year, 10, 31, 2))


### PR DESCRIPTION
@ccostino @LindsayYoung This is the fix for the tests.  We talked about changing how filtering works on the endpoint to fix this.  But after looking at this in the morning it was unclear to me how to modify the endpoint without breaking previous functionality.  This change allows the tests to be year independent and still tests the logic in the same way as before, which to me is the most lightweight, low-impact way to support this test.

If there are still some changes that we think we need to make on the endpoint, I will have to talk to someone about it more, as I don't want to break anything.  Mostly it's unclear how to override default behavior as we have no arguments for `start_date` or `end_date`.  We have `min` and `max` for both of those, but I didn't feel comfortable adding what could potentially be complicated logic just to fix a couple of breaking tests.