### PR TITLE
Adds support to sort by date for entity charts

### DIFF
--- a/data/functions/calendar.sql
+++ b/data/functions/calendar.sql
@@ -382,3 +382,11 @@ returns text as $$
     end
 $$ language plpgsql;
 
+
+-- Retrieves the last day of the month for a given timestamp.
+create or replace function last_day_of_month(timestamp)
+returns timestamp as $$
+    begin
+        return date_trunc('month', $1) + (interval '1 month - 1 day');
+    end
+$$ language plpgsql;

--- a/data/sql_updates/large_aggregates.sql
+++ b/data/sql_updates/large_aggregates.sql
@@ -205,7 +205,7 @@ select
     month,
     year,
     cycle,
-    make_timestamp(cast(year as int), cast(month as int), 1, 0, 0, 0.0) as date,
+    last_day_of_month(make_timestamp(cast(year as int), cast(month as int), 1, 0, 0, 0.0)) as date,
     sum(candidate_receipts) OVER (PARTITION BY cycle order by year asc, month asc) as cumulative_candidate_receipts,
     candidate_receipts,
     sum(canidate_disbursements) OVER (PARTITION BY cycle order by year asc, month asc) as cumulative_candidate_disbursements,

--- a/data/sql_updates/large_aggregates.sql
+++ b/data/sql_updates/large_aggregates.sql
@@ -205,7 +205,7 @@ select
     month,
     year,
     cycle,
-    make_date(cast(year as int), cast(month as int), 01) as chart_date,
+    make_timestamp(cast(year as int), cast(month as int), 1, 0, 0, 0.0) as date,
     sum(candidate_receipts) OVER (PARTITION BY cycle order by year asc, month asc) as cumulative_candidate_receipts,
     candidate_receipts,
     sum(canidate_disbursements) OVER (PARTITION BY cycle order by year asc, month asc) as cumulative_candidate_disbursements,

--- a/data/sql_updates/large_aggregates.sql
+++ b/data/sql_updates/large_aggregates.sql
@@ -205,6 +205,7 @@ select
     month,
     year,
     cycle,
+    make_date(cast(year as int), cast(month as int), 01) as chart_date,
     sum(candidate_receipts) OVER (PARTITION BY cycle order by year asc, month asc) as cumulative_candidate_receipts,
     candidate_receipts,
     sum(canidate_disbursements) OVER (PARTITION BY cycle order by year asc, month asc) as cumulative_candidate_disbursements,

--- a/tests/test_large_aggregates.py
+++ b/tests/test_large_aggregates.py
@@ -25,3 +25,11 @@ class TestEntityReceiptDisbursementTotals(ApiBaseTest):
             results = self._results(page)
             self.assertEqual(len(results), 1)
 
+
+    def test_date_is_correctly_generated(self):
+        totals = factories.EntityReceiptDisbursementTotalsFactory(
+            cycle=2000,
+            cumulative_candidate_receipts=50000,
+            month=3,
+            year=1999)
+        assert totals.date == '1999-03-01'

--- a/tests/test_large_aggregates.py
+++ b/tests/test_large_aggregates.py
@@ -1,3 +1,7 @@
+import datetime
+
+import sqlalchemy as sa
+
 from tests import factories
 from tests.common import ApiBaseTest
 
@@ -31,5 +35,7 @@ class TestEntityReceiptDisbursementTotals(ApiBaseTest):
             cycle=2000,
             cumulative_candidate_receipts=50000,
             month=3,
-            year=1999)
-        assert totals.date == '1999-03-01'
+            year=1999,
+            date=sa.func.make_timestamp(1999, 3, 1, 0, 0, 0.0)
+        )
+        assert totals.date == datetime.datetime(1999, 3, 1, 0, 0)

--- a/tests/test_large_aggregates.py
+++ b/tests/test_large_aggregates.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 from tests import factories
 from tests.common import ApiBaseTest
 
-from webservices.rest import api
+from webservices.rest import api, db
 from webservices.resources.large_aggregates import EntityReceiptDisbursementTotalsView
 
 
@@ -36,6 +36,9 @@ class TestEntityReceiptDisbursementTotals(ApiBaseTest):
             cumulative_candidate_receipts=50000,
             month=3,
             year=1999,
-            date=sa.func.make_timestamp(1999, 3, 1, 0, 0, 0.0)
+            date=sa.func.last_day_of_month(sa.func.make_timestamp(1999, 3, 1, 0, 0, 0.0))
         )
-        assert totals.date == datetime.datetime(1999, 3, 1, 0, 0)
+
+        db.session.commit()
+
+        assert totals.date == datetime.datetime(1999, 3, 31, 0, 0)

--- a/webservices/common/models/large_aggregates.py
+++ b/webservices/common/models/large_aggregates.py
@@ -14,6 +14,7 @@ class EntityReceiptDisbursementTotals(db.Model):
     cycle = db.Column(db.Integer, doc=docs.RECORD_CYCLE)
     month = db.Column(db.Integer, doc="Numeric representation of year")
     year = db.Column(db.Integer, doc="Numeric representation of month")
+    chart_date = db.Column(db.Date, doc="Date representation of the month and year")
     cumulative_candidate_receipts = db.Column(db.Float, doc="Cumulative candidate receipts in a two year period, adjusted to avoid double counting.")
     cumulative_candidate_disbursements = db.Column(db.Float, doc="Cumulative candidate disbursements in a two year period, adjusted to avoid double counting.")
     cumulative_pac_receipts = db.Column(db.Float, doc="Cumulative PAC recipts in a two year period, adjusted to avoid double counting.")

--- a/webservices/common/models/large_aggregates.py
+++ b/webservices/common/models/large_aggregates.py
@@ -14,19 +14,10 @@ class EntityReceiptDisbursementTotals(db.Model):
     cycle = db.Column(db.Integer, doc=docs.RECORD_CYCLE)
     month = db.Column(db.Integer, doc="Numeric representation of year")
     year = db.Column(db.Integer, doc="Numeric representation of month")
-    chart_date = db.Column(db.Date, doc="Date representation of the month and year")
+    date = db.Column(db.DateTime, doc="Date representation of the month and year")
     cumulative_candidate_receipts = db.Column(db.Float, doc="Cumulative candidate receipts in a two year period, adjusted to avoid double counting.")
     cumulative_candidate_disbursements = db.Column(db.Float, doc="Cumulative candidate disbursements in a two year period, adjusted to avoid double counting.")
     cumulative_pac_receipts = db.Column(db.Float, doc="Cumulative PAC recipts in a two year period, adjusted to avoid double counting.")
     cumulative_pac_disbursements = db.Column(db.Float, doc="Cumulative PAC disbursements in a two year period, adjusted to avoid double counting.")
     cumulative_party_receipts = db.Column(db.Float, doc="Cumulative party receipts in a two year period, adjusted to avoid double counting.")
     cumulative_party_disbursements = db.Column(db.Float, doc="Cumulative party disbursements in a two year period, adjusted to avoid double counting.")
-
-    @property
-    def date(self):
-        end_day = calendar.monthrange(int(self.year), int(self.month))[1]
-        formatted_date = datetime(int(self.year), int(self.month), int(end_day))
-        if formatted_date >= datetime.now():
-            formatted_date = date.today() - timedelta(1)
-        return formatted_date
-

--- a/webservices/resources/large_aggregates.py
+++ b/webservices/resources/large_aggregates.py
@@ -28,8 +28,8 @@ class EntityReceiptDisbursementTotalsView(ApiResource):
             args.paging,
             args.large_aggregates,
             args.make_sort_args(
-                default='chart_date',
-                validator=args.OptionValidator(['chart_date',]),
+                default='date',
+                validator=args.OptionValidator(['date',]),
             )
         )
 

--- a/webservices/resources/large_aggregates.py
+++ b/webservices/resources/large_aggregates.py
@@ -27,6 +27,10 @@ class EntityReceiptDisbursementTotalsView(ApiResource):
         return utils.extend(
             args.paging,
             args.large_aggregates,
+            args.make_sort_args(
+                default='chart_date',
+                validator=args.OptionValidator(['chart_date',]),
+            )
         )
 
     @property

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -890,7 +890,7 @@ register_schema(RadAnalystPageSchema)
 EntityReceiptDisbursementTotalsSchema = make_schema(
     models.EntityReceiptDisbursementTotals,
     options={'exclude': ('idx','month', 'year')},
-    fields={'date': ma.fields.Date(doc='The cumulative total for this month.')},
+    fields={'date': ma.fields.DateTime(doc='The cumulative total for this month.')},
 )
 EntityReceiptDisbursementTotalsPageSchema = make_page_schema(EntityReceiptDisbursementTotalsSchema)
 register_schema(EntityReceiptDisbursementTotalsSchema)


### PR DESCRIPTION
Closes #2122 

This changeset adds support for sorting by date in our entity charts.  It accomplishes this by deriving a date from the `month` and `year` columns that are created in the `ofec_entity_chart_mv` materialized view (and always assuming the first of the month as the day).  Note that we already have a `date` property on the Python side in the `EntityReceiptDisbursementTotals` model, so I did not want to disrupt anything currently using that.  Hence the name for this new column and field being `chart_date`.

h/t to @LindsayYoung for the implementation idea!