### PR TITLE
Deletion exception for bulk-downloads

### DIFF
--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -192,5 +192,6 @@ def export_query(path, qs):
 @app.task
 def clear_bucket():
     for obj in task_utils.get_bucket().objects.all():
-        if not obj.key.startswith('legal'):
+        if not obj.key.startswith('legal') or not obj.key.startswith('bulk-downloads'):
             obj.delete()
+


### PR DESCRIPTION
This is to prevent deletion of bulk-downloads directory within s3 bucket.