### PR TITLE
Update Python and Node.js runtimes and README

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,4 +98,12 @@ jobs:
       - deploy:
           name: Deploy API
           command: |
+            export PATH=$HOME/bin:$PATH
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+            . venv/bin/activate
+            nvm use default
+            npm run build
+            pip install -r requirements.txt
             invoke deploy --branch $CIRCLE_BRANCH --login True --yes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
           # Commands listed here are from the CircleCI PostgreSQL config docs:
           # https://circleci.com/docs/2.0/postgres-config/#postgresql-circleci-configuration-example
           command: |
-            apt-get update -qq && apt-get install -y build-essential postgresql-client
-            echo ‘/usr/lib/postgresql/9.6/bin/:$PATH’ >> $BASH_ENV
+            sudo apt-get update -qq && sudo apt-get install -y build-essential postgresql-client
+            echo '/usr/lib/postgresql/9.6/bin/:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "package.json" }}
+          - fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-ci.txt" }}-{{ checksum "package.json" }}
           # fallback to using the latest cache if no exact match is found
           - fec-api-dependencies-
 
@@ -58,7 +58,7 @@ jobs:
           paths:
             - ./venv
             - ./node_modules
-          key: fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "package.json" }}
+          key: fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-ci.txt" }}-{{ checksum "package.json" }}
 
       - run:
           name: Ensure database is available
@@ -85,7 +85,7 @@ jobs:
           command: |
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
-            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.23.0" | tar xzv -C $HOME/bin
+            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.31.0" | tar xzv -C $HOME/bin
             cf install-plugin autopilot -f -r CF-Community
 
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,12 +98,4 @@ jobs:
       - deploy:
           name: Deploy API
           command: |
-            export PATH=$HOME/bin:$PATH
-            export NVM_DIR="$HOME/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-            . venv/bin/activate
-            nvm use default
-            npm run build
-            pip install -r requirements.txt
-            invoke deploy --branch $TRAVIS_BRANCH --login True --yes
+            invoke deploy --branch $CIRCLE_BRANCH --login True --yes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,6 @@ jobs:
             sudo apt-get install postgresql-client
             echo ‘/usr/lib/postgresql/9.6/bin/:$PATH’ >> $BASH_ENV
 
-      - run:
-          name: Install Node.js
-          command: |
-            sudo apt-get update && curl -sL https://deb.nodesource.com/setup_6.x | sudo bash - && sudo apt-get install -y nodejs
-
       - restore_cache:
           keys:
           - fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-ci.txt" }}-{{ checksum "package.json" }}
@@ -45,14 +40,26 @@ jobs:
           - fec-api-dependencies-
 
       - run:
-          name: Install project dependencies
+          name: Install node dependencies
+          command: |
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.4/install.sh | bash
+            echo ". ~/.nvm/nvm.sh" >> $BASH_ENV
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+            nvm install 8.5.0
+            nvm use 8.5.0
+            nvm alias default 8.5.0
+            npm install -g npm swagger-tools
+            npm install
+            npm run build
+
+      - run:
+          name: Install Python dependencies
           command: |
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt -r requirements-dev.txt -r requirements-ci.txt
-            sudo npm install -g swagger-tools
-            npm install
-            npm run build
 
       - save_cache:
           paths:
@@ -92,6 +99,11 @@ jobs:
           name: Deploy API
           command: |
             export PATH=$HOME/bin:$PATH
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
             . venv/bin/activate
+            nvm use default
+            npm run build
             pip install -r requirements.txt
             invoke deploy --branch $TRAVIS_BRANCH --login True --yes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           # Commands listed here are from the CircleCI PostgreSQL config docs:
           # https://circleci.com/docs/2.0/postgres-config/#postgresql-circleci-configuration-example
           command: |
-            sudo apt-get install postgresql-client
+            apt-get update -qq && apt-get install -y build-essential postgresql-client
             echo ‘/usr/lib/postgresql/9.6/bin/:$PATH’ >> $BASH_ENV
 
       - restore_cache:
@@ -47,9 +47,9 @@ jobs:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-            nvm install 8.5.0
-            nvm use 8.5.0
-            nvm alias default 8.5.0
+            nvm install 8.6.0
+            nvm use 8.6.0
+            nvm alias default 8.6.0
             npm install -g npm swagger-tools
             npm install
             npm run build
@@ -92,7 +92,7 @@ jobs:
           command: |
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
-            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.31.0" | tar xzv -C $HOME/bin
+            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.32.0" | tar xzv -C $HOME/bin
             cf install-plugin autopilot -f -r CF-Community
 
       - deploy:
@@ -104,6 +104,4 @@ jobs:
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
             . venv/bin/activate
             nvm use default
-            npm run build
-            pip install -r requirements.txt
             invoke deploy --branch $CIRCLE_BRANCH --login True --yes

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 **Develop**
-[![Build Status](https://img.shields.io/travis/18F/openFEC/develop.svg)](https://travis-ci.org/18F/openFEC)
+[![CircleCI](https://circleci.com/gh/18F/openFEC.svg?style=svg)](https://circleci.com/gh/18F/openFEC)
 [![Test Coverage](https://img.shields.io/codecov/c/github/18F/openFEC/develop.svg)](https://codecov.io/github/18F/openFEC)
 
 **Master**
-[![Build Status](https://img.shields.io/travis/18F/openFEC/master.svg)](https://travis-ci.org/18F/openFEC)
 [![Test Coverage](https://img.shields.io/codecov/c/github/18F/openFEC/master.svg)](https://codecov.io/github/18F/openFEC)
 [![Code Climate](https://img.shields.io/codeclimate/github/18F/openFEC.svg)](https://codeclimate.com/github/18F/openFEC)
 [![Dependencies](https://img.shields.io/gemnasium/18F/openFEC.svg)](https://gemnasium.com/18F/openFEC)
@@ -45,7 +44,7 @@ We are always trying to improve our documentation. If you have suggestions or ru
 ### Project prerequisites
 1. Ensure you have the following requirements installed:
 
-    * Python 3.5.3 (which includes pip and and a built-in version of virtualenv called `pyvenv`)
+    * Python (the latest 3.5 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
     * The latest long term support (LTS) or stable release of Node.js (which includes npm)
     * PostgreSQL (the latest 9.6 release).
          * Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "swagger-ui": {
+      "version": "git+https://github.com/18F/swagger-ui.git#b34956fc2a53cfeac0523a55fb1a981268af0d8d",
+      "integrity": "sha1-iP83lhTzw+xqnWNH9CyQ4FZpDkc="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "mkdir -p static/swagger-ui && cp -R node_modules/swagger-ui/dist static/swagger-ui/"
   },
   "engines": {
-    "node": "0.12.7",
-    "npm": "2.11.3"
+    "node": "8.5.0",
+    "npm": "5.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "mkdir -p static/swagger-ui && cp -R node_modules/swagger-ui/dist static/swagger-ui/"
   },
   "engines": {
-    "node": "8.5.0",
+    "node": "8.6.0",
     "npm": "5.4.2"
   }
 }

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.3
+python-3.5.4


### PR DESCRIPTION
This changeset updates the Python runtime to be `3.5.4` and makes some small adjustments to the README file to account for the recent switch from Travis CI to CircleCI.

This also makes adjustments for running with the latest version of Node.js, `8.6.0`.