### PR TITLE
Add support for multi-column GIN indexes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
     - secure: fOtfMxFpv3MDrH3lzZccqMPTXunH9wqMBLNRgkI5dCGX5gjY2fxGwzfj9wtiXiqYifo/c9DFqNxS37dkFihGShGrE0sfCv5h+kiDRc8R50bH8vK/jE+if8ID8TUH71w7bjWQco7miRsy4MdT/0iFWjeSwwG31Egn5Z/dCxCcGPM= # prod password
 before_script:
   - psql -c 'create database "cfdm_unit_test";' -U postgres
-  - psql -U postgres -c "create extension btree_gin;"
   - travis_retry pip install -U pip setuptools wheel
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - secure: fOtfMxFpv3MDrH3lzZccqMPTXunH9wqMBLNRgkI5dCGX5gjY2fxGwzfj9wtiXiqYifo/c9DFqNxS37dkFihGShGrE0sfCv5h+kiDRc8R50bH8vK/jE+if8ID8TUH71w7bjWQco7miRsy4MdT/0iFWjeSwwG31Egn5Z/dCxCcGPM= # prod password
 before_script:
   - psql -c 'create database "cfdm_unit_test";' -U postgres
+  - psql -U postgres -c "create extension btree_gin;"
   - travis_retry pip install -U pip setuptools wheel
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install -r requirements-dev.txt

--- a/data/functions/extensions.sql
+++ b/data/functions/extensions.sql
@@ -1,0 +1,2 @@
+-- Enables extra extensions in PostgreSQL not already enabled by default.
+CREATE EXTENSION IF NOT EXISTS btree_gin;

--- a/data/functions/itemized.sql
+++ b/data/functions/itemized.sql
@@ -94,8 +94,8 @@ BEGIN
         EXECUTE format('CREATE INDEX idx_%s_two_year_transaction_period_dt%s ON %I (two_year_transaction_period, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
         EXECUTE format('CREATE INDEX idx_%s_contributor_name_text_contb_receipt_dt%s ON %I USING GIN (contributor_name_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_contributor_employer_text_contb_receipt_dt%s ON %I USING GIN (contributor_name_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_contributor_occupation_text_contb_receipt_dt%s ON %I USING GIN (contributor_name_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_employer_text_contb_receipt_dt%s ON %I USING GIN (contributor_employer_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_occupation_text_contb_receipt_dt%s ON %I USING GIN (contributor_occupation_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
           -- for sorting by transaction amount
         EXECUTE format('CREATE INDEX idx_%s_image_num_amt%s ON %I (image_num, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
@@ -110,8 +110,8 @@ BEGIN
         EXECUTE format('CREATE INDEX idx_%s_two_year_transaction_period_amt%s ON %I (two_year_transaction_period, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
         EXECUTE format('CREATE INDEX idx_%s_contributor_name_text_contb_receipt_amt%s ON %I USING GIN (contributor_name_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_contributor_employer_text_contb_receipt_amt%s ON %I USING GIN (contributor_name_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_contributor_occupation_text_contb_receipt_amt%s ON %I USING GIN (contributor_name_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_employer_text_contb_receipt_amt%s ON %I USING GIN (contributor_employer_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_occupation_text_contb_receipt_amt%s ON %I USING GIN (contributor_occupation_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
         -- Other indexes
         EXECUTE format('CREATE UNIQUE INDEX idx_%s_sub_id%s ON %I (sub_id)', child_table_root, index_name_suffix, child_table_name);

--- a/data/functions/itemized.sql
+++ b/data/functions/itemized.sql
@@ -75,6 +75,10 @@ BEGIN
         END IF;
 
         -- Create indexes.
+        -- Note:  The multi-column GIN indexes require the btree_gin extension
+        --        https://www.postgresql.org/docs/current/static/btree-gin.html
+        --        This is installed and enabled in RDS by default.
+
         -- Indexes used for search
            -- for sorting by receipt date
         EXECUTE format('CREATE INDEX idx_%s_image_num_dt%s ON %I (image_num, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
@@ -88,6 +92,10 @@ BEGIN
         EXECUTE format('CREATE INDEX idx_%s_sub_id_line_num_dt%s ON %I (line_num, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX idx_%s_two_year_transaction_period_dt%s ON %I (two_year_transaction_period, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
+        EXECUTE format('CREATE INDEX idx_%s_contributor_name_text%s ON %I USING GIN (contributor_name_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_employer_text%s ON %I USING GIN (contributor_name_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_occupation_text%s ON %I USING GIN (contributor_name_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+
           -- for sorting by transaction amount
         EXECUTE format('CREATE INDEX idx_%s_image_num_amt%s ON %I (image_num, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX idx_%s_contbr_st_amt%s ON %I (contbr_st, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
@@ -100,9 +108,9 @@ BEGIN
         EXECUTE format('CREATE INDEX idx_%s_sub_id_line_num_amt%s ON %I (line_num, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX idx_%s_two_year_transaction_period_amt%s ON %I (two_year_transaction_period, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
-        EXECUTE format('CREATE INDEX idx_%s_contributor_name_text%s ON %I USING GIN (contributor_name_text)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_contributor_employer_text%s ON %I USING GIN (contributor_employer_text)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_contributor_occupation_text%s ON %I USING GIN (contributor_occupation_text)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_name_text%s ON %I USING GIN (contributor_name_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_employer_text%s ON %I USING GIN (contributor_name_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_occupation_text%s ON %I USING GIN (contributor_name_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
         -- Other indexes
         EXECUTE format('CREATE UNIQUE INDEX idx_%s_sub_id%s ON %I (sub_id)', child_table_root, index_name_suffix, child_table_name);
@@ -141,6 +149,10 @@ BEGIN
         END IF;
 
         -- Create indexes.
+        -- Note:  The multi-column GIN indexes require the btree_gin extension
+        --        https://www.postgresql.org/docs/current/static/btree-gin.html
+        --        This is installed and enabled in RDS by default.
+
         -- Indexes for searching
           -- for sorting by date
         EXECUTE format('CREATE INDEX idx_%s_image_num_dt%s ON %I (image_num, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
@@ -153,6 +165,9 @@ BEGIN
         EXECUTE format('CREATE INDEX idx_%s_sub_id_amount_dt%s ON %I (disb_amt, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX idx_%s_cmte_id_dt%s ON %I (cmte_id, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
+        EXECUTE format('CREATE INDEX idx_%s_recipient_name_text%s ON %I USING GIN (recipient_name_text, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_disbursement_description_text%s ON %I USING GIN (disbursement_description_text, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+
           -- for sorting by amount
         EXECUTE format('CREATE INDEX idx_%s_image_num_amt%s ON %I (image_num, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX idx_%s_clean_recipient_cmte_id_amt%s ON %I (clean_recipient_cmte_id, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
@@ -164,8 +179,8 @@ BEGIN
         EXECUTE format('CREATE INDEX idx_%s_sub_id_date_amt%s ON %I (disb_dt, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX idx_%s_cmte_id_amt%s ON %I (cmte_id, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
-        EXECUTE format('CREATE INDEX idx_%s_recipient_name_text%s ON %I USING GIN (recipient_name_text)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_disbursement_description_text%s ON %I USING GIN (disbursement_description_text)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_recipient_name_text%s ON %I USING GIN (recipient_name_text, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_disbursement_description_text%s ON %I USING GIN (disbursement_description_text, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
 
         -- Other indexes

--- a/data/functions/itemized.sql
+++ b/data/functions/itemized.sql
@@ -77,7 +77,8 @@ BEGIN
         -- Create indexes.
         -- Note:  The multi-column GIN indexes require the btree_gin extension
         --        https://www.postgresql.org/docs/current/static/btree-gin.html
-        --        This is installed and enabled in RDS by default.
+        --        This is installed but not enabled in RDS by default, it must
+        --        be turned on with this: CREATE EXTENSION btree_gin;
 
         -- Indexes used for search
            -- for sorting by receipt date
@@ -92,9 +93,9 @@ BEGIN
         EXECUTE format('CREATE INDEX idx_%s_sub_id_line_num_dt%s ON %I (line_num, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX idx_%s_two_year_transaction_period_dt%s ON %I (two_year_transaction_period, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
-        EXECUTE format('CREATE INDEX idx_%s_contributor_name_text%s ON %I USING GIN (contributor_name_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_contributor_employer_text%s ON %I USING GIN (contributor_name_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_contributor_occupation_text%s ON %I USING GIN (contributor_name_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_name_text_contb_receipt_dt%s ON %I USING GIN (contributor_name_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_employer_text_contb_receipt_dt%s ON %I USING GIN (contributor_name_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_occupation_text_contb_receipt_dt%s ON %I USING GIN (contributor_name_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
           -- for sorting by transaction amount
         EXECUTE format('CREATE INDEX idx_%s_image_num_amt%s ON %I (image_num, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
@@ -108,9 +109,9 @@ BEGIN
         EXECUTE format('CREATE INDEX idx_%s_sub_id_line_num_amt%s ON %I (line_num, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX idx_%s_two_year_transaction_period_amt%s ON %I (two_year_transaction_period, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
-        EXECUTE format('CREATE INDEX idx_%s_contributor_name_text%s ON %I USING GIN (contributor_name_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_contributor_employer_text%s ON %I USING GIN (contributor_name_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_contributor_occupation_text%s ON %I USING GIN (contributor_name_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_name_text_contb_receipt_amt%s ON %I USING GIN (contributor_name_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_employer_text_contb_receipt_amt%s ON %I USING GIN (contributor_name_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contributor_occupation_text_contb_receipt_amt%s ON %I USING GIN (contributor_name_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
         -- Other indexes
         EXECUTE format('CREATE UNIQUE INDEX idx_%s_sub_id%s ON %I (sub_id)', child_table_root, index_name_suffix, child_table_name);
@@ -151,7 +152,8 @@ BEGIN
         -- Create indexes.
         -- Note:  The multi-column GIN indexes require the btree_gin extension
         --        https://www.postgresql.org/docs/current/static/btree-gin.html
-        --        This is installed and enabled in RDS by default.
+        --        This is installed but not enabled in RDS by default, it must
+        --        be turned on with this: CREATE EXTENSION btree_gin;
 
         -- Indexes for searching
           -- for sorting by date
@@ -165,8 +167,8 @@ BEGIN
         EXECUTE format('CREATE INDEX idx_%s_sub_id_amount_dt%s ON %I (disb_amt, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX idx_%s_cmte_id_dt%s ON %I (cmte_id, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
-        EXECUTE format('CREATE INDEX idx_%s_recipient_name_text%s ON %I USING GIN (recipient_name_text, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_disbursement_description_text%s ON %I USING GIN (disbursement_description_text, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_recipient_name_text_disb_dt%s ON %I USING GIN (recipient_name_text, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_disbursement_description_text_disb_dt%s ON %I USING GIN (disbursement_description_text, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
           -- for sorting by amount
         EXECUTE format('CREATE INDEX idx_%s_image_num_amt%s ON %I (image_num, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
@@ -179,8 +181,8 @@ BEGIN
         EXECUTE format('CREATE INDEX idx_%s_sub_id_date_amt%s ON %I (disb_dt, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX idx_%s_cmte_id_amt%s ON %I (cmte_id, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
-        EXECUTE format('CREATE INDEX idx_%s_recipient_name_text%s ON %I USING GIN (recipient_name_text, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_disbursement_description_text%s ON %I USING GIN (disbursement_description_text, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_recipient_name_text_disb_amt%s ON %I USING GIN (recipient_name_text, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_disbursement_description_text_disb_amt%s ON %I USING GIN (disbursement_description_text, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
 
         -- Other indexes

--- a/data/functions/itemized.sql
+++ b/data/functions/itemized.sql
@@ -93,9 +93,9 @@ BEGIN
         EXECUTE format('CREATE INDEX idx_%s_sub_id_line_num_dt%s ON %I (line_num, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX idx_%s_two_year_transaction_period_dt%s ON %I (two_year_transaction_period, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
-        EXECUTE format('CREATE INDEX idx_%s_contributor_name_text_contb_receipt_dt%s ON %I USING GIN (contributor_name_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_contributor_employer_text_contb_receipt_dt%s ON %I USING GIN (contributor_employer_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_contributor_occupation_text_contb_receipt_dt%s ON %I USING GIN (contributor_occupation_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contrib_name_text_dt%s ON %I USING GIN (contributor_name_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contrib_emp_text_dt%s ON %I USING GIN (contributor_employer_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contrib_occ_text_dt%s ON %I USING GIN (contributor_occupation_text, contb_receipt_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
           -- for sorting by transaction amount
         EXECUTE format('CREATE INDEX idx_%s_image_num_amt%s ON %I (image_num, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
@@ -109,9 +109,9 @@ BEGIN
         EXECUTE format('CREATE INDEX idx_%s_sub_id_line_num_amt%s ON %I (line_num, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX idx_%s_two_year_transaction_period_amt%s ON %I (two_year_transaction_period, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
-        EXECUTE format('CREATE INDEX idx_%s_contributor_name_text_contb_receipt_amt%s ON %I USING GIN (contributor_name_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_contributor_employer_text_contb_receipt_amt%s ON %I USING GIN (contributor_employer_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_contributor_occupation_text_contb_receipt_amt%s ON %I USING GIN (contributor_occupation_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contrib_name_text_amt%s ON %I USING GIN (contributor_name_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contrib_emp_text_amt%s ON %I USING GIN (contributor_employer_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_contrib_occ_text_amt%s ON %I USING GIN (contributor_occupation_text, contb_receipt_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
         -- Other indexes
         EXECUTE format('CREATE UNIQUE INDEX idx_%s_sub_id%s ON %I (sub_id)', child_table_root, index_name_suffix, child_table_name);
@@ -167,8 +167,8 @@ BEGIN
         EXECUTE format('CREATE INDEX idx_%s_sub_id_amount_dt%s ON %I (disb_amt, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX idx_%s_cmte_id_dt%s ON %I (cmte_id, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
-        EXECUTE format('CREATE INDEX idx_%s_recipient_name_text_disb_dt%s ON %I USING GIN (recipient_name_text, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_disbursement_description_text_disb_dt%s ON %I USING GIN (disbursement_description_text, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_recip_name_text_dt%s ON %I USING GIN (recipient_name_text, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_disb_desc_text_dt%s ON %I USING GIN (disbursement_description_text, disb_dt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
           -- for sorting by amount
         EXECUTE format('CREATE INDEX idx_%s_image_num_amt%s ON %I (image_num, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
@@ -181,8 +181,8 @@ BEGIN
         EXECUTE format('CREATE INDEX idx_%s_sub_id_date_amt%s ON %I (disb_dt, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX idx_%s_cmte_id_amt%s ON %I (cmte_id, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
-        EXECUTE format('CREATE INDEX idx_%s_recipient_name_text_disb_amt%s ON %I USING GIN (recipient_name_text, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
-        EXECUTE format('CREATE INDEX idx_%s_disbursement_description_text_disb_amt%s ON %I USING GIN (disbursement_description_text, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_recip_name_text_amt%s ON %I USING GIN (recipient_name_text, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
+        EXECUTE format('CREATE INDEX idx_%s_disb_desc_text_amt%s ON %I USING GIN (disbursement_description_text, disb_amt, sub_id)', child_table_root, index_name_suffix, child_table_name);
 
 
         -- Other indexes

--- a/tests/common.py
+++ b/tests/common.py
@@ -18,6 +18,9 @@ TEST_CONN = os.getenv('SQLA_TEST_CONN', 'postgresql:///cfdm_unit_test')
 rest.app.config['NPLUSONE_RAISE'] = True
 NPlusOne(rest.app)
 
+def _setup_extensions():
+    rest.db.engine.execute('create extension btree_gin;')
+
 
 def _reset_schema():
     rest.db.engine.execute('drop schema if exists public cascade;')
@@ -51,6 +54,7 @@ class BaseTestCase(unittest.TestCase):
         cls.client = TestApp(rest.app)
         cls.app_context = rest.app.app_context()
         cls.app_context.push()
+        _setup_extensions()
         _reset_schema()
 
     def setUp(self):


### PR DESCRIPTION
Part of #2423

This changeset modifies our GIN indexes in the itemized schedule A and B data to be multi-column, similar to the other multi-column indexes we have setup.  The intent is to provide a boost in performance when searching/filtering on text/ts_vector fields across multiple cycles.

This requires the support of the `btree_gin` PostgreSQL extension, which is installed in Amazon RDS but not enabled by default.  It can be enabled by running the following:

```sql
CREATE EXTENSION btree_gin;
```
This will also require repartitioning to rebuild the indexes.

For more information about this, see the following bits of documentation:

* [PostgreSQL 9.6 extensions supported in Amazon RDS](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.Extensions.96x)
* [PostgreSQL `btree_gin` extension](https://www.postgresql.org/docs/9.6/static/btree-gin.html)
* [PostgreSQL Multicolumn documentation](https://www.postgresql.org/docs/9.6/static/indexes-multicolumn.html)