### PR TITLE
Update env var references

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -108,7 +108,7 @@ def handle_error(error):
 
 # api.data.gov
 trusted_proxies = ('54.208.160.112', '54.208.160.151')
-FEC_API_WHITELIST_IPS = os.getenv('FEC_API_WHITELIST_IPS', False)
+FEC_API_WHITELIST_IPS = env.get_credential('FEC_API_WHITELIST_IPS', False)
 
 
 @app.before_request
@@ -129,7 +129,7 @@ def limit_remote_addr():
 
 @app.after_request
 def add_caching_headers(response):
-    max_age = os.getenv('FEC_CACHE_AGE')
+    max_age = env.get_credential('FEC_CACHE_AGE')
     if max_age is not None:
         response.headers.add('Cache-Control', 'public, max-age={}'.format(max_age))
     return response
@@ -348,7 +348,7 @@ def api_ui():
     return render_template(
         'swagger-ui.html',
         specs_url=url_for('docs.api_spec'),
-        PRODUCTION=os.getenv('PRODUCTION'),
+        PRODUCTION=env.get_credential('PRODUCTION'),
     )
 
 

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -24,7 +24,7 @@ def redis_url():
     if redis:
         url = redis.get_url(host='hostname', password='password', port='port')
         return 'redis://{}'.format(url)
-    return os.getenv('FEC_REDIS_URL', 'redis://localhost:6379/0')
+    return env.get_credential('FEC_REDIS_URL', 'redis://localhost:6379/0')
 
 app = celery.Celery('openfec')
 app.conf.update(

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -42,7 +42,7 @@ API_KEY_ARG = fields.Str(
     missing='DEMO_KEY',
     description=docs.API_KEY_DESCRIPTION,
 )
-if os.getenv('PRODUCTION'):
+if env.get_credential('PRODUCTION'):
     Resource = use_kwargs({'api_key': API_KEY_ARG})(Resource)
 
 fec_url_map = {'9': 'http://docquery.fec.gov/dcdev/posted/{0}.fec'}


### PR DESCRIPTION
This changeset updates most env var references to use `env.get_credential` to ensure that an environment variable is always found.