### PR TITLE
Move contributor aggregate after single receipt amount

### DIFF
--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -105,7 +105,6 @@ class ScheduleA(BaseItemized):
     contributor_occupation = db.Column('contbr_occupation', db.String, doc=docs.CONTRIBUTOR_OCCUPATION)
     contributor_occupation_text = db.Column(TSVECTOR)
     contributor_id = db.Column('clean_contbr_id', db.String, doc=docs.CONTRIBUTOR_ID)
-    contributor_aggregate_ytd = db.Column('contb_aggregate_ytd', db.Numeric(30, 2))
     is_individual = db.Column(db.Boolean, index=True)
 
     # Primary transaction info
@@ -116,6 +115,7 @@ class ScheduleA(BaseItemized):
     memo_text = db.Column(db.String)
     contribution_receipt_date = db.Column('contb_receipt_dt', db.Date)
     contribution_receipt_amount = db.Column('contb_receipt_amt', db.Numeric(30, 2))
+    contributor_aggregate_ytd = db.Column('contb_aggregate_ytd', db.Numeric(30, 2))
 
     # Related candidate info
     candidate_office = db.Column('cand_office', db.String)


### PR DESCRIPTION
This re-orders the schedule A model so that the contributor aggregate amount shows up after the individual receipt amount for greater clarity when downloading and viewing as a CSV.

cc @PaulClark2 @ChristianHilland 