### PR TITLE
Keyset pagination fix

### DIFF
--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -70,7 +70,11 @@ def fetch_page(query, kwargs, model=None, aliases=None, join_columns=None, clear
 
 def fetch_seek_page(query, kwargs, index_column, clear=False, count=None, cap=100, eager=True):
     paginator = fetch_seek_paginator(query, kwargs, index_column, clear=clear, count=count, cap=cap)
-    return paginator.get_page(last_index=kwargs['last_index'], sort_index=None, eager=eager)
+    if paginator.sort_column is not None:
+        sort_index = kwargs['last_{0}'.format(paginator.sort_column[0].key)]
+    else:
+        sort_index = None
+    return paginator.get_page(last_index=kwargs['last_index'], sort_index=sort_index, eager=eager)
 
 
 def fetch_seek_paginator(query, kwargs, index_column, clear=False, count=None, cap=100):


### PR DESCRIPTION
Addresses https://github.com/18F/openFEC/issues/2022.  The sort column is needed to ensure pagination can sort through pages and guarantee already seen records don't appear again, aka duplicates.

However, may employ a similar strategy to actually page through nulls, once they appear in the data set.  But strategy to employ will most likely be a little different.

cc @LindsayYoung @ccostino 