### PR TITLE
Fixes html_url property in filing end points

### DIFF
--- a/data/sql_updates/filings.sql
+++ b/data/sql_updates/filings.sql
@@ -74,10 +74,7 @@ with filings as (
             filing_history.form_tp
         ) as pdf_url,
         means_filed(begin_image_num) as means_filed,
-        case when means_filed(begin_image_num) = 'e-file' then
-          report_html_url(means_filed(begin_image_num), filing_history.cand_cmte_id::text, filing_history.file_num::text)
-          else null::text
-        end as html_url,
+        report_html_url(means_filed(begin_image_num), filing_history.cand_cmte_id::text, filing_history.file_num::text) as html_url,
         report_fec_url(begin_image_num::text, filing_history.file_num::integer) as fec_url,
         amendments.amendment_chain,
         --amendments.prev_file_num as previous_file_number,
@@ -147,10 +144,7 @@ rfai_filings as (
             'RFAI'::text
         ) as pdf_url,
         means_filed(begin_image_num) as means_filed,
-        case when means_filed(begin_image_num) = 'e-file' then
-          report_html_url(means_filed(begin_image_num), id::text, filing_history.file_num::text)
-          else null::text
-        end as html_url,
+        report_html_url(means_filed(begin_image_num), id::text, filing_history.file_num::text) as html_url,
         null::text as fec_url,
         null::numeric[] as amendment_chain,
         null::int as most_recent_file_number,

--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -150,6 +150,10 @@ class EFilings(FecFileNumberMixin, AmendmentChainMixin, CsvMixin, FecMixin, db.M
         image_number = str(self.beginning_image_number)
         return 'http://docquery.fec.gov/pdf/{0}/{1}/{1}.pdf'.format(image_number[-3:], image_number)
 
+    @property
+    def html_url(self):
+        return 'http://docquery.fec.gov/cgi-bin/forms/{0}/{1}/'.format(self.committee_id, self.file_number)
+
 
 # TODO: add index on committee id and filed_date
     #  version -- this is the efiling version and I don't think we need this - let's document in API for now, see if there are objections

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -699,6 +699,7 @@ EFilingsSchema = make_schema(
     fields={
         'beginning_image_number': ma.fields.Str(),
         'ending_image_number': ma.fields.Str(),
+        'html_url': ma.fields.Str(),
         'pdf_url': ma.fields.Str(),
         'fec_url': ma.fields.Str(),
         'csv_url': ma.fields.Str(),


### PR DESCRIPTION
Fixes #2533 

This change set fixes the html_url property in the filings end point and adds the property to the efile/filings end point.

**NOTE**

This requires running `update_schemas` in the database.