### PR TITLE
Hotfix/fix form 6

### DIFF
--- a/data/sql_updates/totals_combined.sql
+++ b/data/sql_updates/totals_combined.sql
@@ -20,6 +20,7 @@ with last_subset as (
         get_cycle(rpt_yr) >= :START_YEAR
         -- issue #2601: F5 has both regular and 24/48 notices data included in disclosure.v_sum_and_det_sum_report, need to exclude the 24/48 hours notice data
         and (form_tp_cd != 'F5' or (form_tp_cd = 'F5' and rpt_tp not in ('24','48')))
+        and form_tp_cd != 'F6'
         order by
         cmte_id,
         cycle,
@@ -58,6 +59,7 @@ first_subset as (
         get_cycle(rpt_yr) >= :START_YEAR
         -- issue #2601: F5 has both regular and 24/48 notices data included in disclosure.v_sum_and_det_sum_report, need to exclude the 24/48 hours notice data
         and (form_tp_cd != 'F5'or (form_tp_cd = 'F5' and rpt_tp not in ('24','48')))
+        and form_tp_cd != 'F6'
     order by
         cmte_id,
         get_cycle(rpt_yr),
@@ -77,6 +79,7 @@ first as (
         get_cycle(rpt_yr) >= :START_YEAR
         -- issue #2601: F5 has both regular and 24/48 notices data included in disclosure.v_sum_and_det_sum_report, need to exclude the 24/48 hours notice data
         and (form_tp_cd != 'F5' or (form_tp_cd = 'F5' and rpt_tp not in ('24','48')))
+        and form_tp_cd != 'F6'
     order by
         cmte_id,
         get_cycle(rpt_yr),
@@ -181,10 +184,11 @@ first as (
         left join first on
             vsd.cmte_id = first.committee_id and
             get_cycle(vsd.rpt_yr) = first.cycle
-        get_cycle(vsd.rpt_yr) >= :START_YEAR
     where
+        get_cycle(vsd.rpt_yr) >= :START_YEAR
         -- issue #2601: F5 has both regular and 24/48 notices data included in disclosure.v_sum_and_det_sum_report, need to exclude the 24/48 hours notice data
-        (vsd.form_tp_cd != 'F5' or (vsd.form_tp_cd = 'F5' and vsd.rpt_tp not in ('24','48')))
+        and (vsd.form_tp_cd != 'F5' or (vsd.form_tp_cd = 'F5' and vsd.rpt_tp not in ('24','48')))
+        and vsd.form_tp_cd != 'F6'
     group by
         vsd.cmte_id,
         vsd.form_tp_cd,

--- a/data/sql_updates/totals_combined.sql
+++ b/data/sql_updates/totals_combined.sql
@@ -18,7 +18,9 @@ with last_subset as (
     from disclosure.v_sum_and_det_sum_report
     where
         get_cycle(rpt_yr) >= :START_YEAR
-    order by
+        -- issue #2601: F5 has both regular and 24/48 notices data included in disclosure.v_sum_and_det_sum_report, need to exclude the 24/48 hours notice data
+        and (form_tp_cd != 'F5' or (form_tp_cd = 'F5' and rpt_tp not in ('24','48')))
+        order by
         cmte_id,
         cycle,
         to_timestamp(cvg_end_dt) desc nulls last
@@ -54,6 +56,8 @@ first_subset as (
     from disclosure.v_sum_and_det_sum_report
     where
         get_cycle(rpt_yr) >= :START_YEAR
+        -- issue #2601: F5 has both regular and 24/48 notices data included in disclosure.v_sum_and_det_sum_report, need to exclude the 24/48 hours notice data
+        and (form_tp_cd != 'F5'or (form_tp_cd = 'F5' and rpt_tp not in ('24','48')))
     order by
         cmte_id,
         get_cycle(rpt_yr),
@@ -71,6 +75,8 @@ first as (
     from disclosure.v_sum_and_det_sum_report
     where
         get_cycle(rpt_yr) >= :START_YEAR
+        -- issue #2601: F5 has both regular and 24/48 notices data included in disclosure.v_sum_and_det_sum_report, need to exclude the 24/48 hours notice data
+        and (form_tp_cd != 'F5' or (form_tp_cd = 'F5' and rpt_tp not in ('24','48')))
     order by
         cmte_id,
         get_cycle(rpt_yr),
@@ -175,8 +181,10 @@ first as (
         left join first on
             vsd.cmte_id = first.committee_id and
             get_cycle(vsd.rpt_yr) = first.cycle
-    where
         get_cycle(vsd.rpt_yr) >= :START_YEAR
+    where
+        -- issue #2601: F5 has both regular and 24/48 notices data included in disclosure.v_sum_and_det_sum_report, need to exclude the 24/48 hours notice data
+        (vsd.form_tp_cd != 'F5' or (vsd.form_tp_cd = 'F5' and vsd.rpt_tp not in ('24','48')))
     group by
         vsd.cmte_id,
         vsd.form_tp_cd,


### PR DESCRIPTION
Removes form 6 to avoid double counting. Includes earlier work excluding 24 and 48 hr