### PR TITLE
Election search results fix

### DIFF
--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -24,6 +24,17 @@ class TestElectionSearch(ApiBaseTest):
             factory(office='H', state='NJ', district='09'),
             factory(office='S', state='VA', district='00'),
             factory(office='H', state='VA', district='05'),
+            factory(office='S', state='GA', district='00'),
+        ]
+        factory = functools.partial(
+            factories.ElectionResultFactory
+        )
+        self.elections = [
+            factory(election_yr=2008, cand_office='P', cand_office_st='US', cand_office_district='00'),
+            factory(election_yr=2006, cand_office='S', cand_office_st='NJ', cand_office_district='00'),
+            factory(election_yr=2010, cand_office='H', cand_office_st='NJ', cand_office_district='09'),
+            factory(election_yr=2006, cand_office='S', cand_office_st='VA', cand_office_district='00'),
+            factory(election_yr=2010, cand_office='H', cand_office_st='VA', cand_office_district='05'),
         ]
 
     def test_search_district(self):
@@ -52,19 +63,20 @@ class TestElectionSearch(ApiBaseTest):
         assert_dicts_subset(results[2], {'cycle': 2012, 'office': 'H', 'state': 'VA', 'district': '05'})
 
     def test_search_incumbent(self):
+
         [
             factories.ElectionResultFactory(
                 cand_office='S',
                 election_yr=2006,
-                cand_office_st='NJ',
+                cand_office_st='GA',
                 cand_office_district='00',
                 cand_id='S012345',
-                cand_name='Howard Stackhouse',
+                cand_name='George P. Burdell',
             )
         ]
-        results = self._results(api.url_for(ElectionList, office='senate', state='NJ'))
+        results = self._results(api.url_for(ElectionList, office='senate', state='GA'))
         assert len(results) == 1
-        assert_dicts_subset(results[0], {'incumbent_id': 'S012345', 'incumbent_name': 'Howard Stackhouse'})
+        assert_dicts_subset(results[0], {'incumbent_id': 'S012345', 'incumbent_name': 'George P. Burdell'})
 
 
 class TestElections(ApiBaseTest):

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -16,6 +16,7 @@ class TestElectionSearch(ApiBaseTest):
             factories.CandidateHistoryFactory,
             two_year_period=2012,
             election_years=[2012],
+            cycles=[2012],
             candidate_status='C',
         )
         self.candidates = [
@@ -90,6 +91,7 @@ class TestElections(ApiBaseTest):
                 state='NY',
                 two_year_period=2012,
                 election_years=[2010, 2012],
+                cycles=[2010, 2012],
                 office='S',
             ),
             factories.CandidateHistoryFactory(
@@ -97,6 +99,7 @@ class TestElections(ApiBaseTest):
                 state='NY',
                 two_year_period=2010,
                 election_years=[2010, 2012],
+                cycles=[2010, 2012],
                 office='S',
             ),
         ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,8 +54,8 @@ class TestSort(ApiBaseTest):
 
         ]
         candidateHistory = [
-            factories.CandidateHistoryFactory(candidate_id='C1234', two_year_period=2016, election_years=[2016]),
-            factories.CandidateHistoryFactory(candidate_id='C5678', two_year_period=2016, election_years=[2016])
+            factories.CandidateHistoryFactory(candidate_id='C1234', two_year_period=2016, election_years=[2016], cycles=[2016]),
+            factories.CandidateHistoryFactory(candidate_id='C5678', two_year_period=2016, election_years=[2016], cycles=[2016])
         ]
         candidateTotals = [
             factories.CandidateTotalFactory(candidate_id='C1234', is_election=False, cycle=2016),
@@ -85,8 +85,8 @@ class TestSort(ApiBaseTest):
         db.session.flush()
         candidateHistory = [
             factories.CandidateHistoryFactory(candidate_id='C1234', two_year_period=2016, state='MO',
-                                              candidate_inactive=False, district='01', office='S', election_years=[2016]),
-            factories.CandidateHistoryFactory(candidate_id='C5678', two_year_period=2016, state='MO', election_years=[2016],
+                                              candidate_inactive=False, district='01', office='S', election_years=[2016], cycles=[2016]),
+            factories.CandidateHistoryFactory(candidate_id='C5678', two_year_period=2016, state='MO', election_years=[2016], cycles=[2016],
                                               candidate_inactive=False, district='02', office='S')
         ]
         candidateCmteLinks = [

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -180,7 +180,7 @@ class ElectionView(utils.Resource):
         ).join(
             latest,
             aggregates.c.candidate_id == latest.c.candidate_id,
-        ).outerjoin(
+        ).join(
             outcomes,
             aggregates.c.candidate_id == outcomes.c.cand_id,
         )

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -67,14 +67,14 @@ class ElectionList(utils.Resource):
                 ],
                 else_=4,
             ).label('_office_status'),
-        ).outerjoin(
+        ).join(
             ElectionResult,
             sa.and_(
                 elections.c.state == ElectionResult.cand_office_st,
                 elections.c.office == ElectionResult.cand_office,
                 sa.func.coalesce(elections.c.district, '00') == ElectionResult.cand_office_district,
                 elections.c.two_year_period == ElectionResult.election_yr + cycle_length(elections),
-            ),
+            )
         ).order_by(
             '_office_status',
             ElectionResult.cand_office_district,
@@ -91,7 +91,13 @@ class ElectionList(utils.Resource):
             CandidateHistory.candidate_inactive == False,  # noqa
             # TODO(jmcarp) Revert after #1271 is resolved
             sa.or_(
-                CandidateHistory.district == None,  # noqa
+                #This line was causing some semi-duplicate entries
+                #an example here: https://beta.fec.gov/data/elections/?cycle=2016&state=AK
+                #young shows up once. In one of those entries the district is null.  I don't know
+                #if this was to counter a bug or some incomplete data.  But I would say we don't
+                #want candidates with null districts showing up.  Thoughts?  The TODO directly
+                #above is also indicator of some prior inconsistent data, is this still the case?
+                #CandidateHistory.district == None,  # noqa
                 CandidateHistory.district != '99',
             )
         )

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -74,7 +74,7 @@ class ElectionList(utils.Resource):
                 elections.c.office == ElectionResult.cand_office,
                 sa.func.coalesce(elections.c.district, '00') == ElectionResult.cand_office_district,
                 elections.c.two_year_period == ElectionResult.election_yr + cycle_length(elections),
-            )
+            ),
         ).order_by(
             '_office_status',
             ElectionResult.cand_office_district,
@@ -180,7 +180,7 @@ class ElectionView(utils.Resource):
         ).join(
             latest,
             aggregates.c.candidate_id == latest.c.candidate_id,
-        ).join(
+        ).outerjoin(
             outcomes,
             aggregates.c.candidate_id == outcomes.c.cand_id,
         )

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -98,7 +98,7 @@ class ElectionList(utils.Resource):
                 #want candidates with null districts showing up.  Thoughts?  The TODO directly
                 #above is also indicator of some prior inconsistent data, is this still the case?
                 #CandidateHistory.district == None,  # noqa
-                CandidateHistory.district != '99',
+                CandidateHistory.district != '99'
             )
         )
         if kwargs.get('cycle'):

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -91,7 +91,7 @@ class ElectionList(utils.Resource):
             CandidateHistory.candidate_inactive == False,  # noqa
         )
         if kwargs.get('cycle'):
-            query = query.filter(CandidateHistory.election_years.contains(kwargs['cycle']))
+            query = query.filter(CandidateHistory.cycles.contains(kwargs['cycle']))
         if kwargs.get('office'):
             values = [each[0].upper() for each in kwargs['office']]
             query = query.filter(CandidateHistory.office.in_(values))
@@ -322,7 +322,7 @@ def filter_candidates(query, kwargs):
     query = query.filter(
         CandidateHistory.two_year_period <= kwargs['cycle'],
         CandidateHistory.two_year_period > (kwargs['cycle'] - duration),
-        CandidateHistory.election_years.any(kwargs['cycle']),
+        CandidateHistory.cycles.any(kwargs['cycle']),
         CandidateHistory.office == kwargs['office'][0].upper(),
     )
     if kwargs.get('state'):

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -89,17 +89,6 @@ class ElectionList(utils.Resource):
             CandidateHistory.two_year_period,
         ).filter(
             CandidateHistory.candidate_inactive == False,  # noqa
-            # TODO(jmcarp) Revert after #1271 is resolved
-            sa.or_(
-                #This line was causing some semi-duplicate entries
-                #an example here: https://beta.fec.gov/data/elections/?cycle=2016&state=AK
-                #young shows up once. In one of those entries the district is null.  I don't know
-                #if this was to counter a bug or some incomplete data.  But I would say we don't
-                #want candidates with null districts showing up.  Thoughts?  The TODO directly
-                #above is also indicator of some prior inconsistent data, is this still the case?
-                #CandidateHistory.district == None,  # noqa
-                CandidateHistory.district != '99'
-            )
         )
         if kwargs.get('cycle'):
             query = query.filter(CandidateHistory.election_years.contains(kwargs['cycle']))


### PR DESCRIPTION
Turns out to be a relatively simple solution here.  The `outerjoin` in the sql_alchmey code was causing nulled entries for Presidents and Senators, because all the code was doing was querying CandidateHistory, finding entries with a two-year period that matched the cycle passed in, and did an outerjoin on ElectionResults.  Since there are entries for numerous candidates in CandidateHistory for any given cycle there were nulled out entries in the join (null district and candidate_name).  The same problem for Senators.

The outer join was maybe necessary to address data inconsistencies as was discussed at https://github.com/18F/openFEC/issues/1271.  Because the endpoint was also allowing candidates with null districts.

This code is ready for review.  I checked the endpoint with a couple of states that were behaving badly (AK, NC).  A more thorough review may be needed in case this is filtering out some valid entries that I'm not aware of.