### PR TITLE
Removing setuptools and wheel due to pip warning output

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-setuptools
-wheel
 apispec==0.19.0
 cfenv==0.5.2
 invoke==0.15.0


### PR DESCRIPTION
Turns out that including these two dependencies is something pip warns against - removing them to ensure things work as expected (or break as expected for that matter).