### PR TITLE
Remove QuanitifiedCode badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Test Coverage](https://img.shields.io/codecov/c/github/18F/openFEC/master.svg)](https://codecov.io/github/18F/openFEC)
 [![Code Climate](https://img.shields.io/codeclimate/github/18F/openFEC.svg)](https://codeclimate.com/github/18F/openFEC)
 [![Dependencies](https://img.shields.io/gemnasium/18F/openFEC.svg)](https://gemnasium.com/18F/openFEC)
-[![Code Issues](https://www.quantifiedcode.com/api/v1/project/d3b2c96b3781466081d418fd50762726/badge.svg)](https://www.quantifiedcode.com/app/project/d3b2c96b3781466081d418fd50set%20o762726)
 
 ![Swagger validation badge](http://online.swagger.io/validator?url=https://api.open.fec.gov/swagger)
 


### PR DESCRIPTION
The QuantifiedCode service is shutting down on July 22, 2017, so this changeset removes the badge from our README.  We will be researching an alternative in the near future.