### PR TITLE
Added coverage start and end date to candidate totals materialized view

### DIFF
--- a/webservices/common/models/candidates.py
+++ b/webservices/common/models/candidates.py
@@ -131,6 +131,8 @@ class CandidateTotal(db.Model):
     disbursements = db.Column(db.Numeric(30, 2), index=True)
     cash_on_hand_end_period = db.Column(db.Numeric(30, 2))
     debts_owed_by_committee = db.Column(db.Numeric(30, 2))
+    coverage_start_date = db.Column(db.Date, doc=docs.COVERAGE_START_DATE)
+    coverage_end_date = db.Column(db.Date, doc=docs.COVERAGE_END_DATE)
 
 
 class CandidateElection(db.Model):


### PR DESCRIPTION
This is ready for review.  Adding `coverage_start_date` and `coverage_end_date` wasn't all that difficult as it turned out.  Have to run update_schemas to fully test this on dev, as it is backed by a materialized view.

/cc @noahmanger @LindsayYoung @ccostino 

Addresses https://github.com/18F/openFEC-web-app/issues/1584.