### PR TITLE
Feature/filters features added

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -440,8 +440,8 @@ class TestItemized(ApiBaseTest):
             ('image_number', ScheduleEEfile.image_number, ['123', '456']),
             ('committee_id', ScheduleEEfile.committee_id, ['C01', 'C02']),
             ('support_oppose_indicator', ScheduleEEfile.support_oppose_indicator, ['S', 'O']),
-            ('is_notice', ScheduleEEfile.is_notice, [True, False]),
-            ('filing_form', ScheduleEEfile.form_type, ['F24N', 'F3XN'])
+            #('is_notice', ScheduleEEfile.is_notice, [True, False]),
+            #('filing_form', ScheduleEEfile.form_type, ['F24N', 'F3XN'])
         ]
         for label, column, values in filters:
             [

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -622,6 +622,7 @@ schedule_e_efile = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_name': fields.List(fields.Str, description=docs.CANDIDATE_NAME),
     'filing_form': fields.List(IStr, description='Filing form'),
     'payee_name': fields.List(fields.Str, description='Name of the entity that received the payment'),
     'image_number': fields.List(

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -219,8 +219,6 @@ filings = {
     'document_type': fields.List(IStr, description=docs.DOC_TYPE),
     'beginning_image_number': fields.List(fields.Str, description=docs.BEGINNING_IMAGE_NUMBER),
     'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
-    'min_receipt_date': fields.Date(description='Selects all items received by FEC after this date'),
-    'max_receipt_date': fields.Date(description='Selects all items received by FEC before this date'),
     'form_type': fields.List(IStr, description='Form type'),
     'filer_type': fields.Str(
         validate=validate.OneOf(['e-file', 'paper']),
@@ -625,6 +623,8 @@ schedule_e_efile = {
     'candidate_name': fields.List(fields.Str, description=docs.CANDIDATE_NAME),
     'filing_form': fields.List(IStr, description='Filing form'),
     'payee_name': fields.List(fields.Str, description='Name of the entity that received the payment'),
+    'min_expenditure_date': fields.Date(description='Selects all items expended by this committee after this date'),
+    'max_expenditure_date': fields.Date(description='Selects all items expended by this committee before this date'),
     'image_number': fields.List(
         fields.Str,
         description='The image number of the page where the schedule item is reported',

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -8,7 +8,7 @@ from webservices import docs, utils
 from webservices.common.models.filings import EFilings
 
 from .base import db
-from .reports import PdfMixin
+from .reports import PdfMixin, name_generator
 
 
 class BaseItemized(db.Model):
@@ -33,6 +33,7 @@ class BaseItemized(db.Model):
 class BaseRawItemized(db.Model):
     __abstract__ = True
 
+    committee = utils.related_committee_history('committee_id', cycle_label='report_year')
     committee_id = db.Column("comid", db.String, doc=docs.COMMITTEE_ID)
     line_number = db.Column("line_num", db.String)
     transaction_id = db.Column('tran_id', db.String)
@@ -440,6 +441,23 @@ class ScheduleEEfile(BaseRawItemized):
 
     is_notice = db.Column(db.Boolean)
     form_type = db.Column('form', db.String)
+    report_type = db.Column(db.String)
+
+    @hybrid_property
+    def payee_name(self):
+        name = name_generator(
+            self.payee_last_name,
+            self.payee_prefix,
+            self.payee_first_name,
+            self.payee_middle_name,
+            self.payee_suffix
+        )
+        name = (
+            name
+            if name
+            else None
+        )
+        return name
 
 
 class ScheduleF(PdfMixin,BaseItemized):

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -33,12 +33,11 @@ class BaseItemized(db.Model):
 class BaseRawItemized(db.Model):
     __abstract__ = True
 
-    committee = utils.related_committee_history('committee_id', cycle_label='report_year')
     committee_id = db.Column("comid", db.String, doc=docs.COMMITTEE_ID)
     line_number = db.Column("line_num", db.String)
     transaction_id = db.Column('tran_id', db.String)
     image_number = db.Column('imageno', db.String, doc=docs.IMAGE_NUMBER)
-    report_year = db.Column(db.Integer, doc=docs.REPORT_YEAR)
+    #report_year = db.Column(db.Integer, doc=docs.REPORT_YEAR)
     entity_type = db.Column('entity', db.String)
     load_timestamp = db.Column('create_dt', db.TIMESTAMP)
     amendment_indicator = db.Column('amend', db.String)
@@ -387,9 +386,8 @@ class ScheduleE(PdfMixin, BaseItemized):
     pdf_url = db.Column(db.String)
 
 
-
 class ScheduleEEfile(BaseRawItemized):
-    __tablename__ = 'real_efile_schedule_e_reports'
+    __tablename__ = 'real_efile_se'
 
     # payee info
     payee_prefix = db.Column('prefix', db.String)
@@ -439,9 +437,7 @@ class ScheduleEEfile(BaseRawItemized):
     file_number = db.Column("repid", db.Integer, primary_key=True)
     related_line_number = db.Column("rel_lineno", db.Integer, primary_key=True)
 
-    is_notice = db.Column(db.Boolean)
-    form_type = db.Column('form', db.String)
-    report_type = db.Column(db.String)
+    #committee = utils.related_committee_history('committee_id', cycle_label='report_year')
 
     @hybrid_property
     def payee_name(self):

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -112,6 +112,11 @@ class ScheduleEEfileView(views.ApiResource):
         ('support_oppose_indicator', models.ScheduleEEfile.support_oppose_indicator),
         ('filing_form', models.ScheduleEEfile.form_type),
         ('is_notice', models.ScheduleEEfile.is_notice),
+        ('candidate_name', models.ScheduleEEfile.candidate_name),
+    ]
+
+    filter_range_fields = [
+        (('min_date', 'max_date'), models.ScheduleEEfile.expenditure_date),
     ]
 
     @property

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -105,18 +105,18 @@ class ScheduleEEfileView(views.ApiResource):
     page_schema = schemas.ScheduleEEfilePageSchema
 
     filter_multi_fields = [
-        ('cycle', sa.func.get_cycle(models.ScheduleEEfile.report_year)),
+        #('cycle', sa.func.get_cycle(models.ScheduleEEfile.report_year)),
         ('image_number', models.ScheduleEEfile.image_number),
         ('committee_id', models.ScheduleEEfile.committee_id),
         ('candidate_id', models.ScheduleEEfile.candidate_id),
         ('support_oppose_indicator', models.ScheduleEEfile.support_oppose_indicator),
-        ('filing_form', models.ScheduleEEfile.form_type),
-        ('is_notice', models.ScheduleEEfile.is_notice),
+        #('filing_form', models.ScheduleEEfile.form_type),
+        #('is_notice', models.ScheduleEEfile.is_notice),
         ('candidate_name', models.ScheduleEEfile.candidate_name),
     ]
 
     filter_range_fields = [
-        (('min_date', 'max_date'), models.ScheduleEEfile.expenditure_date),
+        (('min_expenditure_date', 'max_expenditure_date'), models.ScheduleEEfile.expenditure_date),
     ]
 
     @property

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -680,6 +680,8 @@ ItemizedScheduleEfilingsSchema = make_schema(
         'pdf_url': ma.fields.Str(),
         'fec_url': ma.fields.Str(),
         'is_notice':ma.fields.Boolean(),
+        'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
+        'payee_name': ma.fields.Str(),
         #'csv_url': ma.fields.Str(),
     },
     #options={'exclude': ('e_filing',)},


### PR DESCRIPTION
This added the couple of missing filters, while also removing fields `is_notice`, `report_type`, and `committee`.  We can look at ways of getting those back in but using the custom view like before will have to be abandoned as it could have potentially been creating legitimate n+1 queries, so the solution is essentially just do the joins in sql_alchemy to ensure there are no performance hits.

@ccostino @noahmanger 