### PR TITLE
[WIP] Adds secondary sorting for itemized resources in the API

### DIFF
--- a/webservices/sorting.py
+++ b/webservices/sorting.py
@@ -3,6 +3,15 @@ import sqlalchemy as sa
 from webservices.exceptions import ApiError
 from webservices.common.util import get_class_by_tablename
 
+ITEMIZED_MODELS = (
+    'ScheduleA',
+    'ScheduleB',
+    'ScheduleC',
+    'ScheduleD',
+    'ScheduleE',
+    'ScheduleF'
+)
+
 
 def parse_option(option, model=None, aliases=None, join_columns=None, query=None):
     """Parse sort option to SQLAlchemy order expression.
@@ -69,11 +78,17 @@ def sort(query, key, model, aliases=None, join_columns=None, clear=False,
         join_columns=join_columns,
         query=query
     )
-    query = query.order_by(order(column))
+
+    if model.__name__ in ITEMIZED_MODELS:
+        query = query.order_by(order(column), order(model.sub_id))
+    else:
+        query = query.order_by(order(column))
+
     if relationship:
         query = query.join(relationship)
     if hide_null:
         query = query.filter(column != None)  # noqa
     if index_column:
         query = query.order_by(order(index_column))
+
     return query, (column, order)


### PR DESCRIPTION
**[WIP:  DON'T MERGE]**

This changeset adds support for adding a secondary sort column for all itemized resources to help address the issue with paging through records that have `null` values for the initial sort column (e.g., `expenditure_date` for `ScheduleE`).  This does not fully fix the issue though as the instructions and usage still indicate that if you want to preserve ordering in your result you need to supply the `last_x` column (with `x` being the column you are sorting on) in addition to the `last_index` parameter.  This is still being hammered out and discussed in issue #1960.