### PR TITLE
Update redis service name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,11 +292,11 @@ invoke deploy --space dev
 This command will explicitly target the `dev` space.
 
 #### Setting up a service
-On Cloud Foundry, we use the redis28-swarm
+On Cloud Foundry, we use the redis28
 service. The Redis service can be created as follows:
 
 ```
-cf create-service redis28-swarm standard fec-redis
+cf create-service redis28 standard fec-redis
 ```
 
 #### Setting up credentials

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -22,7 +22,7 @@ if env.app.get('space_name', 'unknown-space').lower() != 'feature':
     }
 
 def redis_url():
-    redis = env.get_service(label='redis28-swarm')
+    redis = env.get_service(label='redis28')
     if redis:
         url = redis.get_url(host='hostname', password='password', port='port')
         return 'redis://{}'.format(url)


### PR DESCRIPTION
I saw an issue with redis in our support channel and noticed that the govcloud branch still refers to the `redis28-swarm` service, which is replaced with `redis28` in govcloud.