### PR TITLE
Tweak Celery config to flip ack_late setting

### DIFF
--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -43,7 +43,7 @@ app.conf.update(
         'webservices.tasks.legal_docs',
     ),
     beat_schedule=schedule,
-    task_acks_late=True
+    task_acks_late=False
 )
 
 app.conf.ONCE = {


### PR DESCRIPTION
This changeset flips the [`ack_late`](http://docs.celeryproject.org/en/latest/reference/celery.app.task.html#celery.app.task.Task.acks_late) (`task_acks_late` in the config code) setting to be `False` again due to some strange behavior we are seeing in the dev environment.  Tasks occasionally get run twice and at the moment this appears to be the only culprit.  The documentation in Celery clearly states that if a worker crashes while processing the task will be run again, but we are not seeing a crash when a task has run more than once.

While this may help the issue, we should continue investigating to see if tasks are being redelivered to the workers as that can also cause this to happen.  It seems that the [`celery flower`](http://docs.celeryproject.org/en/latest/userguide/monitoring.html?highlight=celery%20flower) monitoring tool is a potential culprit in that case but again, it is unclear in our case.

More information can be found in this [user group thread](https://groups.google.com/forum/#!msg/celery-users/W0Qf09ahjas/FgVWqrefkAcJ) describing very similar behavior.

When looking at the logs, I did not see multiple `task_received` messages for the `refresh` task.

**MORE DETAILS**

When looking at the cloud.gov `celery-worker` logs for `dev` this morning after seeing this happen again, I noticed that the Main Process received the `refresh` task, kicked off a worker process, worker 1 in this case, and worker 1 seemed to restart itself shortly after kicking off - that or the logs displayed something out of order.

I never saw a line for Worker 2 starting the process, it just seemed to randomly pick up at updating aggregates and Schedule E.

Both workers then finished the processing and as we saw, sent emails after success.