### PR TITLE
Add support and instructions for cf ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,23 @@ One other thing you may want to consider doing is adding explicit log statements
 
 *Note: We hope to have a better way of accomplishing this in the future.*
 
+### SSH
+*Likely only useful for 18F FEC team members*
+
+You can SSH directly into the running app container to help troubleshoot or inspect things with the instance(s).  Run the following command:
+
+```bash
+cf ssh <app name>
+```
+
+Where *<app name>* is the name of the application instance you want to connect to.  Once you are logged into the remote secure shell, you'll also want to run this command to setup the shell environment correctly:
+
+```bash
+. /home/vcap/app/bin/cf_env_setup.sh
+```
+
+More information about using SSH with cloud.dov can be found in the [cloud.gov SSH documentation](https://cloud.gov/docs/apps/using-ssh/#cf-ssh).
+
 ### Create a changelog
 If you're preparing a release to production, you should also create a changelog. The preferred way to do this is using the [changelog generator](https://github.com/skywinder/github-changelog-generator).
 

--- a/bin/cf_env_setup.sh
+++ b/bin/cf_env_setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This is a convenience script to setup the app container environment to match
+# what was uploaded with the buildpack when you SSH into an app container.
+# This must be run if you want to interact with the application and run
+# anything as you'd expect, e.g., ./manage.py showmigrations for a Python app
+# built with Django.
+
+# This script is built using the commands and information outlined here:
+# https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#ssh-env
+
+# Setup the necessary environment variables
+export HOME=/home/vcap/app
+export TMPDIR=/home/vcap/tmp
+
+# Source the setup files
+if [ -d /home/vcap/app/.profile.d/ ]; then
+    for f in /home/vcap/app/.profile.d/*.sh; do source "$f"; done;
+fi
+
+if [ -f /home/vcap/app/.profile ]; then
+    source /home/vcap/app/.profile;
+fi
+
+# Return to the main app directory
+cd $HOME


### PR DESCRIPTION
This changeset adds support and instructions for running `cf ssh` in the GovCloud environment.  While it is easy and straightforward to SSH into a running application, there is a little bit of environment setup to do once you are in.  This script makes it easy to take care of these things with one command.