### PR TITLE
Use process health check

### DIFF
--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -14,9 +14,11 @@ applications:
   instances: 1
   memory: 256M
   no-route: true
+  health-check-type: process
   command: celery beat --app webservices.tasks
 - name: celery-worker
   instances: 1
   memory: 512M
   no-route: true
+  health-check-type: process
   command: celery worker --app webservices.tasks --loglevel INFO --concurrency 2


### PR DESCRIPTION
Health check process instead of port: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#health-check-type. Necessary for no-route apps on govcloud.