### PR TITLE
[WIP] Fix queue processing to account for column type mis-match

### DIFF
--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_employer.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_employer.sql
@@ -31,11 +31,11 @@ alter table ofec_sched_a_aggregate_employer_tmp rename to ofec_sched_a_aggregate
 create or replace function ofec_sched_a_update_aggregate_employer() returns void as $$
 begin
     with new as (
-        select 1 as multiplier, *
+        select 1 as multiplier, cmte_id, rpt_yr, contbr_employer, contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text, contbr_id
         from ofec_sched_a_queue_new
     ),
     old as (
-        select -1 as multiplier, *
+        select -1 as multiplier, cmte_id, rpt_yr, contbr_employer, contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text, contbr_id
         from ofec_sched_a_queue_old
     ),
     patch as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_occupation.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_occupation.sql
@@ -31,11 +31,11 @@ alter table ofec_sched_a_aggregate_occupation_tmp rename to ofec_sched_a_aggrega
 create or replace function ofec_sched_a_update_aggregate_occupation() returns void as $$
 begin
     with new as (
-        select 1 as multiplier, cmte_id, rpt_yr, contbr_occupation, contb_receipt_amt, receipt_amt, receipt_tp, line_num, memo_cd, memo_text, contbr_id
+        select 1 as multiplier, cmte_id, rpt_yr, contbr_occupation, contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text, contbr_id
         from ofec_sched_a_queue_new
     ),
     old as (
-        select -1 as multiplier, cmte_id, rpt_yr, contbr_occupation, contb_receipt_amt, receipt_amt, receipt_tp, line_num, memo_cd, memo_text, contbr_id
+        select -1 as multiplier, cmte_id, rpt_yr, contbr_occupation, contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text, contbr_id
         from ofec_sched_a_queue_old
     ),
     patch as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_occupation.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_occupation.sql
@@ -31,11 +31,11 @@ alter table ofec_sched_a_aggregate_occupation_tmp rename to ofec_sched_a_aggrega
 create or replace function ofec_sched_a_update_aggregate_occupation() returns void as $$
 begin
     with new as (
-        select 1 as multiplier, *
+        select 1 as multiplier, cmte_id, rpt_yr, contbr_occupation, contb_receipt_amt, receipt_amt, receipt_tp, line_num, memo_cd, memo_text, contbr_id
         from ofec_sched_a_queue_new
     ),
     old as (
-        select -1 as multiplier, *
+        select -1 as multiplier, cmte_id, rpt_yr, contbr_occupation, contb_receipt_amt, receipt_amt, receipt_tp, line_num, memo_cd, memo_text, contbr_id
         from ofec_sched_a_queue_old
     ),
     patch as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_size.sql
@@ -48,11 +48,11 @@ alter table ofec_sched_a_aggregate_size_tmp rename to ofec_sched_a_aggregate_siz
 create or replace function ofec_sched_a_update_aggregate_size() returns void as $$
 begin
     with new as (
-        select 1 as multiplier, *
+        select 1 as multiplier, cmte_id, rpt_yr, contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text, contbr_id
         from ofec_sched_a_queue_new
     ),
     old as (
-        select -1 as multiplier, *
+        select -1 as multiplier, cmte_id, rpt_yr, contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text, contbr_id
         from ofec_sched_a_queue_old
     ),
     patch as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_state.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_state.sql
@@ -35,11 +35,11 @@ alter table ofec_sched_a_aggregate_state_tmp rename to ofec_sched_a_aggregate_st
 create or replace function ofec_sched_a_update_aggregate_state() returns void as $$
 begin
     with new as (
-        select 1 as multiplier, *
+        select 1 as multiplier, cmte_id, rpt_yr, contbr_st, contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text, contbr_id
         from ofec_sched_a_queue_new
     ),
     old as (
-        select -1 as multiplier, *
+        select -1 as multiplier, cmte_id, rpt_yr, contbr_st, contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text, contbr_id
         from ofec_sched_a_queue_old
     ),
     patch as (

--- a/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_zip.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_a_aggregate_zip.sql
@@ -35,11 +35,11 @@ alter table ofec_sched_a_aggregate_zip_tmp rename to ofec_sched_a_aggregate_zip;
 create or replace function ofec_sched_a_update_aggregate_zip() returns void as $$
 begin
     with new as (
-        select 1 as multiplier, *
+        select 1 as multiplier, cmte_id, rpt_yr, contbr_zip, contbr_st, contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text, contbr_id
         from ofec_sched_a_queue_new
     ),
     old as (
-        select -1 as multiplier, *
+        select -1 as multiplier, cmte_id, rpt_yr, contbr_zip, contbr_st, contb_receipt_amt, receipt_tp, line_num, memo_cd, memo_text, contbr_id
         from ofec_sched_a_queue_old
     ),
     patch as (

--- a/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_purpose.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_purpose.sql
@@ -31,11 +31,11 @@ alter table ofec_sched_b_aggregate_purpose_tmp rename to ofec_sched_b_aggregate_
 create or replace function ofec_sched_b_update_aggregate_purpose() returns void as $$
 begin
     with new as (
-        select 1 as multiplier, *
+        select 1 as multiplier, cmte_id, rpt_yr, disb_tp, disb_desc, disb_amt, memo_cd
         from ofec_sched_b_queue_new
     ),
     old as (
-        select -1 as multiplier, *
+        select -1 as multiplier, cmte_id, rpt_yr, disb_tp, disb_desc, disb_amt, memo_cd
         from ofec_sched_b_queue_old
     ),
     patch as (

--- a/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient.sql
@@ -31,11 +31,11 @@ alter table ofec_sched_b_aggregate_recipient_tmp rename to ofec_sched_b_aggregat
 create or replace function ofec_sched_b_update_aggregate_recipient() returns void as $$
 begin
     with new as (
-        select 1 as multiplier, *
+        select 1 as multiplier, cmte_id, rpt_yr, recipient_nm, disb_amt, memo_cd
         from ofec_sched_b_queue_new
     ),
     old as (
-        select -1 as multiplier, *
+        select -1 as multiplier, cmte_id, rpt_yr, recipient_nm, disb_amt, memo_cd
         from ofec_sched_b_queue_old
     ),
     patch as (

--- a/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient_committee.sql
+++ b/data/sql_incremental_aggregates/prepare_schedule_b_aggregate_recipient_committee.sql
@@ -33,11 +33,11 @@ alter table ofec_sched_b_aggregate_recipient_id_tmp rename to ofec_sched_b_aggre
 create or replace function ofec_sched_b_update_aggregate_recipient_id() returns void as $$
 begin
     with new as (
-        select 1 as multiplier, *
+        select 1 as multiplier, cmte_id, rpt_yr, recipient_cmte_id, recipient_nm, disb_amt, memo_cd
         from ofec_sched_b_queue_new
     ),
     old as (
-        select -1 as multiplier, *
+        select -1 as multiplier, cmte_id, rpt_yr, recipient_cmte_id, recipient_nm, disb_amt, memo_cd
         from ofec_sched_b_queue_old
     ),
     patch as (

--- a/manage.py
+++ b/manage.py
@@ -297,9 +297,24 @@ def partition_itemized():
     schedule tables.
     """
 
+    partition_itemized_a()
+    partition_itemized_b()
+
+@manager.command
+def partition_itemized_a():
+    """This command runs the partitioning against the larger itemized
+    schedule a table.
+    """
+
     logger.info('Partitioning Schedule A...')
     partition.SchedAGroup.run()
     logger.info('Finished partitioning Schedule A.')
+
+@manager.command
+def partition_itemized_b():
+    """This command runs the partitioning against the larger itemized
+    schedule b table.
+    """
 
     logger.info('Partitioning Schedule B...')
     partition.SchedBGroup.run()

--- a/webservices/partition/base.py
+++ b/webservices/partition/base.py
@@ -51,6 +51,10 @@ class TableGroup:
     def redefine_columns(cls, parent):
         """Redefines columns in a table definition that are not the type that
         we expect in the parent view.
+
+        This is intended to be used when creating the master table of a
+        partition, which is when the structure of the table is derived
+        directly and solely from the parent/source table/view.
         """
 
         for column_name, cast_type in cls.column_mappings.items():
@@ -62,6 +66,12 @@ class TableGroup:
     def recast_columns(cls, parent):
         """Recasts columns in a table definition that are not the type that
         we expect in the parent view.
+
+        This is intended to be used when creating the child tables that
+        inherit from the master table in a partition, which is when the
+        structure of the table is partially derived from the parent/source
+        table/view but also modified to represent the actual data that will
+        live within the child table.
         """
 
         columns = [

--- a/webservices/partition/base.py
+++ b/webservices/partition/base.py
@@ -50,7 +50,7 @@ class TableGroup:
     @classmethod
     def redefine_columns(cls, parent):
         """Redefines columns in a table definition that are not the type that
-        we expect in the parent view.
+        we expect in the parent table/view.
 
         This is intended to be used when creating the master table of a
         partition, which is when the structure of the table is derived
@@ -65,13 +65,17 @@ class TableGroup:
     @classmethod
     def recast_columns(cls, parent):
         """Recasts columns in a table definition that are not the type that
-        we expect in the parent view.
+        we expect in the parent table/view.
 
         This is intended to be used when creating the child tables that
         inherit from the master table in a partition, which is when the
         structure of the table is partially derived from the parent/source
         table/view but also modified to represent the actual data that will
         live within the child table.
+
+        This is also used for accessing the data found in the queue tables for
+        a refresh due to the fact that they also may have unknown/incorrect
+        column types.
         """
 
         columns = [
@@ -294,7 +298,7 @@ class TableGroup:
             ]
 
             insert_select = sa.select(
-                queue_new.columns + columns
+                cls.recast_columns(queue_new) + columns
             ).select_from(
                 queue_new.join(
                     queue_old,

--- a/webservices/partition/base.py
+++ b/webservices/partition/base.py
@@ -7,7 +7,7 @@ from webservices.config import SQL_CONFIG
 
 from . import utils
 
-logger = logging.getLogger('partitioner.base')
+logger = logging.getLogger('partitioner')
 logging.basicConfig(level=logging.INFO)
 
 def get_cycles():
@@ -16,6 +16,7 @@ def get_cycles():
         SQL_CONFIG['END_YEAR_ITEMIZED'] + 3,
         2,
     )
+    #return range(1978, 1980, 2)
 
 class TableGroup:
 
@@ -185,6 +186,13 @@ class TableGroup:
         cls.create_indexes(child)
         cls.update_child(child)
         db.engine.execute(utils.Analyze(child))
+        logger.info(
+            'Successfully created child table {base}_{start}_{stop}.'.format(
+                base=cls.base_name,
+                start=start,
+                stop=stop
+            )
+        )
         return child
 
     @classmethod


### PR DESCRIPTION
**WIP:  PLEASE DO NOT MERGE**

Fixes #2286 

This changeset addresses a few remaining issues with the SQL that references the queue tables and not accounting for the `unknown` type of the `schedule_type` column.  It also addresses the `refresh_child()` method in the partitioning for the same problem.  The previous work done to fix this issue did not take into account the nightly refresh component of the partition code, only the creation of the partitions.

Additional notes have been added to some of the comments as well to explain the purpose and usage of some methods as well.