### PR TITLE
Remove RAISE statements from triggers

### DIFF
--- a/data/sql_setup/prepare_schedule_a.sql
+++ b/data/sql_setup/prepare_schedule_a.sql
@@ -107,8 +107,6 @@ begin
             -- so keep track of this sub_id if we haven't already so we can
             -- try processing it again each night until we're able to
             -- successfully process it.
-            raise notice 'sub_id % not found, adding to secondary queue.', new.sub_id;
-
             delete from ofec_sched_a_nightly_retries where sub_id = new.sub_id;
             insert into ofec_sched_a_nightly_retries values (new.sub_id, 'insert');
         end if;
@@ -129,8 +127,6 @@ begin
             -- so keep track of this sub_id if we haven't already so we can
             -- try processing it again each night until we're able to
             -- successfully process it.
-            raise notice 'sub_id % not found, adding to secondary queue.', new.sub_id;
-
             delete from ofec_sched_a_nightly_retries where sub_id = new.sub_id;
             insert into ofec_sched_a_nightly_retries values (new.sub_id, 'update');
         end if;
@@ -175,8 +171,6 @@ begin
             -- so keep track of this sub_id if we haven't already so we can
             -- try processing it again each night until we're able to
             -- successfully process it.
-            raise notice 'sub_id % not found, adding to secondary queue.', old.sub_id;
-
             delete from ofec_sched_a_nightly_retries where sub_id = old.sub_id;
             insert into ofec_sched_a_nightly_retries values (old.sub_id, 'delete');
         end if;
@@ -197,8 +191,6 @@ begin
             -- so keep track of this sub_id if we haven't already so we can
             -- try processing it again each night until we're able to
             -- successfully process it.
-            raise notice 'sub_id % not found, adding to secondary queue.', old.sub_id;
-
             delete from ofec_sched_a_nightly_retries where sub_id = old.sub_id;
             insert into ofec_sched_a_nightly_retries values (old.sub_id, 'update');
         end if;

--- a/data/sql_setup/prepare_schedule_b.sql
+++ b/data/sql_setup/prepare_schedule_b.sql
@@ -112,8 +112,6 @@ begin
             -- so keep track of this sub_id if we haven't already so we can
             -- try processing it again each night until we're able to
             -- successfully process it.
-            raise notice 'sub_id % not found, adding to secondary queue.', new.sub_id;
-
             delete from ofec_sched_b_nightly_retries where sub_id = new.sub_id;
             insert into ofec_sched_b_nightly_retries values (new.sub_id, 'insert');
         end if;
@@ -134,8 +132,6 @@ begin
             -- so keep track of this sub_id if we haven't already so we can
             -- try processing it again each night until we're able to
             -- successfully process it.
-            raise notice 'sub_id % not found, adding to secondary queue.', new.sub_id;
-
             delete from ofec_sched_b_nightly_retries where sub_id = new.sub_id;
             insert into ofec_sched_b_nightly_retries values (new.sub_id, 'update');
         end if;
@@ -180,8 +176,6 @@ begin
             -- so keep track of this sub_id if we haven't already so we can
             -- try processing it again each night until we're able to
             -- successfully process it.
-            raise notice 'sub_id % not found, adding to secondary queue.', old.sub_id;
-
             delete from ofec_sched_b_nightly_retries where sub_id = old.sub_id;
             insert into ofec_sched_b_nightly_retries values (old.sub_id, 'delete');
         end if;
@@ -202,8 +196,6 @@ begin
             -- so keep track of this sub_id if we haven't already so we can
             -- try processing it again each night until we're able to
             -- successfully process it.
-            raise notice 'sub_id % not found, adding to secondary queue.', old.sub_id;
-
             delete from ofec_sched_b_nightly_retries where sub_id = old.sub_id;
             insert into ofec_sched_b_nightly_retries values (old.sub_id, 'update');
         end if;


### PR DESCRIPTION
This changeset removes the `RAISE` statements in the itemized schedule triggers as they appear to be causing GoldenGate to malfunction when they are called.  They are only supposed to write statements to the PostgreSQL log, not throw exceptions, but it seems that GoldenGate is treating them as exceptions anyway and halting processing.