### PR TITLE
Remove nightly retry processing of itemized schedule A and B data

### DIFF
--- a/data/functions/itemized.sql
+++ b/data/functions/itemized.sql
@@ -182,24 +182,6 @@ BEGIN
 END
 $$ LANGUAGE plpgsql;
 
--- Provides the functions that allow us to retry processing itemized schedule
--- records that failed to process correctly upon initial record changes to the
--- underlying disclosure.nml_sched_a and disclosure.nml_sched_b tables.
-
--- If the record is successfully processed, it will be added to the main
--- nightly refresh queues to be taken care of with all of the other records
--- that were originally processed successfully.  If it is not, meaning it still
--- couldn't be found in the public.fec_fitem_sched_<x>_vw views, the sub_id
--- will remain in the ofec_sched_<x>_nightly_retries table until it is.
-
--- Convenience function that takes care of all of the processing at once.
-create or replace function retry_processing_itemized_records() returns void as $$
-begin
-    perform retry_processing_schedule_a_records(:START_YEAR_AGGREGATE);
-    perform retry_processing_schedule_b_records(:START_YEAR_AGGREGATE);
-end
-$$ language plpgsql;
-
 CREATE OR REPLACE FUNCTION rename_table_cascade(table_name TEXT) RETURNS VOID AS $$
 DECLARE
     child_tmp_table_name TEXT;
@@ -235,3 +217,7 @@ BEGIN
     END LOOP;
 END
 $$ LANGUAGE plpgsql;
+
+
+-- Drop old retry itemized processing function if it still exists.
+DROP FUNCTION IF EXISTS retry_processing_itemized_records();

--- a/data/sql_setup/prepare_schedule_a.sql
+++ b/data/sql_setup/prepare_schedule_a.sql
@@ -1,12 +1,7 @@
--- Create table to hold sub_ids of records that fail during the nightly
--- processing so that they can be tried at a later time.
--- The "action" column denotes what should happen with the record:
---    insert, update, or delete
+-- Drop the old nightly refresh retry table and function if they still exist.
 drop table if exists ofec_sched_a_nightly_retries;
-create table ofec_sched_a_nightly_retries (
-    sub_id numeric(19,0) not null primary key,
-    action varchar(6) not null
-);
+drop function if exists retry_processing_schedule_a_records(start_year integer);
+
 
 -- Create queue tables to hold changes to Schedule A
 drop table if exists ofec_sched_a_queue_new;
@@ -23,54 +18,6 @@ create index on ofec_sched_a_queue_new (timestamp);
 create index on ofec_sched_a_queue_old (timestamp);
 create index on ofec_sched_a_queue_new (two_year_transaction_period);
 create index on ofec_sched_a_queue_old (two_year_transaction_period);
-
-
--- Support for processing of schedule A itemized records that need to be
--- retried.
-create or replace function retry_processing_schedule_a_records(start_year integer) returns void as $$
-declare
-    timestamp timestamp = current_timestamp;
-    two_year_transaction_period smallint;
-    view_row fec_fitem_sched_a_vw%ROWTYPE;
-    schedule_a_record record;
-begin
-    for schedule_a_record in select * from ofec_sched_a_nightly_retries loop
-        select into view_row * from fec_fitem_sched_a_vw where sub_id = schedule_a_record.sub_id;
-
-        if FOUND then
-            two_year_transaction_period = cast(get_cycle(view_row.rpt_yr) as smallint);
-
-            if two_year_transaction_period >= start_year then
-                -- Determine which queue(s) the found record should go into.
-                case schedule_a_record.action
-                    when 'insert' then
-                        delete from ofec_sched_a_queue_new where sub_id = view_row.sub_id;
-                        insert into ofec_sched_a_queue_new values (view_row.*, timestamp, two_year_transaction_period);
-
-                        delete from ofec_sched_a_nightly_retries where sub_id = schedule_a_record.sub_id;
-                    when 'delete' then
-                        delete from ofec_sched_a_queue_old where sub_id = view_row.sub_id;
-                        insert into ofec_sched_a_queue_old values (view_row.*, timestamp, two_year_transaction_period);
-
-                        delete from ofec_sched_a_nightly_retries where sub_id = schedule_a_record.sub_id;
-                    when 'update' then
-                        delete from ofec_sched_a_queue_new where sub_id = view_row.sub_id;
-                        delete from ofec_sched_a_queue_old where sub_id = view_row.sub_id;
-                        insert into ofec_sched_a_queue_new values (view_row.*, timestamp, two_year_transaction_period);
-                        insert into ofec_sched_a_queue_old values (view_row.*, timestamp, two_year_transaction_period);
-
-                        delete from ofec_sched_a_nightly_retries where sub_id = schedule_a_record.sub_id;
-                    else
-                        raise warning 'Invalid action supplied: %', schedule_a_record.action;
-                end case;
-            end if;
-        else
-            raise notice 'sub_id % still not found', schedule_a_record.sub_id;
-        end if;
-    end loop;
-end
-$$ language plpgsql;
-
 
 -- Create trigger to maintain Schedule A queues for inserts and updates
 -- These happen after a row is inserted/updated so that we can leverage pulling
@@ -101,13 +48,6 @@ begin
                 delete from ofec_sched_a_queue_new where sub_id = view_row.sub_id;
                 insert into ofec_sched_a_queue_new values (view_row.*, timestamp, two_year_transaction_period);
             end if;
-        else
-            -- We weren't able to successfully retrieve a row from the view,
-            -- so keep track of this sub_id if we haven't already so we can
-            -- try processing it again each night until we're able to
-            -- successfully process it.
-            delete from ofec_sched_a_nightly_retries where sub_id = new.sub_id;
-            insert into ofec_sched_a_nightly_retries values (new.sub_id, 'insert');
         end if;
 
         return new;
@@ -121,13 +61,6 @@ begin
                 delete from ofec_sched_a_queue_new where sub_id = view_row.sub_id;
                 insert into ofec_sched_a_queue_new values (view_row.*, timestamp, two_year_transaction_period);
             end if;
-        else
-            -- We weren't able to successfully retrieve a row from the view,
-            -- so keep track of this sub_id if we haven't already so we can
-            -- try processing it again each night until we're able to
-            -- successfully process it.
-            delete from ofec_sched_a_nightly_retries where sub_id = new.sub_id;
-            insert into ofec_sched_a_nightly_retries values (new.sub_id, 'update');
         end if;
 
         return new;
@@ -165,13 +98,6 @@ begin
                 delete from ofec_sched_a_queue_old where sub_id = view_row.sub_id;
                 insert into ofec_sched_a_queue_old values (view_row.*, timestamp, two_year_transaction_period);
             end if;
-        else
-            -- We weren't able to successfully retrieve a row from the view,
-            -- so keep track of this sub_id if we haven't already so we can
-            -- try processing it again each night until we're able to
-            -- successfully process it.
-            delete from ofec_sched_a_nightly_retries where sub_id = old.sub_id;
-            insert into ofec_sched_a_nightly_retries values (old.sub_id, 'delete');
         end if;
 
         return old;
@@ -185,13 +111,6 @@ begin
                 delete from ofec_sched_a_queue_old where sub_id = view_row.sub_id;
                 insert into ofec_sched_a_queue_old values (view_row.*, timestamp, two_year_transaction_period);
             end if;
-        else
-            -- We weren't able to successfully retrieve a row from the view,
-            -- so keep track of this sub_id if we haven't already so we can
-            -- try processing it again each night until we're able to
-            -- successfully process it.
-            delete from ofec_sched_a_nightly_retries where sub_id = old.sub_id;
-            insert into ofec_sched_a_nightly_retries values (old.sub_id, 'update');
         end if;
 
         -- We have to return new here because this record is intended to change

--- a/manage.py
+++ b/manage.py
@@ -323,21 +323,6 @@ def update_aggregates():
         logger.info('Finished updating Schedule E and support aggregates.')
 
 @manager.command
-def retry_itemized():
-    """This is run nightly to retry processing itemized schedule A and B data
-    that was not able to be processed normally.
-    """
-    logger.info('Retrying itemized schedule processing...')
-
-    with db.engine.begin() as connection:
-        connection.execute(
-            sa.text('select retry_processing_itemized_records()').execution_options(
-                autocommit=True
-            )
-        )
-        logger.info('Finished retrying itemized schedule processing.')
-
-@manager.command
 def refresh_itemized():
     """These are run nightly to refresh the itemized schedule A and B data."""
 

--- a/webservices/tasks/refresh.py
+++ b/webservices/tasks/refresh.py
@@ -17,8 +17,6 @@ def refresh():
     with mail.CaptureLogs(manage.logger, buffer):
         try:
             manage.update_aggregates()
-            # this process is having issues, we will fix in a following PR
-            # manage.retry_itemized()
             manage.refresh_itemized()
             manage.update_itemized('e')
             manage.update_schemas()


### PR DESCRIPTION
Part of #2585

This changeset removes the nightly retry processing we had initially setup for the itemized schedule A and B data.  We have found this to be more cumbersome to get working and maintain than it is worth and it has resulted in several nightly updates failing due to deadlocked processes and record conflicts.

We will attempt to improve our processing and updating of itemized schedule A and B data through our continued refactoring that we had started previously to make the partitioning code more efficient and easier to maintain.