### PR TITLE
Update some of the backend tooling for the API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: false
 cache: pip
 python:
-  - "3.4"
+  - "3.5"
 addons:
   postgresql: "9.4"
 env:
@@ -21,14 +21,20 @@ before_script:
   - travis_retry pip install -U pip setuptools wheel
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install -r requirements-dev.txt
+  - ". $HOME/.nvm/nvm.sh"
+  - nvm install v7.7.4
+  - nvm use v7.7.4
+  - npm i -g npm
   - travis_retry npm install -g swagger-tools
+  - travis_retry npm install
+  - npm run build
 script: py.test
 after_success:
   - travis_retry pip install codecov
   - codecov
 before_deploy:
   - export PATH=$HOME:$PATH
-  - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.22.2"
+  - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.25.0"
   - tar xzvf $HOME/cf.tgz -C $HOME
   - travis_retry cf install-plugin autopilot -f -r CF-Community
   - npm install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,6 @@ development tools:
 We currently have several monitoring tools in place:
 
 - New Relic, mainly for basic pings
-- Sentry, for catching more verbose error reports and logs
 - A custom script powered by Mandrill to e-mail us nightly status reports in
   the `dev`, `stage`, and `prod` environments.
 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ We are always trying to improve our documentation. If you have suggestions or ru
 ### Project prerequisites
 1. Ensure you have the following requirements installed:
 
-    * Python 3.4 (which includes pip and and a built-in version of virtualenv called `pyvenv`)
+    * Python 3.5.3 (which includes pip and and a built-in version of virtualenv called `pyvenv`)
     * The latest long term support (LTS) or stable release of Node.js (which includes npm)
-    * PostgreSQL (the latest 9.5 release).
+    * PostgreSQL (the latest 9.6 release).
          * Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/)
          * Read a [Windows tutorial](http://www.postgresqltutorial.com/install-postgresql/)
          * Read a [Linux tutorial](http://www.postgresql.org/docs/9.4/static/installation.html) (or follow your OS package manager)
-    * Elastic Search 1.7 (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/_installation.html)
+    * Elastic Search 2.4 (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/_installation.html)
 
 2. Set up your Node environment—  learn how to do this with our [Javascript Ecosystem Guide](https://pages.18f.gov/dev-environment-standardization/languages/javascript/).
 
@@ -312,8 +312,6 @@ the following keys are set:
 * FEC_WEB_API_KEY
 * FEC_WEB_API_KEY_PUBLIC
 * FEC_GITHUB_TOKEN
-* SENTRY_DSN
-* SENTRY_PUBLIC_DSN
 * NEW_RELIC_LICENSE_KEY
 * WRITE_AUTHORIZED_TOKENS
 

--- a/manifest_feature.yml
+++ b/manifest_feature.yml
@@ -7,5 +7,5 @@ services:
   - fec-s3-feature
   - fec-search-feature
 env:
-  NEW_RELIC_APP_NAME: OpenFEC API (feature)
+  NEW_RELIC_APP_NAME: fec | api | feature
   NEW_RELIC_ENV: feature

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,11 +4,11 @@ git+https://github.com/18F/rdbms-subsetter
 
 # Testing
 mock>=1.3.0
-pytest>=3.0.2
+pytest>=3.0.7
 pytest-cov>=2.3.1
 factory-boy>=2.5.2
 faker>=0.7.5
-nplusone>=0.3.0
+nplusone>=0.7.3
 webtest>=2.0.2
 pdbpp>=0.8.3
 pygments>=2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,17 @@
 apispec==0.19.0
 cfenv==0.5.2
 invoke==0.15.0
-psycopg2==2.6.2
+psycopg2==2.7.1
 Flask==0.12
 Flask-Cors==3.0.2
 Flask-Script==2.0.5
 Flask-RESTful==0.3.5
 Flask-SQLAlchemy==2.1
 python-dateutil==2.4.2
-sqlalchemy-postgres-copy==0.1.0
-networkx==1.9.1
+sqlalchemy-postgres-copy==0.3.0
+networkx==1.11
 newrelic==2.78.0.57
-SQLAlchemy==1.0.15
+SQLAlchemy==1.0.17
 mandrill==1.0.57
 icalendar==3.9.1
 GitPython==1.0.1
@@ -31,7 +31,7 @@ marshmallow-sqlalchemy==0.8.0
 git+https://github.com/jmcarp/marshmallow-pagination@master
 
 # Data export
-boto3==1.2.2
+boto3==1.4.4
 
 # Task queue
 celery==3.1.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ requests==2.13.0
 elasticsearch==2.4.0
 elasticsearch-dsl==2.1.0
 bandit==1.4.0
-git+https://github.com/timClicks/slate.git
+git+https://github.com/18F/slate.git
 
 # Marshalling
 flask-apispec==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+setuptools
+wheel
 apispec==0.19.0
 cfenv==0.5.2
 invoke==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 apispec==0.19.0
 cfenv==0.5.2
-invoke==0.13.0
+invoke==0.15.0
 psycopg2==2.6.2
-Flask==0.11
-Flask-Cors==2.1.0
+Flask==0.12
+Flask-Cors==3.0.2
 Flask-Script==2.0.5
 Flask-RESTful==0.3.5
 Flask-SQLAlchemy==2.1
@@ -15,12 +15,11 @@ SQLAlchemy==1.0.15
 mandrill==1.0.57
 icalendar==3.9.1
 GitPython==1.0.1
-gunicorn==19.3.0
+gunicorn==19.7.1
 webargs==0.18.0
 slacker==0.8.6
-raven[flask]==5.8.1
 ujson==1.33
-requests==2.10.0
+requests==2.13.0
 elasticsearch==2.4.0
 elasticsearch-dsl==2.1.0
 git+https://github.com/timClicks/slate.git
@@ -35,6 +34,6 @@ git+https://github.com/jmcarp/marshmallow-pagination@master
 boto3==1.2.2
 
 # Task queue
-celery==3.1.23
+celery==3.1.25
 celery-once==0.1.4
 redis==2.10.5

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.4.5
+python-3.5.3

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -4,8 +4,6 @@ import celery
 from celery import signals
 from celery.schedules import crontab
 
-from raven import Client
-from raven.contrib.celery import register_signal, register_logger_signal
 
 from webservices.env import env
 from webservices.tasks import utils

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -194,8 +194,6 @@ def make_bundle(resource):
                 resource['query'],
                 resource['schema']
             )
-            import ipdb
-            ipdb.set_trace()
             copy_to(
                 query,
                 fp,

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -194,10 +194,12 @@ def make_bundle(resource):
                 resource['query'],
                 resource['schema']
             )
+            import ipdb
+            ipdb.set_trace()
             copy_to(
                 query,
-                db.session.connection().engine,
                 fp,
+                db.session.connection().engine,
                 format='csv',
                 header=True
             )


### PR DESCRIPTION
This changeset updates some of the tooling and infrastructure in the API to bring things up to date. It includes the following:

* Cleanup of .travis.yml
* Updates several Python dependencies
* Removal of all references to Sentry/Raven
* Updates cloud.gov Python runtime to 3.5.3
* Updates New Relic environment name in the manifest_feature.yml config
* A handful of documentation updates

The Travis cleanup includes updating nvm to make use of the latest stable release of Node.js, which I have been running locally for a while now with no issues.

I originally tried to get things running with Python 3.6 with these changes, but there are a couple of dependencies that are not playing nice with it (namely `slate` and the `distribute` dependency it has).  Things are working fine with Python 3.5 though, so this accounts for running things with the latest patch level release of it, 3.5.3.

A handful of the components updated are related to the downloads/exports, so to test them I ran both the updated web app (based on PR https://github.com/18F/openFEC-web-app/pull/1898) and a local copy of the Celery worker with this updated code as well, and pointed my local API to the dev GovCloud database.  There was a small change I needed to make to fix a failing test and account for a newer version of `sqlalchemy-postgres-copy`, but otherwise things should still be working just fine!