### PR TITLE
Add update_functions to nightly refresh

### DIFF
--- a/webservices/tasks/refresh.py
+++ b/webservices/tasks/refresh.py
@@ -16,6 +16,7 @@ def refresh():
     buffer = io.StringIO()
     with mail.CaptureLogs(manage.logger, buffer):
         try:
+            manage.update_functions()
             manage.update_aggregates()
             manage.refresh_itemized()
             manage.update_itemized('e')


### PR DESCRIPTION
This changeset adds a call to `update_functions` to the nightly process to ensure that the function definitions get updated properly and are not missed.  We have run into a couple of issues in the past with these being out of sync and this is a good way to prevent that from happening again.