### PR TITLE
Add committee names to itemized aggregate exports

### DIFF
--- a/webservices/common/models/aggregates.py
+++ b/webservices/common/models/aggregates.py
@@ -6,6 +6,7 @@ from .base import db, BaseModel
 class BaseAggregate(BaseModel):
     __abstract__ = True
 
+    committee = utils.related_committee_history('committee_id', cycle_label='cycle')
     committee_id = db.Column('cmte_id', db.String, primary_key=True, doc=docs.COMMITTEE_ID)
     cycle = db.Column(db.Integer, primary_key=True, doc=docs.RECORD_CYCLE)
     #? not sure how to document this

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -246,6 +246,7 @@ def augment_itemized_aggregate_models(factory, committee_model, *models, namespa
         schema = factory(
             model,
             options={
+                'exclude': ('committee',),
                 'relationships': [
                     Relationship(
                         model.committee,

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -241,6 +241,23 @@ def augment_models(factory, *models, namespace=schemas):
         schema = factory(model)
         augment_schemas(schema, namespace=namespace)
 
+def augment_itemized_aggregate_models(factory, committee_model, *models, namespace=schemas):
+    for model in models:
+        schema = factory(
+            model,
+            options={
+                'relationships': [
+                    Relationship(
+                        model.committee,
+                        committee_model.name,
+                        'committee_name',
+                        1
+                    ),
+                ],
+            }
+        )
+        augment_schemas(schema, namespace=namespace)
+
 class ApiSchema(ma.Schema):
     def _postprocess(self, data, many, obj):
         ret = {'api_version': __API_VERSION__}
@@ -486,8 +503,9 @@ ScheduleBByRecipientIDSchema = make_schema(
 
 augment_schemas(ScheduleBByRecipientIDSchema)
 
-augment_models(
+augment_itemized_aggregate_models(
     make_schema,
+    models.CommitteeHistory,
     models.ScheduleAByZip,
     models.ScheduleABySize,
     models.ScheduleAByState,


### PR DESCRIPTION
This changeset adds support for displaying committee names in the CSV exports of the itemized aggregate tables.  There is a small amount of technical debt taken on here as I had to incorporate the relationships across multiple models and the existing schema creation convenience methods do not account for this easily.  There might be a way to simplify this in the future, but I also did not want to impact the existing schema building that we have.

This may also expose some additional committee information in the API endpoints, but we can exclude those if need be.

/cc @LindsayYoung and @jontours 