### PR TITLE
Match virtualenv name in CircleCI config to our ignore files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,6 @@ jobs:
             sudo apt-get update -qq && sudo apt-get install -y build-essential postgresql-client
             echo '/usr/lib/postgresql/9.6/bin/:$PATH' >> $BASH_ENV
 
-      - restore_cache:
-          keys:
-          - fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-ci.txt" }}-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - fec-api-dependencies-
-
       - run:
           name: Install node dependencies
           command: |
@@ -60,12 +54,6 @@ jobs:
             python3 -m venv env
             . env/bin/activate
             pip install -r requirements.txt -r requirements-dev.txt -r requirements-ci.txt
-
-      - save_cache:
-          paths:
-            - ./env
-            - ./node_modules
-          key: fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-ci.txt" }}-{{ checksum "package.json" }}
 
       - run:
           name: Ensure database is available

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,13 +57,13 @@ jobs:
       - run:
           name: Install Python dependencies
           command: |
-            python3 -m venv venv
-            . venv/bin/activate
+            python3 -m venv env
+            . env/bin/activate
             pip install -r requirements.txt -r requirements-dev.txt -r requirements-ci.txt
 
       - save_cache:
           paths:
-            - ./venv
+            - ./env
             - ./node_modules
           key: fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-ci.txt" }}-{{ checksum "package.json" }}
 
@@ -74,13 +74,13 @@ jobs:
       - run:
           name: Run tests
           command: |
-            . venv/bin/activate
+            . env/bin/activate
             py.test
 
       - run:
           name: Perform post-test checks
           command: |
-            . venv/bin/activate
+            . env/bin/activate
             codecov
 
       - store_artifacts:
@@ -102,6 +102,6 @@ jobs:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-            . venv/bin/activate
+            . env/bin/activate
             nvm use default
             invoke deploy --branch $CIRCLE_BRANCH --login True --yes


### PR DESCRIPTION
This changeset updates the CircleCI config to use the same name for the Python virtual environment it creates for testing and deployment as we have in the `.gitignore` and `.cfignore` files.  When the name does not match, the virtual environment directory and its contents are pushed up to the cloud.gov environment, which we do not want as it is extra cruft and could potentially cause environment conflicts/issues.