### PR TITLE
Reduces chance of null coverage end dates in committee totals

### DIFF
--- a/data/sql_updates/totals_combined.sql
+++ b/data/sql_updates/totals_combined.sql
@@ -19,7 +19,7 @@ with last_subset as (
     order by
         cmte_id,
         cycle,
-        to_timestamp(cvg_end_dt) desc
+        to_timestamp(cvg_end_dt) desc nulls last
 ),
 last as (
     select


### PR DESCRIPTION
Places nulls last for `cvg_end_dt`.  Then when we find distinct entries, we aren't left with null coverage end dates.  Addresses https://github.com/18F/FEC/issues/4201.