### PR TITLE
Hotfix/disable retry itemized

### DIFF
--- a/webservices/tasks/refresh.py
+++ b/webservices/tasks/refresh.py
@@ -17,7 +17,8 @@ def refresh():
     with mail.CaptureLogs(manage.logger, buffer):
         try:
             manage.update_aggregates()
-            manage.retry_itemized()
+            # this process is having issues, we will fix in a following PR
+            # manage.retry_itemized()
             manage.refresh_itemized()
             manage.update_itemized('e')
             manage.update_schemas()


### PR DESCRIPTION
We killed this process and we don't want it to kick off again as part of nightly updates.