### PR TITLE
Refresh AOs every 15m

### DIFF
--- a/data/load_advisory_opinions_schema.sql
+++ b/data/load_advisory_opinions_schema.sql
@@ -152,7 +152,8 @@ AS
         name,
         summary,
         req_date,
-        issue_date
+        issue_date,
+        pg_date
     FROM aouser.ao;
 
 --

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -1,4 +1,4 @@
-import os
+from datetime import timedelta
 
 import celery
 from celery import signals
@@ -20,7 +20,11 @@ if env.app.get('space_name', 'unknown-space').lower() != 'feature':
         'calandar': {
             'task': 'manage.refresh_calendar',
             'schedule': crontab(minute='0,15,30,45'),
-        }
+        },
+        'refresh_legal_docs': {
+            'task': 'webservices.tasks.legal_docs.refresh',
+            'schedule': timedelta(minutes=15),
+        },
     }
 
 def redis_url():
@@ -38,6 +42,7 @@ app.conf.update(
     CELERY_IMPORTS=(
         'webservices.tasks.refresh',
         'webservices.tasks.download',
+        'webservices.tasks.legal_docs',
     ),
     CELERYBEAT_SCHEDULE=schedule,
 )

--- a/webservices/tasks/legal_docs.py
+++ b/webservices/tasks/legal_docs.py
@@ -1,0 +1,30 @@
+import logging
+
+from celery_once import QueueOnce
+
+from webservices.tasks import app
+from webservices.rest import db
+from webservices.legal_docs.advisory_opinions import load_advisory_opinions
+
+logger = logging.getLogger(__name__)
+
+RECENTLY_MODIFIED_STARTING_AO = """
+    SELECT ao_no, pg_date
+    FROM aouser.aos_with_parsed_numbers
+    WHERE pg_date >= NOW() - '1 day'::INTERVAL
+    ORDER BY ao_year, ao_serial
+    LIMIT 1;
+"""
+
+@app.task(once={'graceful': True}, base=QueueOnce)
+def refresh():
+    with db.engine.connect() as conn:
+        refresh_aos(conn)
+
+def refresh_aos(conn):
+    row = conn.execute(RECENTLY_MODIFIED_STARTING_AO).first()
+    if row:
+        logger.info("AO found %s modified at %s", row["ao_no"], row["pg_date"])
+        load_advisory_opinions(row["ao_no"])
+    else:
+        logger.info("No modified AOs found")


### PR DESCRIPTION
Check every 15 minutes for AOs modified in the last day. Use the
first AO in this set as the starting AO for loading advisory opinions.
This may be run multiple times with no harm as the loading process is
idempotent.