### PR TITLE
Hotfix/remove expire date

### DIFF
--- a/data/sql_updates/committee_history.sql
+++ b/data/sql_updates/committee_history.sql
@@ -34,7 +34,6 @@ select distinct on (fec_yr.cmte_id, fec_yr.fec_election_yr)
     to_tsvector(fec_yr.tres_nm) as treasurer_text,
     f1.org_tp as organization_type,
     expand_organization_type(f1.org_tp) as organization_type_full,
-    --null::date as expire_date,
     -- Address
     fec_yr.cmte_st1 as street_1,
     fec_yr.cmte_st2 as street_2,

--- a/data/sql_updates/committee_history.sql
+++ b/data/sql_updates/committee_history.sql
@@ -34,7 +34,7 @@ select distinct on (fec_yr.cmte_id, fec_yr.fec_election_yr)
     to_tsvector(fec_yr.tres_nm) as treasurer_text,
     f1.org_tp as organization_type,
     expand_organization_type(f1.org_tp) as organization_type_full,
-    null::date as expire_date,
+    --null::date as expire_date,
     -- Address
     fec_yr.cmte_st1 as street_1,
     fec_yr.cmte_st2 as street_2,

--- a/webservices/common/models/committees.py
+++ b/webservices/common/models/committees.py
@@ -31,8 +31,6 @@ class BaseCommittee(BaseModel):
     party = db.Column(db.String(3), index=True, doc=docs.PARTY)
     party_full = db.Column(db.String(50), doc=docs.PARTY)
     state = db.Column(db.String(2), index=True, doc=docs.COMMITTEE_STATE)
-    # ? how to explain
-    expire_date = db.Column(db.DateTime())
 
 
 class BaseConcreteCommittee(BaseCommittee):


### PR DESCRIPTION
This should kill a recurring bug we are having with material reviews not being able to understand the casting of `expire_date`.  `update_schemas` will need to be ran after it is merged, I can take care of that.

/cc @ccostino @LindsayYoung 