### PR TITLE
Casting null to date so distinct can work right [merge w/ git flow]

### DIFF
--- a/data/sql_updates/committee_history.sql
+++ b/data/sql_updates/committee_history.sql
@@ -34,7 +34,7 @@ select distinct on (fec_yr.cmte_id, fec_yr.fec_election_yr)
     to_tsvector(fec_yr.tres_nm) as treasurer_text,
     f1.org_tp as organization_type,
     expand_organization_type(f1.org_tp) as organization_type_full,
-    null as expire_date,
+    null::date as expire_date,
     -- Address
     fec_yr.cmte_st1 as street_1,
     fec_yr.cmte_st2 as street_2,


### PR DESCRIPTION
Closes issue: https://github.com/18F/openFEC/issues/2088.  Why this wasn't exposed as a bug originally is hard to say, suffice to say a `select distinct *` requires more column integrity than just `select *`.  Because during the distinct selection postgres couldn't determine the column type.