### PR TITLE
Amending the f3x total loan field because it is called other loans

### DIFF
--- a/data/crosswalks/f3x_reports.sql
+++ b/data/crosswalks/f3x_reports.sql
@@ -40,7 +40,8 @@ vs.fed_cand_cmte_contb_per as fed_cand_cmte_contb_per, --contributions to other 
 vs.indt_exp_per as indt_exp_per, --independent expenditures
 vs.coord_exp_by_pty_cmte_per as coord_exp_by_pty_cmte_per, --coordinated party expenditures
 vs.loans_made_per as loans_made_per, --loans made
-vs.oth_loan_repymts as loan_repymts_made_per, --total loan repayments made
+-- vs.oth_loan_repymts as
+vs.ttl_loan_repymts as loan_repymts_made_per, --total loan repayments made
 vs.indv_ref as indv_contb_ref_per, --individual refunds
 vs.pol_pty_cmte_contb as pol_pty_cmte_refund, --political party refunds
 vs.oth_cmte_ref as other_pol_cmte_refund, --other committee refunds

--- a/data/sql_updates/totals_pac_party.sql
+++ b/data/sql_updates/totals_pac_party.sql
@@ -31,6 +31,7 @@ select
     oft.individual_contributions,
     -- for F3x total loan repayments made are called other loans
     oft.loan_repayments_other_loans as loan_repayments_made,
+    oft.loan_repayments_other_loans,
     oft.loan_repayments_received,
     oft.loans_made,
     oft.transfers_to_other_authorized_committee, -- was not here before

--- a/data/sql_updates/totals_pac_party.sql
+++ b/data/sql_updates/totals_pac_party.sql
@@ -30,9 +30,10 @@ select
     oft.individual_unitemized_contributions,
     oft.individual_contributions,
     oft.loan_repayments_made,
+    -- for F3x total loan repayments made are called other loans
+    oft.loan_repayments_other_loans as loan_repayments_made,
     oft.loan_repayments_received,
     oft.loans_made,
-    oft.loan_repayments_other_loans, -- was not here before
     oft.transfers_to_other_authorized_committee, -- was not here before
     oft.net_operating_expenditures,
     oft.non_allocated_fed_election_activity,
@@ -59,7 +60,6 @@ select
     oft.last_report_type_full,
     oft.last_beginning_image_number,
     oft.last_cash_on_hand_end_period,
-    -- last_cash_on_hand_beginning_period,
     oft.cash_on_hand_beginning_period,
     oft.last_debts_owed_by_committee,
     oft.last_debts_owed_to_committee,

--- a/data/sql_updates/totals_pac_party.sql
+++ b/data/sql_updates/totals_pac_party.sql
@@ -29,7 +29,6 @@ select
     oft.individual_itemized_contributions,
     oft.individual_unitemized_contributions,
     oft.individual_contributions,
-    oft.loan_repayments_made,
     -- for F3x total loan repayments made are called other loans
     oft.loan_repayments_other_loans as loan_repayments_made,
     oft.loan_repayments_received,


### PR DESCRIPTION
This was the variable replacement that Jeff found. No changes needed in combined because it adds other and candidate loans. 