### PR TITLE
Remove old function from nightly update tasks

### DIFF
--- a/webservices/tasks/refresh.py
+++ b/webservices/tasks/refresh.py
@@ -17,7 +17,6 @@ def refresh():
     with mail.CaptureLogs(manage.logger, buffer):
         try:
             manage.update_functions()
-            manage.refresh_itemized()
             manage.update_itemized('e')
             manage.update_schemas()
             download.clear_bucket()


### PR DESCRIPTION
This changeset removes the refreshed_itemized method from the nightly update script.  We had removed this method when wrapping up the last itemized schedule updates but this change did not make it through to the release branch at the time the release branch was made.