### PR TITLE
Improve logging and split out calls for nightly updates

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -357,10 +357,13 @@ def refresh_itemized_a():
     """Used to refresh the itemized Schedule A data."""
 
     logger.info('Updating Schedule A...')
-    errors = partition.SchedAGroup.refresh_children()
+    output_messages = partition.SchedAGroup.refresh_children()
 
-    for error_message in errors:
-        logger.error(error_message)
+    for message in output_messages:
+        if message[0] == 0:
+            logger.info(message)
+        else:
+            logger.error(message)
 
     logger.info('Finished updating Schedule A.')
 
@@ -368,10 +371,13 @@ def refresh_itemized_a():
 def refresh_itemized_b():
     """Used to refresh the itemized Schedule B data."""
     logger.info('Updating Schedule B...')
-    errors = partition.SchedBGroup.refresh_children()
+    output_messages = partition.SchedBGroup.refresh_children()
 
-    for error_message in errors:
-        logger.error(error_message)
+    for message in output_messages:
+        if message[0] == 0:
+            logger.info(message)
+        else:
+            logger.error(message)
 
     logger.info('Finished updating Schedule B.')
 

--- a/manage.py
+++ b/manage.py
@@ -361,9 +361,9 @@ def refresh_itemized_a():
 
     for message in output_messages:
         if message[0] == 0:
-            logger.info(message)
+            logger.info(message[1])
         else:
-            logger.error(message)
+            logger.error(message[1])
 
     logger.info('Finished updating Schedule A.')
 
@@ -375,9 +375,9 @@ def refresh_itemized_b():
 
     for message in output_messages:
         if message[0] == 0:
-            logger.info(message)
+            logger.info(message[1])
         else:
-            logger.error(message)
+            logger.error(message[1])
 
     logger.info('Finished updating Schedule B.')
 

--- a/manage.py
+++ b/manage.py
@@ -343,15 +343,37 @@ def update_aggregates():
         )
         logger.info('Finished updating Schedule E and support aggregates.')
 
-    logger.info('Updating Schedule A...')
-    partition.SchedAGroup.refresh_children()
-    logger.info('Finished updating Schedule A.')
+@manager.command
+def refresh_itemized():
+    """These are run nightly to refresh the itemized schedule A and B data."""
 
-    logger.info('Updating Schedule B...')
-    partition.SchedBGroup.refresh_children()
-    logger.info('Finished updating Schedule B.')
+    refresh_itemized_a()
+    refresh_itemized_b()
 
     logger.info('Finished updating incremental aggregates.')
+
+@manager.command
+def refresh_itemized_a():
+    """Used to refresh the itemized Schedule A data."""
+
+    logger.info('Updating Schedule A...')
+    errors = partition.SchedAGroup.refresh_children()
+
+    for error_message in errors:
+        logger.error(error_message)
+
+    logger.info('Finished updating Schedule A.')
+
+@manager.command
+def refresh_itemized_b():
+    """Used to refresh the itemized Schedule B data."""
+    logger.info('Updating Schedule B...')
+    errors = partition.SchedBGroup.refresh_children()
+
+    for error_message in errors:
+        logger.error(error_message)
+
+    logger.info('Finished updating Schedule B.')
 
 @manager.command
 def add_itemized_partition_cycle(cycle=None, amount=1):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -163,6 +163,7 @@ class TestViews(common.IntegrationTestCase):
         )
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         search = models.ScheduleA.query.filter(
             models.ScheduleA.sub_id == row.sub_id
         ).one()
@@ -173,6 +174,7 @@ class TestViews(common.IntegrationTestCase):
         db.session.add(row)
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         search = models.ScheduleA.query.filter(
             models.ScheduleA.sub_id == row.sub_id
         ).one()
@@ -183,6 +185,7 @@ class TestViews(common.IntegrationTestCase):
         db.session.delete(row)
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         self.assertEqual(
             models.ScheduleA.query.filter(
                 models.ScheduleA.sub_id == row.sub_id
@@ -202,6 +205,7 @@ class TestViews(common.IntegrationTestCase):
         db.session.add(row)
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         self.assertEqual(
             models.ScheduleA.query.filter(
                 models.ScheduleA.sub_id == row.sub_id
@@ -241,6 +245,7 @@ class TestViews(common.IntegrationTestCase):
         self.assertEqual(new_queue_count, 1)
         self.assertEqual(old_queue_count, 0)
         manage.update_aggregates()
+        manage.refresh_itemized()
         search = models.ScheduleA.query.filter(
             models.ScheduleA.sub_id == row.sub_id
         ).one()
@@ -259,6 +264,7 @@ class TestViews(common.IntegrationTestCase):
         self.assertEqual(new_queue_count, 1)
         self.assertEqual(old_queue_count, 1)
         manage.update_aggregates()
+        manage.refresh_itemized()
         search = models.ScheduleA.query.filter(
             models.ScheduleA.sub_id == row.sub_id
         ).one()
@@ -277,6 +283,7 @@ class TestViews(common.IntegrationTestCase):
         self.assertEqual(new_queue_count, 0)
         self.assertEqual(old_queue_count, 1)
         manage.update_aggregates()
+        manage.refresh_itemized()
         new_queue_count = self._get_sched_a_queue_new_count()
         old_queue_count = self._get_sched_a_queue_old_count()
         self.assertEqual(new_queue_count, 0)
@@ -299,6 +306,7 @@ class TestViews(common.IntegrationTestCase):
         )
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
 
         # Test insert/update failure
         row.contbr_nm = 'Shelley Adelson'
@@ -313,6 +321,7 @@ class TestViews(common.IntegrationTestCase):
         old_queue_count = self._get_sched_a_queue_old_count()
         self.assertEqual(old_queue_count, 0)
         manage.update_aggregates()
+        manage.refresh_itemized()
         search = models.ScheduleA.query.filter(
             models.ScheduleA.sub_id == row.sub_id
         ).one()
@@ -335,6 +344,7 @@ class TestViews(common.IntegrationTestCase):
         })
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         rows = total_model.query.filter_by(**{
             'cycle': 2016,
             'committee_id': 'C12345',
@@ -347,6 +357,7 @@ class TestViews(common.IntegrationTestCase):
         db.session.add(filing)
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         db.session.refresh(rows[0])
         self.assertEqual(rows[0].total, 53)
         self.assertEqual(rows[0].count, 1)
@@ -368,6 +379,7 @@ class TestViews(common.IntegrationTestCase):
         })
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         db.session.refresh(existing)
         self.assertEqual(existing.total, total + 538)
         self.assertEqual(existing.count, count + 1)
@@ -400,6 +412,7 @@ class TestViews(common.IntegrationTestCase):
         )
         db.session.flush()
         manage.update_aggregates()
+        manage.refresh_itemized()
         db.session.refresh(existing)
         self.assertEqual(existing.total, total)
         self.assertEqual(existing.count, count)
@@ -414,6 +427,7 @@ class TestViews(common.IntegrationTestCase):
         )
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged_mv')
         rows = models.ScheduleABySize.query.filter_by(
             cycle=2016,
@@ -427,6 +441,7 @@ class TestViews(common.IntegrationTestCase):
         db.session.add(filing)
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged_mv')
         db.session.refresh(rows[0])
         self.assertEqual(rows[0].total, 0)
@@ -452,6 +467,7 @@ class TestViews(common.IntegrationTestCase):
         )
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged_mv')
         existing = get_existing()
         self.assertEqual(existing.total, total + 538)
@@ -484,6 +500,7 @@ class TestViews(common.IntegrationTestCase):
         db.session.execute(ins)
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         db.session.execute('refresh materialized view ofec_totals_house_senate_mv')
         db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged_mv')
         db.session.refresh(existing)
@@ -502,6 +519,7 @@ class TestViews(common.IntegrationTestCase):
         )
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         rows = models.ScheduleBByPurpose.query.filter_by(
             cycle=2016,
             committee_id='C12345',
@@ -514,6 +532,7 @@ class TestViews(common.IntegrationTestCase):
         db.session.add(filing)
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         db.session.refresh(rows[0])
         self.assertEqual(rows[0].total, 538)
         self.assertEqual(rows[0].count, 1)
@@ -521,6 +540,7 @@ class TestViews(common.IntegrationTestCase):
         db.session.add(filing)
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         db.session.refresh(rows[0])
         self.assertEqual(rows[0].total, 0)
         self.assertEqual(rows[0].count, 0)
@@ -541,6 +561,7 @@ class TestViews(common.IntegrationTestCase):
         )
         db.session.commit()
         manage.update_aggregates()
+        manage.refresh_itemized()
         db.session.refresh(existing)
         self.assertEqual(existing.total, total + 538)
         self.assertEqual(existing.count, count + 1)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -344,7 +344,6 @@ class TestViews(common.IntegrationTestCase):
         })
         db.session.commit()
         manage.update_aggregates()
-        manage.refresh_itemized()
         rows = total_model.query.filter_by(**{
             'cycle': 2016,
             'committee_id': 'C12345',
@@ -357,7 +356,6 @@ class TestViews(common.IntegrationTestCase):
         db.session.add(filing)
         db.session.commit()
         manage.update_aggregates()
-        manage.refresh_itemized()
         db.session.refresh(rows[0])
         self.assertEqual(rows[0].total, 53)
         self.assertEqual(rows[0].count, 1)
@@ -379,7 +377,6 @@ class TestViews(common.IntegrationTestCase):
         })
         db.session.commit()
         manage.update_aggregates()
-        manage.refresh_itemized()
         db.session.refresh(existing)
         self.assertEqual(existing.total, total + 538)
         self.assertEqual(existing.count, count + 1)
@@ -427,7 +424,6 @@ class TestViews(common.IntegrationTestCase):
         )
         db.session.commit()
         manage.update_aggregates()
-        manage.refresh_itemized()
         db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged_mv')
         rows = models.ScheduleABySize.query.filter_by(
             cycle=2016,
@@ -441,7 +437,6 @@ class TestViews(common.IntegrationTestCase):
         db.session.add(filing)
         db.session.commit()
         manage.update_aggregates()
-        manage.refresh_itemized()
         db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged_mv')
         db.session.refresh(rows[0])
         self.assertEqual(rows[0].total, 0)
@@ -467,7 +462,6 @@ class TestViews(common.IntegrationTestCase):
         )
         db.session.commit()
         manage.update_aggregates()
-        manage.refresh_itemized()
         db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged_mv')
         existing = get_existing()
         self.assertEqual(existing.total, total + 538)
@@ -500,7 +494,6 @@ class TestViews(common.IntegrationTestCase):
         db.session.execute(ins)
         db.session.commit()
         manage.update_aggregates()
-        manage.refresh_itemized()
         db.session.execute('refresh materialized view ofec_totals_house_senate_mv')
         db.session.execute('refresh materialized view ofec_sched_a_aggregate_size_merged_mv')
         db.session.refresh(existing)
@@ -561,7 +554,6 @@ class TestViews(common.IntegrationTestCase):
         )
         db.session.commit()
         manage.update_aggregates()
-        manage.refresh_itemized()
         db.session.refresh(existing)
         self.assertEqual(existing.total, total + 538)
         self.assertEqual(existing.count, count + 1)

--- a/webservices/partition/base.py
+++ b/webservices/partition/base.py
@@ -281,6 +281,7 @@ class TableGroup:
             base=cls.base_name, start=start, stop=stop
         )
         child = utils.load_table(name)
+        errors = []
         connection = db.engine.connect()
         transaction = connection.begin()
 
@@ -339,11 +340,16 @@ class TableGroup:
             logger.info('Successfully refreshed {name}.'.format(name=name))
         except Exception as e:
             transaction.rollback()
-            logger.error(
-                'Refreshing {name} failed: {error}'.format(name=name, error=e)
+
+            error_message = 'Refreshing {name} failed: {error}'.format(
+                name=name,
+                error=e
             )
+            logger.error(error_message)
+            errors.append(error_message)
 
         connection.close()
+        return errors
 
     @classmethod
     def clear_queue(cls, queue, record_ids, connection):

--- a/webservices/tasks/refresh.py
+++ b/webservices/tasks/refresh.py
@@ -17,6 +17,7 @@ def refresh():
     with mail.CaptureLogs(manage.logger, buffer):
         try:
             manage.update_aggregates()
+            manage.refresh_itemized()
             manage.refresh_materialized()
             download.clear_bucket()
         except Exception as error:


### PR DESCRIPTION
This changeset adds a bit of extra support for logging when the nightly updates are run for the itemized schedule data.  It also splits the methods out a bit more from the one management command into one for each, just like the we did for the partitioning code.  This should provide us with more flexibility as well as more visibility into any problems that are currently being swallowed by the success messages.