### PR TITLE
[MERGE with git flow] Hotfix/schedule legal refresh with cron

### DIFF
--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -23,7 +23,7 @@ if env.app.get('space_name', 'unknown-space').lower() != 'feature':
         },
         'refresh_legal_docs': {
             'task': 'webservices.tasks.legal_docs.refresh',
-            'schedule': timedelta(minutes=15),
+            'schedule': crontab(minute=[5, 20, 35, 50]),
         },
     }
 


### PR DESCRIPTION
To minimize the delay between legal documents published in Postgres and
getting indexed in Elasticsearch, use a cron based schedule. As the
Postgres refresh runs 0, 15, 30 and 45 minutes after the hour, and is
very quick, we should schedule the legal docs refresh to run 5, 20, 35
and 50 minutes after the hour.