### PR TITLE
Simplify citation text and links

### DIFF
--- a/tests/test_load_current_murs.py
+++ b/tests/test_load_current_murs.py
@@ -13,21 +13,22 @@ from tests.common import TEST_CONN, BaseTestCase
 
 @pytest.mark.parametrize("test_input,case_id,entity_id,expected", [
     ("110", 1, 2,
-        [{'text': '11 C.F.R. 110', 'url': '/regulations/110/CURRENT'}]),
+        [{'text': '110', 'title': '11', 'type': 'regulation', 'url': '/regulations/110/CURRENT'}]),
     ("110.21", 1, 2,
-        [{'text': '11 C.F.R. 110.21', 'url': '/regulations/110-21/CURRENT'}]),
+        [{'text': '110.21', 'title': '11', 'type': 'regulation', 'url': '/regulations/110-21/CURRENT'}]),
     ("114.5(a)(3)", 1, 2,
-        [{'text': '11 C.F.R. 114.5(a)(3)', 'url': '/regulations/114-5/CURRENT'}]),
+        [{'text': '114.5(a)(3)', 'title': '11', 'type': 'regulation', 'url': '/regulations/114-5/CURRENT'}]),
     ("114.5(a)(3)-(5)", 1, 2,
-        [{'text': '11 C.F.R. 114.5(a)(3)-(5)', 'url': '/regulations/114-5/CURRENT'}]),
+        [{'text': '114.5(a)(3)-(5)', 'title': '11', 'type': 'regulation', 'url': '/regulations/114-5/CURRENT'}]),
     ("102.17(a)(l)(i), (b)(l), (b)(2), and (c)(3)", 1, 2,
-        [{'text': '11 C.F.R. 102.17(a)(l)(i), (b)(l), (b)(2), and (c)(3)', 'url': '/regulations/102-17/CURRENT'}
+        [{'text': '102.17(a)(l)(i), (b)(l), (b)(2), and (c)(3)', 'title': '11',
+          'type': 'regulation', 'url': '/regulations/102-17/CURRENT'}
          ]),
     ("102.5(a)(2); 104.3(a)(4)(i); 114.5(a)(3)-(5); 114.5(g)(1)", 1, 2,
-        [{'text': '11 C.F.R. 102.5(a)(2)', 'url': '/regulations/102-5/CURRENT'},
-         {'text': '11 C.F.R. 104.3(a)(4)(i)', 'url': '/regulations/104-3/CURRENT'},
-         {'text': '11 C.F.R. 114.5(a)(3)-(5)', 'url': '/regulations/114-5/CURRENT'},
-         {'text': '11 C.F.R. 114.5(g)(1)', 'url': '/regulations/114-5/CURRENT'}
+        [{'text': '102.5(a)(2)', 'title': '11', 'type': 'regulation', 'url': '/regulations/102-5/CURRENT'},
+         {'text': '104.3(a)(4)(i)', 'title': '11', 'type': 'regulation', 'url': '/regulations/104-3/CURRENT'},
+         {'text': '114.5(a)(3)-(5)', 'title': '11', 'type': 'regulation', 'url': '/regulations/114-5/CURRENT'},
+         {'text': '114.5(g)(1)', 'title': '11', 'type': 'regulation', 'url': '/regulations/114-5/CURRENT'}
          ]),
 ])
 def test_parse_regulatory_citations(test_input, case_id, entity_id, expected):
@@ -35,33 +36,53 @@ def test_parse_regulatory_citations(test_input, case_id, entity_id, expected):
 
 @pytest.mark.parametrize("test_input,case_id,entity_id,expected", [
     ("431", 1, 2,    # With reclassification
-        [{'text': '2 U.S.C. 431',
+        [{'text': '431',
+          'title': '2',
+          'type': 'statute',
           'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html'
           '&title=52&section=30101'}]),
     ("30116", 1, 2,  # Already reclassified
-        [{'text': '52 U.S.C. 30116',
+        [{'text': '30116',
+          'title': '52',
+          'type': 'statute',
         'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=52&section=30116'}]),
     ("434(a)(11)", 1, 2,
-        [{'text': '2 U.S.C. 434(a)(11)',
+        [{'text': '434(a)(11)',
+          'title': '2',
+          'type': 'statute',
         'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=52&section=30104'}]),
     ("9999", 1, 2,
-        [{'text': '2 U.S.C. 9999',
+        [{'text': '9999',
+          'title': '2',
+          'type': 'statute',
         'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=2&section=9999'}]),
     ("9993(c)(2)", 1, 2,
-        [{'text': '2 U.S.C. 9993(c)(2)',
+        [{'text': '9993(c)(2)',
+          'title': '2',
+          'type': 'statute',
         'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=2&section=9993'}]),
     ("9993(a)(4) formerly 438(a)(4)", 1, 2,
-        [{'text': '2 U.S.C. 9993(a)(4)',
+        [{'text': '9993(a)(4)',
+          'title': '2',
+          'type': 'statute',
         'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=2&section=9993'}]),
     ("9116(a)(2)(A), 9114(b) (formerly 441a(a)(2)(A), 434(b)), 30116(f) (formerly 441a(f))", 1, 2,
-        [{'text': '2 U.S.C. 9116(a)(2)(A)',
+        [{'text': '9116(a)(2)(A)',
+          'title': '2',
+          'type': 'statute',
         'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=2&section=9116'},
-        {'text': '2 U.S.C. 9114(b)',
+        {'text': '9114(b)',
+          'title': '2',
+          'type': 'statute',
         'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=2&section=9114'},
-        {'text': '52 U.S.C. 30116(f)',
+        {'text': '30116(f)',
+          'title': '52',
+          'type': 'statute',
         'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=52&section=30116'}]),
     ("9993(a)(4) (formerly 438(a)(4)", 1, 2,  # No matching ')' for (formerly
-        [{'text': '2 U.S.C. 9993(a)(4)',
+        [{'text': '9993(a)(4)',
+          'title': '2',
+          'type': 'statute',
         'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=2&section=9993'}]),
 ])
 def test_parse_statutory_citations(test_input, case_id, entity_id, expected):
@@ -232,11 +253,17 @@ class TestLoadCurrentMURs(BaseTestCase):
 
         expected_mur = {'disposition': {'data': [{'disposition': 'Conciliation-PPC',
             'respondent': 'Open Elections LLC', 'penalty': Decimal('50000.00'),
-            'citations': [{'text': '2 U.S.C. 431',
-            'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=52'
+            'citations': [
+                {'text': '431',
+                'title': '2',
+                'type': 'statute',
+                'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=52'
                 '&section=30101'},
-            {'text': '11 C.F.R. 456',
-            'url': '/regulations/456/CURRENT'}]}],
+                {'text': '456',
+                'title': '11',
+                'type': 'regulation',
+                'url': '/regulations/456/CURRENT'}
+            ]}],
             'text': [{'text': 'Conciliation Reached.', 'vote_date': datetime(2008, 1, 1, 0, 0)}]},
             'text': '', 'subject': {'text': ['Fraudulent misrepresentation']},
             'documents': [], 'participants': [], 'no': '1', 'doc_id': 'mur_1',

--- a/tests/test_load_current_murs.py
+++ b/tests/test_load_current_murs.py
@@ -41,6 +41,9 @@ def test_parse_regulatory_citations(test_input, case_id, entity_id, expected):
     ("30116", 1, 2,  # Already reclassified
         [{'text': '52 U.S.C. 30116',
         'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=52&section=30116'}]),
+    ("434(a)(11)", 1, 2,
+        [{'text': '2 U.S.C. 434(a)(11)',
+        'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=52&section=30104'}]),
     ("9999", 1, 2,
         [{'text': '2 U.S.C. 9999',
         'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=2&section=9999'}]),

--- a/tests/test_load_current_murs.py
+++ b/tests/test_load_current_murs.py
@@ -21,10 +21,7 @@ from tests.common import TEST_CONN, BaseTestCase
     ("114.5(a)(3)-(5)", 1, 2,
         [{'text': '11 C.F.R. 114.5(a)(3)-(5)', 'url': '/regulations/114-5/CURRENT'}]),
     ("102.17(a)(l)(i), (b)(l), (b)(2), and (c)(3)", 1, 2,
-        [{'text': '11 C.F.R. 102.17(a)(l)(i)', 'url': '/regulations/102-17/CURRENT'},
-         {'text': '11 C.F.R. 102.17(b)(l)', 'url': '/regulations/102-17/CURRENT'},
-         {'text': '11 C.F.R. 102.17(b)(2)', 'url': '/regulations/102-17/CURRENT'},
-         {'text': '11 C.F.R. 102.17(c)(3)', 'url': '/regulations/102-17/CURRENT'}
+        [{'text': '11 C.F.R. 102.17(a)(l)(i), (b)(l), (b)(2), and (c)(3)', 'url': '/regulations/102-17/CURRENT'}
          ]),
     ("102.5(a)(2); 104.3(a)(4)(i); 114.5(a)(3)-(5); 114.5(g)(1)", 1, 2,
         [{'text': '11 C.F.R. 102.5(a)(2)', 'url': '/regulations/102-5/CURRENT'},
@@ -38,7 +35,7 @@ def test_parse_regulatory_citations(test_input, case_id, entity_id, expected):
 
 @pytest.mark.parametrize("test_input,case_id,entity_id,expected", [
     ("431", 1, 2,    # With reclassification
-        [{'text': '52 U.S.C. 30101',
+        [{'text': '2 U.S.C. 431',
           'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html'
           '&title=52&section=30101'}]),
     ("30116", 1, 2,  # Already reclassified
@@ -232,7 +229,7 @@ class TestLoadCurrentMURs(BaseTestCase):
 
         expected_mur = {'disposition': {'data': [{'disposition': 'Conciliation-PPC',
             'respondent': 'Open Elections LLC', 'penalty': Decimal('50000.00'),
-            'citations': [{'text': '52 U.S.C. 30101',
+            'citations': [{'text': '2 U.S.C. 431',
             'url': 'https://api.fdsys.gov/link?collection=uscode&year=mostrecent&link-type=html&title=52'
                 '&section=30101'},
             {'text': '11 C.F.R. 456',

--- a/webservices/legal_docs/current_murs.py
+++ b/webservices/legal_docs/current_murs.py
@@ -79,7 +79,7 @@ WHERE case_id = %s
 ORDER BY vote_date desc;
 """
 
-STATUTE_REGEX = re.compile(r'(?<!\()(?P<section>\d+([a-z](-1)?)?)')
+STATUTE_REGEX = re.compile(r'(?<!\(|\d)(?P<section>\d+([a-z](-1)?)?)')
 REGULATION_REGEX = re.compile(r'(?<!\()(?P<part>\d+)(\.(?P<section>\d+))?')
 
 def load_current_murs():

--- a/webservices/legal_docs/current_murs.py
+++ b/webservices/legal_docs/current_murs.py
@@ -185,8 +185,8 @@ def parse_statutory_citations(statutory_citation, case_id, entity_id):
                 match_text = statutory_citation[match.start():]
             else:
                 match_text = statutory_citation[match.start():matches[index + 1].start()]
-            text = '%s U.S.C. %s' % (orig_title, match_text.rstrip(' ,;'))
-            citations.append({'text': text, 'url': url})
+            text = match_text.rstrip(' ,;')
+            citations.append({'text': text, 'type': 'statute', 'title': orig_title,  'url': url})
         if not citations:
             logger.warn("Cannot parse statutory citation %s for Entity %s in case %s",
                     statutory_citation, entity_id, case_id)
@@ -204,8 +204,8 @@ def parse_regulatory_citations(regulatory_citation, case_id, entity_id):
                 match_text = regulatory_citation[match.start():]
             else:
                 match_text = regulatory_citation[match.start():matches[index + 1].start()]
-            text = '11 C.F.R. %s' % match_text.rstrip(' ,;')
-            citations.append({'text': text, 'url': url})
+            text = match_text.rstrip(' ,;')
+            citations.append({'text': text, 'type': 'regulation', 'title': '11',  'url': url})
         if not citations:
             logger.warn("Cannot parse regulatory citation %s for Entity %s in case %s",
                     regulatory_citation, entity_id, case_id)

--- a/webservices/legal_docs/reclassify_statutory_citation.py
+++ b/webservices/legal_docs/reclassify_statutory_citation.py
@@ -76,8 +76,8 @@ def reclassify_current_mur_statutory_citation(section):
     if mapped_section:
         logger.info('Mapping current MUR statute citation %s -> %s',
                     section, (MAPPED_TITLE, mapped_section))
-        return MAPPED_TITLE, mapped_section
+        return ORIGINAL_TITLE, MAPPED_TITLE, mapped_section
     elif RECLASSIFIED_STATUTE_SECTION_REGEX.match(section):
-        return MAPPED_TITLE, section
+        return MAPPED_TITLE, MAPPED_TITLE, section
     else:
-        return ORIGINAL_TITLE, section
+        return ORIGINAL_TITLE, ORIGINAL_TITLE, section


### PR DESCRIPTION
Display one link per distinct target citation. As we cannot link directly to
52 U.S.C. 30118(b)(3)(B) and can only link to 52 U.S.C. 30118, we will
concatenate the text of all citations that have this link target and
have a single link for them. This has the following benefits:

- Considerable reduction in the use of vertical space.
- Less user frustration as we avoid having multiple links to the same
target.
- It should be easier for humans to comprehend the elided citations at a
glance as we do not bother to expand them. E.g., we would display
"434(b)(2),(3), 434(b)(4),(6)(B)(v)" (from the original text) instead of
"434(b)(2),434(b)(3), 434(b)(4),434(b)(6)(B)(v) ".

Closes 18F/openFEC#2069