### PR TITLE
Fix tests with references to the unittest.mock module

### DIFF
--- a/tests/test_advisory_opinions.py
+++ b/tests/test_advisory_opinions.py
@@ -1,6 +1,6 @@
 import datetime
 import subprocess
-from mock import patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_current_murs.py
+++ b/tests/test_current_murs.py
@@ -1,6 +1,6 @@
 import re
 import subprocess
-from mock import patch
+from unittest.mock import patch
 from datetime import datetime
 from decimal import Decimal
 

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,7 +1,7 @@
 import base64
 import datetime
-import mock
 import hashlib
+import unittest.mock as mock
 
 import pytest
 from botocore.exceptions import ClientError

--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -2,8 +2,8 @@ from webservices import rest
 import json
 import codecs
 import unittest
-import mock
-from mock import patch
+import unittest.mock as mock
+from unittest.mock import patch
 
 from webservices.resources.legal import es, parse_query_string
 

--- a/tests/test_load_legal_docs.py
+++ b/tests/test_load_legal_docs.py
@@ -1,5 +1,5 @@
 import unittest
-from mock import patch
+from unittest.mock import patch
 from webservices.legal_docs import (
     delete_murs_from_es,
     delete_murs_from_s3,

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,7 +1,7 @@
 import io
 import logging
+import unittest.mock as mock
 
-import mock
 import cfenv
 import pytest
 import mandrill

--- a/tests/test_map_citations_murs.py
+++ b/tests/test_map_citations_murs.py
@@ -1,5 +1,5 @@
-import mock
 import unittest
+import unittest.mock as mock
 import urllib
 
 from webservices.legal_docs import load_legal_docs, reclassify_statutory_citation


### PR DESCRIPTION
This changeset addresses an issue that was uncovered shortly after the updates to the development requirements.  I had not cleaned out my virtual environment entirely and therefore still had the existing backport `mock` library in it, which prevented me from seeing the import errors with the change to using the internal `mock` library.  The library needs to now reference `unittest.mock` instead.

h/t to @vrajmohan for catching this, thank you!  It is also still unclear why the Travis builds have not caught this issue either.