### PR TITLE
Relax candidate table construction

### DIFF
--- a/data/sql_updates/candidate_history.sql
+++ b/data/sql_updates/candidate_history.sql
@@ -8,7 +8,7 @@ with
             distinct on (cand_valid_yr_id)
             cand.*
         from disclosure.cand_valid_fec_yr cand
-        join disclosure.cand_cmte_linkage link on
+        left join disclosure.cand_cmte_linkage link on
             cand.cand_id = link.cand_id and
             cand.fec_election_yr = link.fec_election_yr and
             link.linkage_type in ('P', 'A')


### PR DESCRIPTION
I think this is a nice way to expose more candidates while keeping options to restrict them.  Some of the candidates will be `U` type candidates, however the `principal_committees` will still only be `P` type committees, so we can decorate any of the resources (how candidate search is done now) with more restrictions on a case-by-case basis.

@LindsayYoung @ccostino 
