### PR TITLE
Revert "Sort MURs by descending case number"

### DIFF
--- a/tests/test_load_current_murs.py
+++ b/tests/test_load_current_murs.py
@@ -136,9 +136,7 @@ class TestLoadCurrentMURs(BaseTestCase):
             'dispositions': [],
             'close_date': None,
             'open_date': None,
-            'url': '/legal/matter-under-review/1/',
-            'sort1': -1,
-            'sort2': None
+            'url': '/legal/matter-under-review/1/'
         }
         self.create_mur(1, expected_mur['no'], expected_mur['name'], mur_subject)
         manage.legal_docs.load_current_murs()
@@ -296,10 +294,7 @@ class TestLoadCurrentMURs(BaseTestCase):
             'mur_type': 'current', 'name': 'Open Elections LLC', 'open_date': datetime(2005, 1, 1, 0, 0),
             'election_cycles': [2016],
             'close_date': datetime(2008, 1, 1, 0, 0),
-            'url': '/legal/matter-under-review/1/',
-            'sort1': -1,
-            'sort2': None
-        }
+            'url': '/legal/matter-under-review/1/'}
 
         assert mur == expected_mur
 

--- a/webservices/legal_docs/current_murs.py
+++ b/webservices/legal_docs/current_murs.py
@@ -109,8 +109,6 @@ def load_current_murs():
                 'no': row['case_no'],
                 'name': row['name'],
                 'mur_type': 'current',
-                "sort1": -int(row['case_no']),
-                "sort2": None,
             }
             mur['subjects'] = get_subjects(case_id)
             mur['subject'] = {'text': mur['subjects']}


### PR DESCRIPTION
This reverts commit 01ff18300f369f893b6b1f70c2d6043504aad965.

18 MURs have non-integral case numbers.