### PR TITLE
Remove nightly refresh of schedule A and B in prod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
+dist: trusty
 language: python
 sudo: false
 cache: pip
 python:
   - "3.5"
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"
 env:
   global:
     - secure: fZSgHvzAttJcq5GYEwp/jo8/hcRs0hW169dTG4VC6vW29sPFjc2R6NuXVzXxGzxkWN16KvUNU+feMiMIse7c2zQIceTmhJh7cz19v+xmmwgqJgv0ln8+7+1rGB6FIblS9C70b2ggKjZ5DYMD4DxCrtQkWkVzQDncdADb4vg0ZA4=

--- a/data/functions/itemized.sql
+++ b/data/functions/itemized.sql
@@ -1,17 +1,2 @@
--- Provides the functions that allow us to retry processing itemized schedule
--- records that failed to process correctly upon initial record changes to the
--- underlying disclosure.nml_sched_a and disclosure.nml_sched_b tables.
-
--- If the record is successfully processed, it will be added to the main
--- nightly refresh queues to be taken care of with all of the other records
--- that were originally processed successfully.  If it is not, meaning it still
--- couldn't be found in the public.fec_fitem_sched_<x>_vw views, the sub_id
--- will remain in the ofec_sched_<x>_nightly_retries table until it is.
-
--- Convenience function that takes care of all of the processing at once.
-create or replace function retry_processing_itemized_records() returns void as $$
-begin
-    perform retry_processing_schedule_a_records(:START_YEAR_AGGREGATE);
-    perform retry_processing_schedule_b_records(:START_YEAR_AGGREGATE);
-end
-$$ language plpgsql;
+-- Drop old retry itemized processing function if it still exists.
+DROP FUNCTION IF EXISTS retry_processing_itemized_records();

--- a/data/sql_setup/prepare_schedule_a.sql
+++ b/data/sql_setup/prepare_schedule_a.sql
@@ -1,12 +1,7 @@
--- Create table to hold sub_ids of records that fail during the nightly
--- processing so that they can be tried at a later time.
--- The "action" column denotes what should happen with the record:
---    insert, update, or delete
+-- Drop the old nightly refresh retry table and function if they still exist.
 drop table if exists ofec_sched_a_nightly_retries;
-create table ofec_sched_a_nightly_retries (
-    sub_id numeric(19,0) not null primary key,
-    action varchar(6) not null
-);
+drop function if exists retry_processing_schedule_a_records(start_year integer);
+
 
 -- Create queue tables to hold changes to Schedule A
 drop table if exists ofec_sched_a_queue_new;
@@ -23,54 +18,6 @@ create index on ofec_sched_a_queue_new (timestamp);
 create index on ofec_sched_a_queue_old (timestamp);
 create index on ofec_sched_a_queue_new (two_year_transaction_period);
 create index on ofec_sched_a_queue_old (two_year_transaction_period);
-
-
--- Support for processing of schedule A itemized records that need to be
--- retried.
-create or replace function retry_processing_schedule_a_records(start_year integer) returns void as $$
-declare
-    timestamp timestamp = current_timestamp;
-    two_year_transaction_period smallint;
-    view_row fec_fitem_sched_a_vw%ROWTYPE;
-    schedule_a_record record;
-begin
-    for schedule_a_record in select * from ofec_sched_a_nightly_retries loop
-        select into view_row * from fec_fitem_sched_a_vw where sub_id = schedule_a_record.sub_id;
-
-        if FOUND then
-            two_year_transaction_period = cast(get_cycle(view_row.rpt_yr) as smallint);
-
-            if two_year_transaction_period >= start_year then
-                -- Determine which queue(s) the found record should go into.
-                case schedule_a_record.action
-                    when 'insert' then
-                        delete from ofec_sched_a_queue_new where sub_id = view_row.sub_id;
-                        insert into ofec_sched_a_queue_new values (view_row.*, timestamp, two_year_transaction_period);
-
-                        delete from ofec_sched_a_nightly_retries where sub_id = schedule_a_record.sub_id;
-                    when 'delete' then
-                        delete from ofec_sched_a_queue_old where sub_id = view_row.sub_id;
-                        insert into ofec_sched_a_queue_old values (view_row.*, timestamp, two_year_transaction_period);
-
-                        delete from ofec_sched_a_nightly_retries where sub_id = schedule_a_record.sub_id;
-                    when 'update' then
-                        delete from ofec_sched_a_queue_new where sub_id = view_row.sub_id;
-                        delete from ofec_sched_a_queue_old where sub_id = view_row.sub_id;
-                        insert into ofec_sched_a_queue_new values (view_row.*, timestamp, two_year_transaction_period);
-                        insert into ofec_sched_a_queue_old values (view_row.*, timestamp, two_year_transaction_period);
-
-                        delete from ofec_sched_a_nightly_retries where sub_id = schedule_a_record.sub_id;
-                    else
-                        raise warning 'Invalid action supplied: %', schedule_a_record.action;
-                end case;
-            end if;
-        else
-            raise notice 'sub_id % still not found', schedule_a_record.sub_id;
-        end if;
-    end loop;
-end
-$$ language plpgsql;
-
 
 -- Create trigger to maintain Schedule A queues for inserts and updates
 -- These happen after a row is inserted/updated so that we can leverage pulling
@@ -101,13 +48,6 @@ begin
                 delete from ofec_sched_a_queue_new where sub_id = view_row.sub_id;
                 insert into ofec_sched_a_queue_new values (view_row.*, timestamp, two_year_transaction_period);
             end if;
-        else
-            -- We weren't able to successfully retrieve a row from the view,
-            -- so keep track of this sub_id if we haven't already so we can
-            -- try processing it again each night until we're able to
-            -- successfully process it.
-            delete from ofec_sched_a_nightly_retries where sub_id = new.sub_id;
-            insert into ofec_sched_a_nightly_retries values (new.sub_id, 'insert');
         end if;
 
         return new;
@@ -121,13 +61,6 @@ begin
                 delete from ofec_sched_a_queue_new where sub_id = view_row.sub_id;
                 insert into ofec_sched_a_queue_new values (view_row.*, timestamp, two_year_transaction_period);
             end if;
-        else
-            -- We weren't able to successfully retrieve a row from the view,
-            -- so keep track of this sub_id if we haven't already so we can
-            -- try processing it again each night until we're able to
-            -- successfully process it.
-            delete from ofec_sched_a_nightly_retries where sub_id = new.sub_id;
-            insert into ofec_sched_a_nightly_retries values (new.sub_id, 'update');
         end if;
 
         return new;
@@ -165,13 +98,6 @@ begin
                 delete from ofec_sched_a_queue_old where sub_id = view_row.sub_id;
                 insert into ofec_sched_a_queue_old values (view_row.*, timestamp, two_year_transaction_period);
             end if;
-        else
-            -- We weren't able to successfully retrieve a row from the view,
-            -- so keep track of this sub_id if we haven't already so we can
-            -- try processing it again each night until we're able to
-            -- successfully process it.
-            delete from ofec_sched_a_nightly_retries where sub_id = old.sub_id;
-            insert into ofec_sched_a_nightly_retries values (old.sub_id, 'delete');
         end if;
 
         return old;
@@ -185,13 +111,6 @@ begin
                 delete from ofec_sched_a_queue_old where sub_id = view_row.sub_id;
                 insert into ofec_sched_a_queue_old values (view_row.*, timestamp, two_year_transaction_period);
             end if;
-        else
-            -- We weren't able to successfully retrieve a row from the view,
-            -- so keep track of this sub_id if we haven't already so we can
-            -- try processing it again each night until we're able to
-            -- successfully process it.
-            delete from ofec_sched_a_nightly_retries where sub_id = old.sub_id;
-            insert into ofec_sched_a_nightly_retries values (old.sub_id, 'update');
         end if;
 
         -- We have to return new here because this record is intended to change

--- a/manage.py
+++ b/manage.py
@@ -343,21 +343,6 @@ def update_aggregates():
         logger.info('Finished updating Schedule E and support aggregates.')
 
 @manager.command
-def retry_itemized():
-    """This is run nightly to retry processing itemized schedule A and B data
-    that was not able to be processed normally.
-    """
-    logger.info('Retrying itemized schedule processing...')
-
-    with db.engine.begin() as connection:
-        connection.execute(
-            sa.text('select retry_processing_itemized_records()').execution_options(
-                autocommit=True
-            )
-        )
-        logger.info('Finished retrying itemized schedule processing.')
-
-@manager.command
 def refresh_itemized():
     """These are run nightly to refresh the itemized schedule A and B data."""
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,15 +3,14 @@
 git+https://github.com/18F/rdbms-subsetter
 
 # Testing
-mock>=1.3.0
-pytest>=3.0.7
-pytest-cov>=2.3.1
-factory-boy>=2.5.2
-faker>=0.7.5
-nplusone>=0.7.3
-webtest>=2.0.2
-pdbpp>=0.8.3
-pygments>=2.2.0
+pytest==3.1.3
+pytest-cov==2.5.1
+factory_boy==2.8.1
+faker==0.7.18
+nplusone==0.8.0
+webtest==2.0.27
+pdbpp==0.9.1
+pygments==2.2.0
 
 
 #efiling

--- a/tests/test_advisory_opinions.py
+++ b/tests/test_advisory_opinions.py
@@ -1,6 +1,6 @@
 import datetime
 import subprocess
-from mock import patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_current_murs.py
+++ b/tests/test_current_murs.py
@@ -1,6 +1,6 @@
 import re
 import subprocess
-from mock import patch
+from unittest.mock import patch
 from datetime import datetime
 from decimal import Decimal
 

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,6 +1,6 @@
 import datetime
-import mock
 import hashlib
+import unittest.mock as mock
 
 import pytest
 from botocore.exceptions import ClientError

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -334,61 +334,6 @@ class TestViews(common.IntegrationTestCase):
         self.assertEqual(search.sub_id, row.sub_id)
         self.assertEqual(search.contributor_name, 'Sheldon Adelson')
 
-    def test_sched_a_retry_processing(self):
-        rows = [
-            self.SchedAFactory(
-                rpt_yr=2014,
-                contbr_nm='Sheldon Adelson',
-                contb_receipt_dt=datetime.datetime(2014, 1, 1)
-            ),
-            self.SchedAFactory(
-                rpt_yr=2015,
-                contbr_nm='Shelly Adelson',
-                contb_receipt_dt=datetime.datetime(2015, 1, 1)
-            ),
-            self.SchedAFactory(
-                rpt_yr=2016,
-                contbr_nm='Jane Doe',
-                contb_receipt_dt=datetime.datetime(2016, 1, 1)
-            )
-        ]
-
-        db.session.commit()
-
-        # Make sure queues are clear before testing this
-        self._clear_sched_a_queues()
-
-        db.session.execute(
-            'insert into ofec_sched_a_nightly_retries values ({sub_id}, \'insert\')'.format(sub_id=rows[0].sub_id)
-        )
-        db.session.execute(
-            'insert into ofec_sched_a_nightly_retries values ({sub_id}, \'update\')'.format(sub_id=rows[1].sub_id)
-        )
-        db.session.execute(
-            'insert into ofec_sched_a_nightly_retries values ({sub_id}, \'delete\')'.format(sub_id=rows[2].sub_id)
-        )
-
-        db.session.commit()
-
-        retry_queue_count = db.engine.execute(
-            'select count(*) from ofec_sched_a_nightly_retries'
-        ).scalar()
-
-        self.assertEqual(retry_queue_count, 3)
-
-        manage.retry_itemized()
-
-        new_queue_count = self._get_sched_a_queue_new_count()
-        old_queue_count = self._get_sched_a_queue_old_count()
-        self.assertEqual(new_queue_count, 2)
-        self.assertEqual(old_queue_count, 2)
-
-        retry_queue_count = db.engine.execute(
-            'select count(*) from ofec_sched_a_nightly_retries'
-        ).scalar()
-
-        self.assertEqual(retry_queue_count, 0)
-
 
     def _check_update_aggregate_create(self, item_key, total_key, total_model, value):
         filing = self.SchedAFactory(**{

--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -2,8 +2,8 @@ from webservices import rest
 import json
 import codecs
 import unittest
-import mock
-from mock import patch
+import unittest.mock as mock
+from unittest.mock import patch
 
 from webservices.resources.legal import es, parse_query_string
 

--- a/tests/test_load_legal_docs.py
+++ b/tests/test_load_legal_docs.py
@@ -1,5 +1,5 @@
 import unittest
-from mock import patch
+from unittest.mock import patch
 from webservices.legal_docs import (
     delete_murs_from_es,
     delete_murs_from_s3,

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,7 +1,7 @@
 import io
 import logging
+import unittest.mock as mock
 
-import mock
 import cfenv
 import pytest
 import mandrill

--- a/tests/test_map_citations_murs.py
+++ b/tests/test_map_citations_murs.py
@@ -1,5 +1,5 @@
-import mock
 import unittest
+import unittest.mock as mock
 import urllib
 
 from webservices.legal_docs import load_legal_docs, reclassify_statutory_citation

--- a/webservices/tasks/refresh.py
+++ b/webservices/tasks/refresh.py
@@ -17,8 +17,6 @@ def refresh():
     with mail.CaptureLogs(manage.logger, buffer):
         try:
             manage.update_aggregates()
-            # this process is having issues, we will fix in a following PR
-            # manage.retry_itemized()
             manage.refresh_itemized()
             manage.update_itemized('e')
             manage.update_schemas()


### PR DESCRIPTION
This changeset is intended to alleviate an immediate problem we are facing in prod with record inserts.  This work was already completed in the development branch with #2589 and tested in that environment and has had the desired and positive impact we were looking for.  The situation in prod is becoming worse and we cannot wait for the next release for this to be fixed, hence this hotfix.

This hotfix also addresses the broken tests and dependency adjustments we had made and tested in `develop`.  In addition to ensuring this hotfix has passing tests and can be deployed successfully to production, this will also fix the automatic deploys that we have setup to refresh the application.