### PR TITLE
Add commands to support index alias management

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -38,6 +38,8 @@ manager.command(legal_docs.load_advisory_opinions_into_s3)
 manager.command(legal_docs.load_archived_murs)
 manager.command(legal_docs.load_current_murs)
 manager.command(legal_docs.initialize_legal_docs)
+manager.command(legal_docs.move_index_for_loads)
+manager.command(legal_docs.move_index_for_searches)
 
 def check_itemized_queues(schedule):
     """Checks to see if the queues associated with an itemized schedule have

--- a/webservices/legal_docs/__init__.py
+++ b/webservices/legal_docs/__init__.py
@@ -13,4 +13,6 @@ from .load_legal_docs import (
     index_statutes,
     load_advisory_opinions_into_s3,
     load_archived_murs,
+    move_index_for_loads,
+    move_index_for_searches,
     initialize_legal_docs)


### PR DESCRIPTION
The commands are rather opinionated:
move_index_for_loads creates a new index and moves docs_index to point
to it.
move_index_for_searches moves docs_search to point to a new index and
deletes the old index.