### PR TITLE
Feature/fix indexes for amendments

### DIFF
--- a/data/sql_updates/filing_amendments_house_senate.sql
+++ b/data/sql_updates/filing_amendments_house_senate.sql
@@ -33,7 +33,7 @@ SELECT old_f.cmte_id,
 from oldest_filing old_f inner join most_recent_filing mrf on old_f.cmte_id = mrf.cmte_id and old_f.last = mrf.last
 ) select row_number() over () as idx, * from electronic_filer_chain;
 
-create unique index file_number_house_senate_electronic_index_tmp on ofec_house_senate_electronic_amendments_mv_tmp(idx);
+create unique index on ofec_house_senate_electronic_amendments_mv_tmp(idx);
 
 drop materialized view if exists ofec_house_senate_paper_amendments_mv_tmp;
 create materialized view ofec_house_senate_paper_amendments_mv_tmp as
@@ -100,4 +100,4 @@ select
     amendment_chain
 from filtered_longest_path;
 
-create unique index file_number_house_senate_paper_index_tmp on ofec_house_senate_paper_amendments_mv_tmp(idx);
+create unique index on ofec_house_senate_paper_amendments_mv_tmp(idx);

--- a/data/sql_updates/filing_amendments_pac_party.sql
+++ b/data/sql_updates/filing_amendments_pac_party.sql
@@ -33,7 +33,7 @@ SELECT old_f.cmte_id,
 from oldest_filing old_f inner join most_recent_filing mrf on old_f.cmte_id = mrf.cmte_id and old_f.last = mrf.last
 ) select row_number() over () as idx, * from electronic_filer_chain;
 
-create unique index file_number_pac_party_electronic_index_tmp on ofec_pac_party_electronic_amendments_mv_tmp(idx);
+create unique index on ofec_pac_party_electronic_amendments_mv_tmp(idx);
 
 drop materialized view if exists ofec_pac_party_paper_amendments_mv_tmp cascade;
 create materialized view ofec_pac_party_paper_amendments_mv_tmp as
@@ -100,7 +100,7 @@ with recursive oldest_filing_paper as (
         and flp.last = prf.last)
     select row_number() over () as idx, * from paper_filer_chain;
 
-create unique index file_number_pac_party_paper_index_tmp on ofec_pac_party_paper_amendments_mv_tmp(idx);
+create unique index on ofec_pac_party_paper_amendments_mv_tmp(idx);
 
 
 

--- a/data/sql_updates/filing_amendments_presidential.sql
+++ b/data/sql_updates/filing_amendments_presidential.sql
@@ -34,8 +34,7 @@ SELECT
 from oldest_filing old_f inner join most_recent_filing mrf on old_f.cmte_id = mrf.cmte_id and old_f.last = mrf.last
 ) select row_number() over () as idx, * from electronic_filer_chain;
 
-create unique index file_number_presidential_electronic_index_tmp on ofec_presidential_electronic_amendments_mv_tmp(idx);
-
+create unique index on ofec_presidential_electronic_amendments_mv_tmp(idx);
 
 drop materialized view if exists ofec_presidential_paper_amendments_mv_tmp cascade;
 create materialized view ofec_presidential_paper_amendments_mv_tmp as
@@ -100,4 +99,4 @@ with recursive oldest_filing_paper as (
     select row_number() over () as idx, * from paper_filer_chain;
 ;
 
-create unique index file_number_presidential_paper_index_tmp on ofec_presidential_paper_amendments_mv_tmp(idx);
+create unique index on ofec_presidential_paper_amendments_mv_tmp(idx);

--- a/data/sql_updates/filings.sql
+++ b/data/sql_updates/filings.sql
@@ -22,7 +22,7 @@ create materialized view ofec_filings_amendments_all_mv_tmp as with combined AS 
   FROM ofec_pac_party_paper_amendments_mv_tmp
 ) select row_number() over () as idx2, * from combined;
 
-create unique index file_number_amendments_all_index_tmp on ofec_filings_amendments_all_mv_tmp(idx2);
+create unique index on ofec_filings_amendments_all_mv_tmp(idx2);
 
 
 


### PR DESCRIPTION
As Hemingway once said, cats lead to more cats, such as this feature with bugs.  This should rectify the issue with `update_schemas` bombing out.