### PR TITLE
Add commands to support index alias management

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -38,6 +38,8 @@ manager.command(legal_docs.load_advisory_opinions_into_s3)
 manager.command(legal_docs.load_archived_murs)
 manager.command(legal_docs.load_current_murs)
 manager.command(legal_docs.initialize_legal_docs)
+manager.command(legal_docs.create_staging_index)
+manager.command(legal_docs.restore_from_staging_index)
 
 def check_itemized_queues(schedule):
     """Checks to see if the queues associated with an itemized schedule have

--- a/webservices/legal_docs/__init__.py
+++ b/webservices/legal_docs/__init__.py
@@ -12,5 +12,11 @@ from .load_legal_docs import (
     index_regulations,
     index_statutes,
     load_advisory_opinions_into_s3,
-    load_archived_murs,
-    initialize_legal_docs)
+    load_archived_murs
+)
+
+from .index_management import (
+    initialize_legal_docs,
+    create_staging_index,
+    restore_from_staging_index,
+)

--- a/webservices/legal_docs/index_management.py
+++ b/webservices/legal_docs/index_management.py
@@ -1,0 +1,107 @@
+import elasticsearch
+import elasticsearch.helpers
+
+from . import (
+    DOCS_INDEX,
+    DOCS_SEARCH
+)
+from webservices import utils
+
+DEFAULT_MAPPINGS = {
+    "_default_": {
+        "properties": {
+            "no": {
+                "type": "string",
+                "index": "not_analyzed"
+            },
+            "text": {
+                "type": "string",
+                "analyzer": "english"
+            },
+            "name": {
+                "type": "string",
+                "analyzer": "english"
+            },
+            "description": {
+                "type": "string",
+                "analyzer": "english"
+            },
+            "summary": {
+                "type": "string",
+                "analyzer": "english"
+            }
+        }
+    }
+}
+
+ANALYZER_SETTINGS = {
+    "analysis": {"analyzer": {"default": {"type": "english"}}}
+}
+
+
+def initialize_legal_docs():
+    """
+    Initialize elasticsearch for storing legal documents.
+    Create the `docs` index, and set up the aliases `docs_index` and `docs_search`
+    to point to the `docs` index. If the `doc` index already exists, delete it.
+    """
+
+    es = utils.get_elasticsearch_connection()
+    try:
+        es.indices.delete('docs')
+    except elasticsearch.exceptions.NotFoundError:
+        pass
+    es.indices.create('docs', {
+        "mappings": DEFAULT_MAPPINGS,
+        "settings": ANALYZER_SETTINGS,
+        "aliases": {
+            DOCS_INDEX: {},
+            DOCS_SEARCH: {}
+        }
+    })
+
+def create_staging_index():
+    """
+    Create the index `docs_staging`.
+    Move the alias docs_index to point to `docs_staging` instead of `docs`.
+    """
+    es = utils.get_elasticsearch_connection()
+    es.indices.create('docs_staging', {
+        "mappings": DEFAULT_MAPPINGS,
+        "settings": ANALYZER_SETTINGS,
+    })
+    es.indices.update_aliases(body={"actions": [
+        {"remove": {"index": 'docs', "alias": DOCS_INDEX}},
+        {"add": {"index": 'docs_staging', "alias": DOCS_INDEX}}
+    ]})
+
+def restore_from_staging_index():
+    """
+    A 4-step process:
+    1. Move the alias docs_search to point to `docs_staging` instead of `docs`.
+    2. Reinitialize the index `docs`.
+    3. Reindex `doc_staging` to `docs`
+    4. Move `docs_index` and `docs_search` aliases to point to the `docs` index.
+       Delete index `docs_staging`.
+    """
+    es = utils.get_elasticsearch_connection()
+    es.indices.update_aliases(body={"actions": [
+        {"remove": {"index": 'docs', "alias": DOCS_SEARCH}},
+        {"add": {"index": 'docs_staging', "alias": DOCS_SEARCH}}
+    ]})
+
+    es.indices.delete('docs')
+    es.indices.create('docs', {
+        "mappings": DEFAULT_MAPPINGS,
+        "settings": ANALYZER_SETTINGS
+    })
+
+    elasticsearch.helpers.reindex(es, 'docs_staging', 'docs')
+
+    es.indices.update_aliases(body={"actions": [
+        {"remove": {"index": 'docs_staging', "alias": DOCS_INDEX}},
+        {"remove": {"index": 'docs_staging', "alias": DOCS_SEARCH}},
+        {"add": {"index": 'docs', "alias": DOCS_INDEX}},
+        {"add": {"index": 'docs', "alias": DOCS_SEARCH}}
+    ]})
+    es.indices.delete('docs_staging')

--- a/webservices/legal_docs/load_legal_docs.py
+++ b/webservices/legal_docs/load_legal_docs.py
@@ -12,17 +12,13 @@ from multiprocessing import Pool
 import logging
 from urllib.parse import urlencode
 
-import elasticsearch
 import requests
 
 from webservices.rest import db
 from webservices.env import env
 from webservices import utils
 from webservices.tasks.utils import get_bucket
-from webservices.legal_docs import (
-    DOCS_INDEX,
-    DOCS_SEARCH
-)
+from webservices.legal_docs import DOCS_INDEX
 
 from . import reclassify_statutory_citation
 
@@ -53,56 +49,6 @@ def get_text(node):
     for child in node["children"]:
         text += ' ' + get_text(child)
     return text
-
-
-def initialize_legal_docs():
-    """
-    Initialize elasticsearch for storing legal documents. Create the `docs` index,
-    and set up the aliases `docs_index` and `docs_search` to point to the `docs`
-    index. If the `doc` index already exists, it is deleted.
-    """
-    settings = {
-        "mappings": {
-            "_default_": {
-                "properties": {
-                    "no": {
-                        "type": "string",
-                        "index": "not_analyzed"
-                    },
-                    "text": {
-                        "type": "string",
-                        "analyzer": "english"
-                    },
-                    "name": {
-                        "type": "string",
-                        "analyzer": "english"
-                    },
-                    "description": {
-                        "type": "string",
-                        "analyzer": "english"
-                    },
-                    "summary": {
-                        "type": "string",
-                        "analyzer": "english"
-                    }
-                }
-            }
-        },
-        "settings": {
-            "analysis": {"analyzer": {"default": {"type": "english"}}}
-        },
-        "aliases": {
-            DOCS_INDEX: {},
-            DOCS_SEARCH: {}
-        }
-    }
-
-    es = utils.get_elasticsearch_connection()
-    try:
-        es.indices.delete('docs')
-    except elasticsearch.exceptions.NotFoundError:
-        pass
-    es.indices.create('docs', settings)
 
 
 def index_regulations():


### PR DESCRIPTION
The commands are rather opinionated:
create_staging_index creates a new index `docs_staging` and moves `docs_index`
to point to it.
restore_from_staging_index moves documents from `docs_staging` back to `docs`
and restores the aliases `docs_index` and `docs_search`.