### PR TITLE
[MERGE WITH GITFLOW] hotfix/celery-vertical

### DIFF
--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -20,4 +20,3 @@ applications:
 - name: celery-worker
   no-route: true
   health-check-type: process
-  command: celery worker --app webservices.tasks --loglevel INFO --concurrency 2

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -12,3 +12,4 @@ applications:
   - name: celery-worker
     instances: 1
     memory: 512M
+    command: celery worker --app webservices.tasks --loglevel INFO --concurrency 2

--- a/manifest_feature.yml
+++ b/manifest_feature.yml
@@ -12,3 +12,4 @@ applications:
   - name: celery-worker
     instances: 1
     memory: 512M
+    command: celery worker --app webservices.tasks --loglevel INFO --concurrency 2

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -15,5 +15,6 @@ applications:
   - name: api
     instances: 4
   - name: celery-worker
-    instances: 4
-    memory: 1G
+    instances: 1
+    memory: 4G
+    command: celery worker --app webservices.tasks --loglevel INFO --concurrency 8

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -13,3 +13,4 @@ applications:
   - name: celery-worker
     instances: 1
     memory: 512M
+    command: celery worker --app webservices.tasks --loglevel INFO --concurrency 2


### PR DESCRIPTION
As we found out, celery can not scale horizontally without creating errors, this pr uses vertical scaling to create the same ratio of workers and memory  in production that we started out with and increases the resources to be be in balance with the other production increases. We know that we can get slow response times if celery is under resourced. 