### PR TITLE
This is a fix so records do not get duplicated if the committee

### DIFF
--- a/data/sql_updates/communication_cost.sql
+++ b/data/sql_updates/communication_cost.sql
@@ -1,14 +1,19 @@
 drop materialized view if exists ofec_communication_cost_mv_tmp;
 create materialized view ofec_communication_cost_mv_tmp as
-select
-    row_number() over () as idx,
+with com_names as(
+    select distinct on(committee_id)
+    committee_id,
+    name as committee_name
+from ofec_committee_history_mv_tmp
+order by committee_id, cycle desc
+) select
     f76.*,
     f76.s_o_cand_id as cand_id,
     f76.org_id as cmte_id,
-    committee_history.name as committee_name,
+    com_names.committee_name,
     report_pdf_url(image_num) as pdf_url
 from fec_vsum_f76_vw f76
-    left join ofec_committee_history_mv_tmp committee_history on f76.org_id = committee_history.committee_id
+    left join com_names on f76.org_id = com_names.committee_id
 where extract(year from communication_dt)::integer >= :START_YEAR
 ;
 


### PR DESCRIPTION
has multiple entries in the committee history table.
I used the most up to date name, that is what we do elsewhere.
Removed idx because we were not using it since we have the unique
key sub_id.