### PR TITLE
prevent accidents 

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -65,3 +65,6 @@ data/subset.dump
 
 # Celery artifacts
 celerybeat-schedule
+
+# Credientials
+*.env.json

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ target/
 
 # Celery artifacts
 celerybeat-schedule
+
+# Credientials
+*.env.json


### PR DESCRIPTION
Since we need to make files to change the creds, I don't want those accidentally checked into source control. This will catch files that have the naming convention we outline in the wiki:
https://github.com/18F/openFEC/wiki/switch-out-cf-service-environment-variables