### PR TITLE
Restore highlights

### DIFF
--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -131,9 +131,16 @@ class SearchTest(unittest.TestCase):
                 {"match": {"no": "president"}},
                 {"match_phrase": {"_all": {"query": "president", "slop": 50}}},
             ]}},
-            "highlight": {"fields": {"text": {}, "name": {}, "no": {}, "summary": {},
-                "documents.text": {}, "documents.description": {}},
-                "highlight_query": {"match": {"_all": "president"}}},
+            "highlight": {
+                "fields": {
+                    "text": {},
+                    "name": {},
+                    "no": {},
+                    "summary": {},
+                    "documents.text": {},
+                    "documents.description": {}
+                },
+                "require_field_match": False},
             "_source": {"exclude": ["text", "documents.text", "sort1", "sort2"]},
             "sort": ['sort1', 'sort2'],
             "from": 0,
@@ -162,9 +169,17 @@ class SearchTest(unittest.TestCase):
                 {"match": {"no": '"electronic filing"'}},
                 {"match_phrase": {"_all": {"query": '"electronic filing"', "slop": 50}}},
             ]}},
-            "highlight": {"fields": {"text": {}, "name": {}, "no": {}, "summary": {},
-                "documents.text": {}, "documents.description": {}},
-                "highlight_query": {"bool": {"must": [{"match_phrase": {"_all": "electronic filing"}}]}}},
+            "highlight": {
+                "fields": {
+                    "text": {},
+                    "name": {},
+                    "no": {},
+                    "summary": {},
+                    "documents.text": {},
+                    "documents.description": {}
+                },
+                "require_field_match": False
+            },
             "_source": {"exclude": ["text", "documents.text", "sort1", "sort2"]},
             "sort": ['sort1', 'sort2'],
             "from": 0,
@@ -173,19 +188,6 @@ class SearchTest(unittest.TestCase):
         es_search.assert_called_with(body=expected_query,
                                      index=mock.ANY,
                                      doc_type=mock.ANY)
-
-    @patch.object(es, 'search')
-    def test_query_dsl_phrase_search_highlight(self, es_search):
-        response = self.app.get('/v1/legal/search/', query_string={
-                                'q': '"electronic filing" 2016 "vice president"',
-                                'type': 'advisory_opinions'})
-        assert response.status_code == 200
-        expected_highlight_query = Q('match_phrase', _all="electronic filing") & \
-                                   Q('match_phrase', _all="vice president") & \
-                                   Q('match', _all="2016")
-        _, args = es_search.call_args
-        query = args['body']
-        assert get_path(query, 'highlight.highlight_query') == expected_highlight_query.to_dict()
 
     @patch.object(es, 'search')
     def test_query_dsl_with_ao_category_filter(self, es_search):
@@ -197,7 +199,8 @@ class SearchTest(unittest.TestCase):
         # This is mostly copy/pasted from the dict-based query. This is not a
         # very meaningful test but helped to ensure we're using the
         # elasitcsearch_dsl correctly.
-        expected_query = {'sort': ['sort1', 'sort2'],
+        expected_query = {
+            'sort': ['sort1', 'sort2'],
             'from': 0,
             'query': {'bool': {
                 'must': [{'term': {'_type': 'advisory_opinions'}},
@@ -211,9 +214,18 @@ class SearchTest(unittest.TestCase):
                     {'bool': {'minimum_should_match': 1}}], 'should': [{'match': {'no': 'president'}},
                     {'match_phrase': {'_all': {'slop': 50, 'query': 'president'}}}]}},
             'size': 20, '_source': {'exclude': ['text', 'documents.text', 'sort1', 'sort2']},
-            'highlight': {'highlight_query': {'match': {'_all': 'president'}},
-            'fields': {'documents.text': {}, 'text': {},
-            'documents.description': {}, 'name': {}, 'no': {}, 'summary': {}}}}
+            'highlight': {
+                'fields': {
+                    'documents.text': {},
+                    'text': {},
+                    'documents.description': {},
+                    'name': {},
+                    'no': {},
+                    'summary': {}
+                },
+                "require_field_match": False
+            }
+        }
 
         es_search.assert_called_with(body=expected_query,
                                      index=mock.ANY,

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -105,23 +105,21 @@ class UniversalSearch(utils.Resource):
         total_count = 0
         for type in types:
             must_query = [Q('term', _type=type)]
-            text_highlight_query = Q()
 
             if len(terms):
                 term_query = Q('match', _all=' '.join(terms))
                 must_query.append(term_query)
-                text_highlight_query = text_highlight_query & term_query
 
             if len(phrases):
                 phrase_queries = [Q('match_phrase', _all=phrase) for phrase in phrases]
                 must_query.extend(phrase_queries)
-                text_highlight_query = text_highlight_query & Q('bool', must=phrase_queries)
 
             query = Search().using(es) \
                 .query(Q('bool',
                          must=must_query,
                          should=[Q('match', no=q), Q('match_phrase', _all={"query": q, "slop": 50})])) \
                 .highlight('text', 'name', 'no', 'summary', 'documents.text', 'documents.description') \
+                .highlight_options(require_field_match=False) \
                 .source(exclude=['text', 'documents.text', 'sort1', 'sort2']) \
                 .extra(size=hits_returned, from_=from_hit) \
                 .index(DOCS_SEARCH) \
@@ -132,9 +130,6 @@ class UniversalSearch(utils.Resource):
 
             if type == 'murs':
                 query = apply_mur_specific_query_params(query, q, **kwargs)
-
-            if text_highlight_query:
-                query = query.highlight_options(highlight_query=text_highlight_query.to_dict())
 
             es_results = query.execute()
 


### PR DESCRIPTION
Highlight fields regardless of whether the query matched on them
specifically. Also, remove the highlight_query option as we are not
doing anything special in highlighting.