### PR TITLE
Enable stemming when creating index

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -39,7 +39,6 @@ manager.command(legal_docs.load_archived_murs)
 manager.command(legal_docs.load_current_murs)
 manager.command(legal_docs.remap_archived_murs_citations)
 manager.command(legal_docs.remove_legal_docs)
-manager.command(legal_docs.enable_stemming)
 
 def check_itemized_queues(schedule):
     """Checks to see if the queues associated with an itemized schedule have

--- a/webservices/legal_docs/__init__.py
+++ b/webservices/legal_docs/__init__.py
@@ -12,5 +12,4 @@ from .load_legal_docs import (
     load_advisory_opinions_into_s3,
     load_archived_murs,
     remap_archived_murs_citations,
-    remove_legal_docs,
-    enable_stemming)
+    remove_legal_docs)


### PR DESCRIPTION
Enable stemming when creating an empty index through remove_legal_docs.
Remove enable_stemming management command as it is no longer needed.