### PR TITLE
Upgrade Celery to latest 4.0.x release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ mandrill==1.0.57
 icalendar==3.9.1
 GitPython==1.0.1
 gunicorn==19.7.1
-gevent==1.2.1
+gevent==1.2.2
 webargs==0.18.0
 slacker==0.8.6
 ujson==1.33
@@ -36,6 +36,6 @@ git+https://github.com/jmcarp/marshmallow-pagination@master
 boto3==1.4.4
 
 # Task queue
-celery==3.1.25
+celery==4.0.2
 celery-once==1.2.0
 redis==2.10.5

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,3 +1,4 @@
+import base64
 import datetime
 import mock
 import hashlib
@@ -112,7 +113,7 @@ class TestDownloadTask(ApiBaseTest):
                 url = api.url_for(view, committee_id=committee.committee_id)
             else:
                 url = api.url_for(view)
-            tasks.export_query(url, b'')
+            tasks.export_query(url, base64.b64encode(b'').decode('UTF-8'))
 
 
 class TestDownloadResource(ApiBaseTest):
@@ -124,7 +125,10 @@ class TestDownloadResource(ApiBaseTest):
         res = self.client.post_json(api.url_for(resource.DownloadView, path='candidates', office='S'))
         assert res.json == {'status': 'queued'}
         get_cached.assert_called_once_with('/v1/candidates/', b'office=S', filename=None)
-        export.delay.assert_called_once_with('/v1/candidates/', b'office=S')
+        export.delay.assert_called_once_with(
+            '/v1/candidates/',
+            base64.b64encode(b'office=S').decode('UTF-8')
+        )
 
     @mock.patch('webservices.resources.download.get_cached_file')
     @mock.patch('webservices.resources.download.download.export_query')

--- a/webservices/resources/download.py
+++ b/webservices/resources/download.py
@@ -1,3 +1,4 @@
+import base64
 import http
 
 from marshmallow import fields
@@ -37,7 +38,10 @@ class DownloadView(utils.Resource):
                 'Cannot request downloads with more than {} records'.format(MAX_RECORDS),
                 status_code=http.client.FORBIDDEN,
             )
-        download.export_query.delay(path, request.query_string)
+        download.export_query.delay(
+            path,
+            base64.b64encode(request.query_string).decode('UTF-8')
+        )
         return {'status': 'queued'}
 
 def get_cached_file(path, qs, filename=None):

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -43,7 +43,10 @@ app.conf.update(
         'webservices.tasks.legal_docs',
     ),
     beat_schedule=schedule,
-    task_acks_late=True
+    task_acks_late=True,
+    task_serializer='pickle',
+    result_serializer='pickle',
+    accept_content={'pickle'}
 )
 
 app.conf.ONCE = {

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -43,10 +43,7 @@ app.conf.update(
         'webservices.tasks.legal_docs',
     ),
     beat_schedule=schedule,
-    task_acks_late=True,
-    task_serializer='pickle',
-    result_serializer='pickle',
-    accept_content={'pickle'}
+    task_acks_late=True
 )
 
 app.conf.ONCE = {

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -36,17 +36,14 @@ def redis_url():
 
 app = celery.Celery('openfec')
 app.conf.update(
-    # will be celery_broker_url in celery 4
-    BROKER_URL=redis_url(),
-    ONCE_REDIS_URL=redis_url(),
-    ONCE_DEFAULT_TIMEOUT=60 * 60,
-    CELERY_IMPORTS=(
+    broker_url=redis_url(),
+    imports=(
         'webservices.tasks.refresh',
         'webservices.tasks.download',
         'webservices.tasks.legal_docs',
     ),
-    CELERYBEAT_SCHEDULE=schedule,
-    tasks_acks_late=True,
+    beat_schedule=schedule,
+    task_acks_late=True
 )
 
 app.conf.ONCE = {

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -1,4 +1,5 @@
 import os
+import base64
 import hashlib
 import logging
 import zipfile
@@ -180,6 +181,8 @@ def make_bundle(resource):
 
 @app.task(base=QueueOnce, once={'graceful': True})
 def export_query(path, qs):
+    qs = base64.b64decode(qs.encode('UTF-8'))
+
     try:
         logger.info('Download query: {0}'.format(qs))
         resource = call_resource(path, qs)


### PR DESCRIPTION
This changeset updates Celery to the latest current 4.0.x release.  We are doing this to keep our dependencies up to date and to help address some issues we have been having with our downloads recently.

We are following Celery's [4.0 upgrade documentation](http://docs.celeryproject.org/en/latest/whatsnew-4.0.html#upgrading-from-celery-3-1) and making adjustments as necessary to get the new version working.

**TODO**

* [x] Fix serialization to not use Python's `pickle` module and instead allow for Celery 4.0's default of `JSON`

/cc @jmcarp - I won't ask for a formal review, but you're more than welcome to chime in if you'd like! :-)