### PR TITLE
Use only case number for sorting MURs

### DIFF
--- a/tests/test_current_murs.py
+++ b/tests/test_current_murs.py
@@ -133,7 +133,7 @@ class TestLoadCurrentMURs(BaseTestCase):
             'open_date': None,
             'url': '/legal/matter-under-review/1/',
             'sort1': -1,
-            'sort2': ''
+            'sort2': None
         }
         self.create_mur(1, expected_mur['no'], expected_mur['name'], mur_subject)
         actual_mur = next(get_murs())
@@ -284,7 +284,7 @@ class TestLoadCurrentMURs(BaseTestCase):
             'close_date': datetime(2008, 1, 1, 0, 0),
             'url': '/legal/matter-under-review/1/',
             'sort1': -1,
-            'sort2': ''
+            'sort2': None
         }
         assert actual_mur == expected_mur
 

--- a/webservices/legal_docs/current_murs.py
+++ b/webservices/legal_docs/current_murs.py
@@ -89,7 +89,7 @@ ORDER BY vote_date desc;
 
 STATUTE_REGEX = re.compile(r'(?<!\(|\d)(?P<section>\d+([a-z](-1)?)?)')
 REGULATION_REGEX = re.compile(r'(?<!\()(?P<part>\d+)(\.(?P<section>\d+))?')
-MUR_NO_REGEX = re.compile(r'(?P<serial>\d+)(?P<extra>.*)')
+MUR_NO_REGEX = re.compile(r'(?P<serial>\d+)')
 
 def load_current_murs():
     """
@@ -319,4 +319,4 @@ def remove_reclassification_notes(statutory_citation):
 
 def get_sort_fields(case_no):
     match = MUR_NO_REGEX.match(case_no)
-    return -int(match.group("serial")), match.group("extra")
+    return -int(match.group("serial")), None


### PR DESCRIPTION
The 2nd part, which is usually 'R' or 'r', cannot be used as it
conflicts with other 2nd sort fields which are ints.