### PR TITLE
Feature/disclosure transition

### DIFF
--- a/data/sql_updates/cand_cmte_linkage.sql
+++ b/data/sql_updates/cand_cmte_linkage.sql
@@ -3,7 +3,7 @@ create materialized view ofec_cand_cmte_linkage_mv_tmp as
 select
     row_number() over () as idx,
     *
-from cand_cmte_linkage
+from disclosure.cand_cmte_linkage
 where
     substr(cand_id, 1, 1) = cmte_tp or
     cmte_tp not in ('P', 'S', 'H')

--- a/data/sql_updates/candidate_fulltext.sql
+++ b/data/sql_updates/candidate_fulltext.sql
@@ -10,7 +10,7 @@ with nicknames as (
     select
         cand_id as candidate_id,
         sum(receipts) as receipts
-    from cand_cmte_linkage link
+    from disclosure.cand_cmte_linkage link
     join ofec_totals_combined_mv_tmp totals on
         link.cmte_id = totals.committee_id and
         link.fec_election_yr = totals.cycle

--- a/data/sql_updates/candidate_history.sql
+++ b/data/sql_updates/candidate_history.sql
@@ -2,13 +2,13 @@ drop materialized view if exists ofec_candidate_history_mv_tmp cascade;
 create materialized view ofec_candidate_history_mv_tmp as
 with
     -- Select rows from `cand_valid_fec_yr` that are associated with principal
-    -- or authorized committees via `cand_cmte_linkage`
+    -- or authorized committees via `disclosure.cand_cmte_linkage`
     fec_yr as (
         select
             distinct on (cand_valid_yr_id)
             cand.*
-        from cand_valid_fec_yr cand
-        join cand_cmte_linkage link on
+        from disclosure.cand_valid_fec_yr cand
+        join disclosure.cand_cmte_linkage link on
             cand.cand_id = link.cand_id and
             cand.fec_election_yr = link.fec_election_yr and
             link.linkage_type in ('P', 'A')

--- a/data/sql_updates/committee_history.sql
+++ b/data/sql_updates/committee_history.sql
@@ -6,7 +6,7 @@ with
             cmte_id,
             array_agg(fec_election_yr)::int[] as cycles,
             max(fec_election_yr) as max_cycle
-        from cmte_valid_fec_yr
+        from disclosure.cmte_valid_fec_yr
         group by cmte_id
     ),
     dates as (
@@ -22,7 +22,7 @@ with
         select
             cmte_id,
             array_agg(distinct cand_id)::text[] as candidate_ids
-        from cand_cmte_linkage
+        from disclosure.cand_cmte_linkage
         group by cmte_id
     )
 select distinct on (fec_yr.cmte_id, fec_yr.fec_election_yr)
@@ -91,7 +91,7 @@ select distinct on (fec_yr.cmte_id, fec_yr.fec_election_yr)
     fec_yr.cmte_pty_affiliation_desc as party_full,
     cycles.cycles,
     coalesce(candidates.candidate_ids, '{}'::text[]) as candidate_ids
-from cmte_valid_fec_yr fec_yr
+from disclosure.cmte_valid_fec_yr fec_yr
 left join dimcmteproperties dcp on fec_yr.cmte_id = dcp.cmte_id and fec_yr.fec_election_yr >= dcp.rpt_yr
 left join cycles on fec_yr.cmte_id = cycles.cmte_id
 left join dates on fec_yr.cmte_id = dates.cmte_id

--- a/data/sql_updates/election_outcome.sql
+++ b/data/sql_updates/election_outcome.sql
@@ -3,7 +3,7 @@ drop materialized view if exists ofec_election_result_mv_tmp;
 create materialized view ofec_election_result_mv_tmp as
 (
     select fec_election_yr - 4 as election_yr, *
-    from cand_valid_fec_yr
+    from disclosure.cand_valid_fec_yr
     where
         cand_ici = 'I' and
         cand_office = 'P' and
@@ -14,7 +14,7 @@ union all
 (
     select distinct on (cand_office_st, cand_election_yr)
         cand_election_yr - 6 as election_yr, *
-    from cand_valid_fec_yr
+    from disclosure.cand_valid_fec_yr
     where
         cand_ici = 'I' and
         cand_office = 'S'
@@ -27,7 +27,7 @@ union all
 (
     select distinct on (cand_office_st, cand_office_district, cand_election_yr)
         cand_election_yr - 2 as election_yr, *
-    from cand_valid_fec_yr
+    from disclosure.cand_valid_fec_yr
     where
         cand_ici = 'I' and
         cand_office = 'H'

--- a/data/sql_updates/omnibus_dates.sql
+++ b/data/sql_updates/omnibus_dates.sql
@@ -64,7 +64,7 @@ with elections_raw as(
                 ], '-')
             else elections_raw.election_state
         end as report_contest
-    from trc_report_due_date reports
+    from disclosure.trc_report_due_date reports
     left join dimreporttype on reports.report_type = dimreporttype.rpt_tp
     left join elections_raw using (trc_election_id)
     where

--- a/data/subset-config.json
+++ b/data/subset-config.json
@@ -43,13 +43,13 @@
     "cand_cmte_linkage": [
       {
         "referred_schema": null,
-        "referred_table": "cand_valid_fec_yr",
+        "referred_table": "disclosure.cand_valid_fec_yr",
         "referred_columns": ["cand_id"],
         "constrained_columns": ["cand_id"]
       },
       {
         "referred_schema": null,
-        "referred_table": "cmte_valid_fec_yr",
+        "referred_table": "disclosure.cmte_valid_fec_yr",
         "referred_columns": ["cmte_id"],
         "constrained_columns": ["cmte_id"]
       }

--- a/tests/common.py
+++ b/tests/common.py
@@ -22,6 +22,13 @@ def _reset_schema():
     rest.db.engine.execute('drop schema if exists public cascade;')
     rest.db.engine.execute('drop schema if exists disclosure cascade;')
     rest.db.engine.execute('create schema public;')
+    rest.db.engine.execute('create schema disclosure;')
+
+
+def _reset_schema_for_integration():
+    rest.db.engine.execute('drop schema if exists public cascade;')
+    rest.db.engine.execute('drop schema if exists disclosure cascade;')
+    rest.db.engine.execute('create schema public;')
 
 
 class BaseTestCase(unittest.TestCase):
@@ -102,7 +109,14 @@ class IntegrationTestCase(BaseTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(IntegrationTestCase, cls).setUpClass()
+        rest.app.config['TESTING'] = True
+        rest.app.config['SQLALCHEMY_DATABASE_URI'] = TEST_CONN
+        rest.app.config['PRESERVE_CONTEXT_ON_EXCEPTION'] = False
+        cls.app = rest.app.test_client()
+        cls.client = TestApp(rest.app)
+        cls.app_context = rest.app.app_context()
+        cls.app_context.push()
+        _reset_schema_for_integration()
         with open(os.devnull, 'w') as null:
             subprocess.check_call(
                 ['pg_restore', './data/subset.dump', '--dbname', TEST_CONN, '--no-acl', '--no-owner'],

--- a/webservices/common/models/dates.py
+++ b/webservices/common/models/dates.py
@@ -13,6 +13,10 @@ class ReportType(db.Model):
     report_type_full = db.Column('rpt_tp_desc', db.String, index=True, doc=docs.REPORT_TYPE)
 
 
+class DisclosureMixin(object):
+    __table__args = {"schema": "disclosure"}
+
+
 class ReportDate(db.Model):
     __tablename__ = 'trc_report_due_date'
 
@@ -28,6 +32,10 @@ class ReportDate(db.Model):
     @property
     def report_type_full(self):
         return clean_report_type(self.report.report_type_full)
+
+
+class ReportDateDisclosure(DisclosureMixin, ReportDate):
+    pass
 
 
 REPORT_TYPE_CLEAN = re.compile(r'{[^)]*}')

--- a/webservices/common/models/dates.py
+++ b/webservices/common/models/dates.py
@@ -2,8 +2,11 @@ import re
 
 from webservices import decoders, docs
 from sqlalchemy.dialects.postgresql import ARRAY, TSVECTOR
+from sqlalchemy.ext.declarative import declared_attr
 
 from .base import db, BaseModel
+
+#Base = declarative_base()
 
 
 class ReportType(db.Model):
@@ -14,28 +17,31 @@ class ReportType(db.Model):
 
 
 class DisclosureMixin(object):
-    __table__args = {"schema": "disclosure"}
+    __table_args__ = {"schema": "disclosure"}
 
 
-class ReportDate(db.Model):
-    __tablename__ = 'trc_report_due_date'
-
+class DateMixin(object):
     trc_report_due_date_id = db.Column(db.BigInteger, primary_key=True)
     report_year = db.Column(db.Integer, index=True, doc=docs.REPORT_YEAR)
-    report_type = db.Column(db.String, db.ForeignKey(ReportType.report_type), index=True)
     due_date = db.Column(db.Date, index=True, doc=docs.DUE_DATE)
     create_date = db.Column(db.Date, index=True, doc=docs.CREATE_DATE)
     update_date = db.Column(db.Date, index=True, doc=docs.UPDATE_DATE)
-
-    report = db.relationship(ReportType)
 
     @property
     def report_type_full(self):
         return clean_report_type(self.report.report_type_full)
 
 
-class ReportDateDisclosure(DisclosureMixin, ReportDate):
-    pass
+class ReportDateForTest(db.Model, DateMixin):
+    __tablename__ = 'trc_report_due_date'
+    report = db.relationship(ReportType)
+    report_type = db.Column(db.String, db.ForeignKey(ReportType.report_type), index=True)
+
+
+class ReportDate(db.Model, DateMixin, DisclosureMixin):
+    __tablename__ = 'trc_report_due_date'
+    report = db.relationship(ReportType)
+    report_type = db.Column(db.String, db.ForeignKey(ReportType.report_type), index=True)
 
 
 REPORT_TYPE_CLEAN = re.compile(r'{[^)]*}')

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -673,7 +673,7 @@ ReportTypeSchema = make_schema(models.ReportType)
 register_schema(ReportTypeSchema)
 
 ReportingDatesSchema = make_schema(
-    models.ReportDateDisclosure,
+    models.ReportDate,
     fields={
         'report_type': ma.fields.Str(),
         'report_type_full': ma.fields.Str(),

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -673,7 +673,7 @@ ReportTypeSchema = make_schema(models.ReportType)
 register_schema(ReportTypeSchema)
 
 ReportingDatesSchema = make_schema(
-    models.ReportDate,
+    models.ReportDateDisclosure,
     fields={
         'report_type': ma.fields.Str(),
         'report_type_full': ma.fields.Str(),


### PR DESCRIPTION
This is ready to review.  Had some interesting git issues this morning (I can bore you with the details if need be), so opened this PR in lieu of the closed one.

This was mostly straightforward. There was an issue being that one of the models (`dates.py`) referenced a table directly that moved to the `disclosure` schema.  It wasn't hard figuring out how to map it to a different table, however the tests didn't recognize the syntax needed to point to a new table.  I created a mixin to solve this; essential for that one table the public schema is used for the tests and when deployed will use the disclosure schema.

/cc
@LindsayYoung @ccostino