### PR TITLE
Force using Trusty and PostgreSQL 9.6 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
+dist: trusty
 language: python
 sudo: false
 cache: pip
 python:
   - "3.5"
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"
 env:
   global:
     - secure: fZSgHvzAttJcq5GYEwp/jo8/hcRs0hW169dTG4VC6vW29sPFjc2R6NuXVzXxGzxkWN16KvUNU+feMiMIse7c2zQIceTmhJh7cz19v+xmmwgqJgv0ln8+7+1rGB6FIblS9C70b2ggKjZ5DYMD4DxCrtQkWkVzQDncdADb4vg0ZA4=

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,15 +3,14 @@
 git+https://github.com/18F/rdbms-subsetter
 
 # Testing
-mock>=1.3.0
-pytest>=3.0.7
-pytest-cov>=2.3.1
-factory-boy>=2.5.2
-faker>=0.7.5
-nplusone>=0.7.3
-webtest>=2.0.2
-pdbpp>=0.8.3
-pygments>=2.2.0
+pytest==3.1.3
+pytest-cov==2.5.1
+factory_boy==2.8.1
+faker==0.7.18
+nplusone==0.8.0
+webtest==2.0.27
+pdbpp==0.9.1
+pygments==2.2.0
 
 
 #efiling


### PR DESCRIPTION
We are running into some issues with our tests failing in Travis and currently all signs point to something breaking down in the Travis build.  This changeset forces the build environment to use Trusty (which Travis is in the process of rolling out to all builds regardless), which in turn also supports using PostgreSQL 9.6 (which this project is running on).  We will continue making adjustments as necessary to see what is causing the tests to fail and what might be needed to get them to work.

This PR also pins all of our development dependencies to specific versions.  Please see issue #2573 for more information.