### PR TITLE
[WIP] Remove two year cycle restriction on itemized schedule API endpoints

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -56,22 +56,22 @@ class TestItemized(ApiBaseTest):
         )
     #This is the only test that the years will have to be bumped when in a new cycle
     #maybe refactor to use some logic based on current year?
-    def test_two_year_transaction_period_default_supplied_automatically(self):
-        receipts = [
-            factories.ScheduleAFactory(
-                report_year=2016,
-                contribution_receipt_date=datetime.date(2016, 1, 1),
-                two_year_transaction_period=2016
-            ),
-            factories.ScheduleAFactory(
-                report_year=2018,
-                contribution_receipt_date=datetime.date(2018, 1, 1),
-                two_year_transaction_period=2018
-            ),
-        ]
+    # def test_two_year_transaction_period_default_supplied_automatically(self):
+    #     receipts = [
+    #         factories.ScheduleAFactory(
+    #             report_year=2016,
+    #             contribution_receipt_date=datetime.date(2016, 1, 1),
+    #             two_year_transaction_period=2016
+    #         ),
+    #         factories.ScheduleAFactory(
+    #             report_year=2018,
+    #             contribution_receipt_date=datetime.date(2018, 1, 1),
+    #             two_year_transaction_period=2018
+    #         ),
+    #     ]
 
-        response = self._response(api.url_for(ScheduleAView))
-        self.assertEqual(len(response['results']), 1)
+    #     response = self._response(api.url_for(ScheduleAView))
+    #     self.assertEqual(len(response['results']), 1)
 
     def test_two_year_transaction_period_limits_results_per_cycle(self):
         receipts = [

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -462,9 +462,9 @@ schedule_a = {
         description='Filters individual or committee contributions based on line number'
     ),
     'two_year_transaction_period': fields.Int(
-        description=docs.TWO_YEAR_TRANSACTION_PERIOD,
-        required=True,
-        missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
+        description=docs.TWO_YEAR_TRANSACTION_PERIOD
+        #required=True,
+        #missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
     ),
 }
 
@@ -532,9 +532,9 @@ schedule_b = {
     'last_disbursement_date': fields.Date(missing=None, description='When sorting by `disbursement_date`, this is populated with the `disbursement_date` of the last result. However, you will need to pass the index of that last result to `last_index` to get the next page.'),
     'last_disbursement_amount': fields.Float(missing=None, description='When sorting by `disbursement_amount`, this is populated with the `disbursement_amount` of the last result.  However, you will need to pass the index of that last result to `last_index` to get the next page.'),
     'two_year_transaction_period': fields.Int(
-        description=docs.TWO_YEAR_TRANSACTION_PERIOD,
-        required=True,
-        missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
+        description=docs.TWO_YEAR_TRANSACTION_PERIOD
+        #required=True,
+        #missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
     ),
 }
 


### PR DESCRIPTION
**WIP:  PLEASE DO NOT MERGE**

Part of #2423

This changeset removes the two year cycle restriction from the itemized schedule A and B API endpoints to enable searching and querying across multiple cycles.  Very early performance tests indicate that as long as the indexes are setup properly this is reasonably performant, even with large cross sections of data.

**NOTE**
* We still need to provide some type of restriction; simply asking for the whole data set results in a long-running query
* It might be possible to setup a restriction just based on min/max dates alone; that is worth exploring
* Alternatively, we could either allow multiple values for `two_year_transaction_period` or change that parameter to work on groupings of 4, 6, or 8 cycles

Again, this code only drops the restriction in the API for the moment and is only meant for testing and further development.  Work should be actively coordinated with the front end development in the web app to ensure consistency and proper UI/UX support.

/cc @LindsayYoung, @jontours, @anthonygarvan, @vrajmohan and anyone else interested in helping build this out from the API side:  please feel free to hop into this PR and carry it forward!

/cc @xtine and @noahmanger:  FYI to help coordinate with front end development.