### PR TITLE
Multi-sort fully enabled for reports

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -134,7 +134,7 @@ class TestReports(ApiBaseTest):
         contributions = [0, 100]
         factories.ReportsHouseSenateFactory(committee_id=committee_id, net_contributions_period=contributions[0])
         factories.ReportsHouseSenateFactory(committee_id=committee_id, net_contributions_period=contributions[1])
-        results = self._results(api.url_for(CommitteeReportsView, committee_id=committee_id, sort='-net_contributions_period'))
+        results = self._results(api.url_for(CommitteeReportsView, committee_id=committee_id, sort=['-net_contributions_period']))
         self.assertEqual([each['net_contributions_period'] for each in results], contributions[::-1])
 
     def test_reports_sort_default(self):

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -47,6 +47,8 @@ class BaseFilings(views.ApiResource):
 
     @property
     def args(self):
+        #Place the sort argument in a list, as the api will return a 422 status code if it's not in a list
+        #list is needed because multisort is used
         default_sort = ['-receipt_date']
         return utils.extend(
             args.paging,

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -102,18 +102,21 @@ class ReportsView(utils.Resource):
 
     @use_kwargs(args.paging)
     @use_kwargs(args.reports)
-    @use_kwargs(args.make_sort_args(default='-coverage_end_date'))
+    @use_kwargs(
+        args.make_multi_sort_args(default=['-coverage_end_date'])
+    )
     @marshal_with(schemas.CommitteeReportsPageSchema(), apply=False)
     def get(self, committee_type=None, **kwargs):
         committee_id = kwargs.get('committee_id')
+        print(kwargs)
         query, reports_class, reports_schema = self.build_query(
             committee_type=committee_type,
             **kwargs
         )
         if kwargs['sort']:
-            validator = args.IndexValidator(reports_class)
+            validator = args.IndicesValidator(reports_class)
             validator(kwargs['sort'])
-        page = utils.fetch_page(query, kwargs, model=reports_class)
+        page = utils.fetch_page(query, kwargs, model=reports_class, multi=True)
         return reports_schema().dump(page).data
 
     def build_query(self, committee_type=None, **kwargs):
@@ -165,7 +168,7 @@ class CommitteeReportsView(utils.Resource):
 
     @use_kwargs(args.paging)
     @use_kwargs(args.committee_reports)
-    @use_kwargs(args.make_sort_args(default='-coverage_end_date'))
+    @use_kwargs(args.make_multi_sort_args(default=['-coverage_end_date']))
     @marshal_with(schemas.CommitteeReportsPageSchema(), apply=False)
     def get(self, committee_id=None, committee_type=None, **kwargs):
         query, reports_class, reports_schema = self.build_query(
@@ -174,9 +177,9 @@ class CommitteeReportsView(utils.Resource):
             **kwargs
         )
         if kwargs['sort']:
-            validator = args.IndexValidator(reports_class)
+            validator = args.IndicesValidator(reports_class)
             validator(kwargs['sort'])
-        page = utils.fetch_page(query, kwargs, model=reports_class)
+        page = utils.fetch_page(query, kwargs, model=reports_class, multi=True)
         return reports_schema().dump(page).data
 
     def build_query(self, committee_id=None, committee_type=None, **kwargs):


### PR DESCRIPTION
This helps address the issue of amendments appearing lower in the list than the report they amended.

The params to pass into the url for proper sorting would be `sort=-receipt_date&sort=-beginning_image_number`.  It is best to do it this way I think as the time in the time stamp is all zeros for any equal dates.