### PR TITLE
Feature/parse boolean operators

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ elasticsearch==2.4.0
 elasticsearch-dsl==2.1.0
 bandit==1.4.0
 git+https://github.com/18F/slate.git
-nltk==3.2.4
 
 # Marshalling
 flask-apispec==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ elasticsearch==2.4.0
 elasticsearch-dsl==2.1.0
 bandit==1.4.0
 git+https://github.com/18F/slate.git
+nltk==3.2.4
 
 # Marshalling
 flask-apispec==0.2.0

--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -134,9 +134,7 @@ class SearchTest(unittest.TestCase):
     def test_invalid_search(self):
         response = self.app.get('/v1/legal/search/' +
                                 '?q=president%20AND%20OR&type=advisory_opinions')
-        assert response.status_code == 200
-        result = json.loads(codecs.decode(response.data))
-        assert result['status_code'] == 400
+        assert response.status_code == 400
 
     @patch.object(es, 'search')
     def test_query_dsl(self, es_search):

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -98,7 +98,7 @@ class UniversalSearch(utils.Resource):
                 formatted_hits, count = execute_query(query)
             except RequestError as e:
                 logger.info(e.args)
-                return ApiError("Could not parse query", 400)
+                raise ApiError("Could not parse query", 400)
             results[type_] = formatted_hits
             results['total_%s' % type_] = count
             total_count += count

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -90,8 +90,7 @@ class UniversalSearch(utils.Resource):
 
         results = {}
         total_count = 0
-        print(q)
-        print(kwargs)
+ 
         for type_ in doc_types:
             query = query_builders.get(type_)(q, type_, from_hit, hits_returned, **kwargs)
             try:
@@ -274,21 +273,21 @@ def execute_query(query):
     es_results = query.execute()
     formatted_hits = []
     for hit in es_results:
-            formatted_hit = hit.to_dict()
-            formatted_hit['highlights'] = []
-            formatted_hit['document_highlights'] = {}
-            formatted_hits.append(formatted_hit)
+        formatted_hit = hit.to_dict()
+        formatted_hit['highlights'] = []
+        formatted_hit['document_highlights'] = {}
+        formatted_hits.append(formatted_hit)
 
-            if 'highlight' in hit.meta:
-                for key in hit.meta.highlight:
-                    formatted_hit['highlights'].extend(hit.meta.highlight[key])
+        if 'highlight' in hit.meta:
+            for key in hit.meta.highlight:
+                formatted_hit['highlights'].extend(hit.meta.highlight[key])
 
-            if 'inner_hits' in hit.meta:
-                for inner_hit in hit.meta.inner_hits['documents'].hits:
-                    if 'highlight' in inner_hit.meta and 'nested' in inner_hit.meta:
-                        offset = inner_hit.meta['nested']['offset']
-                        highlights = inner_hit.meta.highlight.to_dict().values()
-                        formatted_hit['document_highlights'][offset] = [
-                            hl for hl_list in highlights for hl in hl_list]
+        if 'inner_hits' in hit.meta:
+            for inner_hit in hit.meta.inner_hits['documents'].hits:
+                if 'highlight' in inner_hit.meta and 'nested' in inner_hit.meta:
+                    offset = inner_hit.meta['nested']['offset']
+                    highlights = inner_hit.meta.highlight.to_dict().values()
+                    formatted_hit['document_highlights'][offset] = [
+                        hl for hl_list in highlights for hl in hl_list]
 
     return formatted_hits, es_results.hits.total

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -8,7 +8,15 @@ from webservices import args
 from webservices import utils
 from webservices.utils import use_kwargs
 from webservices.legal_docs import DOCS_SEARCH
+from elasticsearch import RequestError
+from webservices.exceptions import ApiError
+import logging
+
+import nltk
+from nltk.tokenize import wordpunct_tokenize
+
 es = utils.get_elasticsearch_connection()
+logger = logging.getLogger(__name__)
 
 INNER_HITS = {
     "_source": False,
@@ -66,6 +74,7 @@ class GetLegalDocument(utils.Resource):
             return abort(404)
 
 phrase_regex = re.compile('"(?P<phrase>[^"]*)"')
+
 def parse_query_string(query):
     """Parse phrases from a query string for exact matches e.g. "independent agency"."""
 
@@ -102,6 +111,62 @@ def parse_query_string(query):
     terms, phrases = _parse_query_string(query)
     return dict(terms=terms, phrases=phrases)
 
+def parse_boolean_query(q):
+    """
+    This is a shift-reduce parser for the keywork input. The operator precedence
+    follows SQL: first NOT, then AND, then OR.
+
+    Here is the grammar:
+    """
+    parser_regex = re.compile('(?P<operator>(?:AND|OR|NOT|\(|\)))|(?P<phrase>(?:"[^"]*"))|(?P<term>[^\s\(\)]+)')
+    parsed = re.findall(parser_regex, q)
+    tokens = []
+
+    RULES = ["CLAUSE -> TERM | PHRASE | AND_CLAUSE | OR_CLAUSE | NOT_CLAUSE",
+            "CLAUSE -> OPEN_PAREN CLAUSE CLOSE_PAREN",
+            "OR_CLAUSE -> CLAUSE CLAUSE | CLAUSE OR CLAUSE",
+            "AND_CLAUSE -> CLAUSE AND CLAUSE",
+            "NOT_CLAUSE -> NOT CLAUSE",
+            "OPEN_PAREN -> '('",
+            "CLOSE_PAREN -> ')'",
+            "AND -> 'AND'",
+            "OR -> 'OR'",
+            "NOT -> 'NOT'"]
+
+    for result in parsed:
+        if result[0]:  # operator
+            tokens.append(result[0])
+        if result[1]:  # phrase
+            tokens.append(result[1])
+            RULES.append("PHRASE -> '%s'" % result[1])
+        if result[2]:  # term
+            tokens.append(result[2])
+            RULES.append("TERM -> '%s'" % result[2])
+
+    print(tokens)
+    parse_tree = list(nltk.ShiftReduceParser(
+        nltk.CFG.fromstring(RULES), trace=2)
+        .parse(tokens))
+
+    print(parse_tree)
+
+    return parse_tree
+
+def build_query_from_parse_tree(clause):
+    print('*' * 50)
+    print(clause)
+    print(clause.label())
+    print(clause[0])
+    if clause.label() == 'CLAUSE':
+        return build_query_from_parse_tree(clause[0])
+    if clause.label() == 'OR_CLAUSE':
+        return Q('bool', must=[build_query_from_parse_tree(clause[0]), build_query_from_parse_tree(clause[-1])],
+                    operator='OR')
+    if clause.label() == 'TERM':
+        return Q('match', _all=clause[0])
+    if clause.label() == 'PHRASE':
+        return Q('match_phrase', _all=clause[0].strip('"'))
+
 
 class UniversalSearch(utils.Resource):
     @use_kwargs(args.query)
@@ -126,8 +191,12 @@ class UniversalSearch(utils.Resource):
         results = {}
         total_count = 0
         for type_ in doc_types:
-            query = query_builders.get(type_)(q, terms, phrases, type_, from_hit, hits_returned, **kwargs)
-            formatted_hits, count = execute_query(query)
+            query = query_builders.get(type_)(q, type_, from_hit, hits_returned, **kwargs)
+            try:
+                formatted_hits, count = execute_query(query)
+            except RequestError as e:
+                logger.info(e.args)
+                return ApiError("Could not parse query", 400)
             results[type_] = formatted_hits
             results['total_%s' % type_] = count
             total_count += count
@@ -135,16 +204,8 @@ class UniversalSearch(utils.Resource):
         results['total_all'] = total_count
         return results
 
-def generic_query_builder(q, terms, phrases, type_, from_hit, hits_returned, **kwargs):
-    must_query = [Q('term', _type=type_)]
-
-    if len(terms):
-        term_query = Q('match', _all=' '.join(terms))
-        must_query.append(term_query)
-
-    if len(phrases):
-        phrase_queries = [Q('match_phrase', _all=phrase) for phrase in phrases]
-        must_query.extend(phrase_queries)
+def generic_query_builder(q, type_, from_hit, hits_returned, **kwargs):
+    must_query = [Q('term', _type=type_), Q('query_string', query=q, lenient=True)]
 
     query = Search().using(es) \
         .query(Q('bool', must=must_query)) \
@@ -157,16 +218,8 @@ def generic_query_builder(q, terms, phrases, type_, from_hit, hits_returned, **k
 
     return query
 
-def mur_query_builder(q, terms, phrases, type_, from_hit, hits_returned, **kwargs):
-    must_query = [Q('term', _type=type_)]
-
-    if len(terms):
-        term_query = Q('match', _all=' '.join(terms))
-        must_query.append(term_query)
-
-    if len(phrases):
-        phrase_queries = [Q('match_phrase', _all=phrase) for phrase in phrases]
-        must_query.extend(phrase_queries)
+def mur_query_builder(q, type_, from_hit, hits_returned, **kwargs):
+    must_query = [Q('term', _type=type_), Q('query_string', query=q, fields=['documents.text'], lenient=True)]
 
     query = Search().using(es) \
         .query(Q('bool', must=must_query)) \
@@ -177,11 +230,16 @@ def mur_query_builder(q, terms, phrases, type_, from_hit, hits_returned, **kwarg
         .index(DOCS_SEARCH) \
         .sort("sort1", "sort2")
 
-    return apply_mur_specific_query_params(query, terms, phrases, **kwargs)
+    return apply_mur_specific_query_params(query, **kwargs)
 
-def ao_query_builder(q, terms, phrases, type_, from_hit, hits_returned, **kwargs):
-    must_query = [Q('term', _type=type_)]
+def ao_query_builder(q, type_, from_hit, hits_returned, **kwargs):
+    must_query = [Q('term', _type=type_), Q('query_string', query=q, fields=['no', 'name', 'summary'], lenient=True)]
+    # parses = parse_boolean_query(q)
+    # boolean_query = build_query_from_parse_tree(parses[0])
+    # print(boolean_query)
+    # must_query.append(boolean_query)
 
+    """
     should_query = []
     if len(terms):
         term_query = Q('multi_match', query=' '.join(terms), fields=['no', 'name', 'summary'])
@@ -193,9 +251,9 @@ def ao_query_builder(q, terms, phrases, type_, from_hit, hits_returned, **kwargs
         should_query.extend(phrase_queries)
 
     should_query.append(get_ao_document_query(terms, phrases, **kwargs))
-
+    """
     query = Search().using(es) \
-        .query(Q('bool', must=must_query, should=should_query, minimum_should_match=1)) \
+        .query(Q('bool', must=must_query)) \
         .highlight('text', 'name', 'no', 'summary', 'documents.text', 'documents.description') \
         .highlight_options(require_field_match=False) \
         .source(exclude=['text', 'documents.text', 'sort1', 'sort2']) \
@@ -203,9 +261,9 @@ def ao_query_builder(q, terms, phrases, type_, from_hit, hits_returned, **kwargs
         .index(DOCS_SEARCH) \
         .sort("sort1", "sort2")
 
-    return apply_ao_specific_query_params(query, terms, phrases, **kwargs)
+    return apply_ao_specific_query_params(query, **kwargs)
 
-def apply_mur_specific_query_params(query, terms, phrases, **kwargs):
+def apply_mur_specific_query_params(query, **kwargs):
     if kwargs.get('mur_no'):
         query = query.query('terms', no=kwargs.get('mur_no'))
     if kwargs.get('mur_respondents'):
@@ -217,9 +275,6 @@ def apply_mur_specific_query_params(query, terms, phrases, **kwargs):
 
     if kwargs.get('mur_document_category'):
         combined_query = [Q('terms', documents__category=kwargs.get('mur_document_category'))]
-        if terms:
-            combined_query.append(Q('match', documents__text=' '.join(terms)))
-        combined_query.extend([Q('match_phrase', documents__text=phrase) for phrase in phrases])
         query = query.query("nested", path="documents", inner_hits=INNER_HITS, query=Q('bool', must=combined_query))
 
     return query
@@ -245,7 +300,7 @@ def get_ao_document_query(terms, phrases, **kwargs):
 
     return Q("nested", path="documents", inner_hits=INNER_HITS, query=Q('bool', must=combined_query))
 
-def apply_ao_specific_query_params(query, terms, phrases, **kwargs):
+def apply_ao_specific_query_params(query, **kwargs):
     must_clauses = []
     if kwargs.get('ao_no'):
         must_clauses.append(Q('terms', no=kwargs.get('ao_no')))
@@ -328,24 +383,23 @@ def apply_ao_specific_query_params(query, terms, phrases, **kwargs):
 
 def execute_query(query):
     es_results = query.execute()
-
     formatted_hits = []
     for hit in es_results:
-        formatted_hit = hit.to_dict()
-        formatted_hit['highlights'] = []
-        formatted_hit['document_highlights'] = {}
-        formatted_hits.append(formatted_hit)
+            formatted_hit = hit.to_dict()
+            formatted_hit['highlights'] = []
+            formatted_hit['document_highlights'] = {}
+            formatted_hits.append(formatted_hit)
 
-        if 'highlight' in hit.meta:
-            for key in hit.meta.highlight:
-                formatted_hit['highlights'].extend(hit.meta.highlight[key])
+            if 'highlight' in hit.meta:
+                for key in hit.meta.highlight:
+                    formatted_hit['highlights'].extend(hit.meta.highlight[key])
 
-        if 'inner_hits' in hit.meta:
-            for inner_hit in hit.meta.inner_hits['documents'].hits:
-                if 'highlight' in inner_hit.meta and 'nested' in inner_hit.meta:
-                    offset = inner_hit.meta['nested']['offset']
-                    highlights = inner_hit.meta.highlight.to_dict().values()
-                    formatted_hit['document_highlights'][offset] = [
-                        hl for hl_list in highlights for hl in hl_list]
+            if 'inner_hits' in hit.meta:
+                for inner_hit in hit.meta.inner_hits['documents'].hits:
+                    if 'highlight' in inner_hit.meta and 'nested' in inner_hit.meta:
+                        offset = inner_hit.meta['nested']['offset']
+                        highlights = inner_hit.meta.highlight.to_dict().values()
+                        formatted_hit['document_highlights'][offset] = [
+                            hl for hl_list in highlights for hl in hl_list]
 
     return formatted_hits, es_results.hits.total


### PR DESCRIPTION
Replaces previous parse logic for terms & phrases with the built in query_string, which supports boolean operations and proximity search.

The `q` parameter for all searches is not parsed as a `query_string` instead of a `match`. Documentation for `query_string` is [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html). Basically, it supports AND, OR, NOT, parenthesis, quotation marks for phrase match, proximity search, and wildcards. 

If the query is not parsable (eg., `president AND OR`), the query will return a json object with HTTP status code 400 and message "Could not parse query". This HTTP status will need to be handled by consumers of the API.