### PR TITLE
Hotfix/horizantal celery

### DIFF
--- a/manifests/manifest_celery_worker_prod.yml
+++ b/manifests/manifest_celery_worker_prod.yml
@@ -4,9 +4,9 @@ env:
   NEW_RELIC_APP_NAME: fec | celery worker | prod
 applications:
   - name: celery-worker
-    instances: 1
-    memory: 4G
+    instances: 4
+    memory: 1G
     disk_quota: 2G
     no-route: true
     health-check-type: process
-    command: celery worker --app webservices.tasks --loglevel INFO --concurrency 8
+    command: celery worker --app webservices.tasks --loglevel INFO --concurrency 2


### PR DESCRIPTION
Tested multiple instances on staging with the download tester script and no errors. this gives us 4 G of memory and 8G of disk across 4 instances in production. 