### PR TITLE
[MERGE WITH GIT FLOW] Adds support for generating new itemized child tables

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -261,6 +261,28 @@ def update_aggregates():
     logger.info('Finished updating incremental aggregates.')
 
 @manager.command
+def add_itemized_partition_cycle(cycle=None, amount=1):
+    """Adds a new itemized cycle child table.
+    By default this will try to add just the current cycle to all partitioned
+    itemized schedule tables if it doesn't already exist.
+    If the child table already exists, skip over it.
+    """
+
+    amount = int(amount)
+
+    if not cycle:
+        cycle = SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
+    else:
+        cycle = int(cycle)
+
+    logger.info('Adding Schedule A cycles...')
+    partition.SchedAGroup.add_cycles(cycle, amount)
+    logger.info('Finished adding Schedule A cycles.')
+    logger.info('Adding Schedule B cycles...')
+    partition.SchedBGroup.add_cycles(cycle, amount)
+    logger.info('Finished adding Schedule B cycles.')
+
+@manager.command
 def update_all(processes=1):
     """Update all derived data. Warning: Extremely slow on production data.
     """

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -1,0 +1,52 @@
+import datetime
+
+import sqlalchemy as sa
+
+from tests import factories
+from tests.common import ApiBaseTest
+
+from webservices.partition import sched_a, sched_b, utils
+from webservices.common.models import ScheduleA, ScheduleB
+from webservices.rest import db
+
+
+class TestPartitioning(ApiBaseTest):
+    def test_load_table_util(self):
+        parent = utils.load_table('ofec_sched_a_master')
+        self.assertIsNotNone(parent)
+
+    def test_schedule_a_master_create_and_rename(self):
+        parent = utils.load_table('ofec_sched_a_master')
+        sched_a.SchedAGroup.create_master(parent)
+
+        temp_table = db.session.execute(
+            'select tablename from pg_tables where tablename = \'ofec_sched_a_master_tmp\''
+        )
+
+        self.assertEqual(temp_table.scalar(), 'ofec_sched_a_master_tmp')
+
+        sched_a.SchedAGroup.rename_master()
+
+        temp_table = db.session.execute(
+            'select tablename from pg_tables where tablename = \'ofec_sched_a_master_tmp\''
+        )
+
+        self.assertIsNone(temp_table.scalar())
+
+    def test_schedule_b_master_create_and_rename(self):
+        parent = utils.load_table('ofec_sched_b_master')
+        sched_b.SchedBGroup.create_master(parent)
+
+        temp_table = db.session.execute(
+            'select tablename from pg_tables where tablename = \'ofec_sched_b_master_tmp\''
+        )
+
+        self.assertEqual(temp_table.scalar(), 'ofec_sched_b_master_tmp')
+
+        sched_b.SchedBGroup.rename_master()
+
+        temp_table = db.session.execute(
+            'select tablename from pg_tables where tablename = \'ofec_sched_b_master_tmp\''
+        )
+
+        self.assertIsNone(temp_table.scalar())


### PR DESCRIPTION
**MERGE WITH GIT FLOW**

Closes #2136

This changeset adds a management command to support creating new child tables to an existing partition of Schedule A and Schedule B data. It will check first before just creating the new table(s) so existing data is not wiped out.

This also includes the beginning of a test suite for the partitioning code.

I modified the existing partitioning code a bit to break out some of the underlying child table processing code and ended up having to add a new flag to a couple of those methods to account for when we're doing a full partition vs. operating against already partitioned tables.

The new command is this:

```sh
./manage.py add_itemized_partition_cycle
```

Given the current year at the time of this PR (2017), this will attempt to create the 2017 - 2018 cycle tables.  If you haven't already repartitioned they'll be added, but if you have then it will skip over them.  You can also specify a cycle and/or a range:

```sh
./manage.py add_itemized_partition_cycle -c 2014 -a 5
```

This will start attempting to create child tables for the 2013 - 2014 cycle and work its way up to the 2021 - 2022 cycle (and again, skipping tables that already exist so they're not undone and wiped out).

The testing was proving to be fairly difficult to get going but I wanted to have something given the changes I had to make.  I'm definitely open to suggestions for improvement and/or pairing with someone to take them further!

/cc @LindsayYoung, @jontours 