### PR TITLE
[MERGE WITH GITFLOW]fixed logic of candidate inactive criteria

### DIFF
--- a/data/sql_updates/candidate_history.sql
+++ b/data/sql_updates/candidate_history.sql
@@ -78,7 +78,7 @@ left join elections using (cand_id)
 left join dates using (cand_id)
 left join disclosure.cand_inactive inactive on
     fec_yr.cand_id = inactive.cand_id and
-    fec_yr.fec_election_yr < inactive.election_yr
+    fec_yr.fec_election_yr = inactive.election_yr
 left join staging.ref_pty ref_party on fec_yr.cand_pty_affiliation = ref_party.pty_cd
 where max_cycle >= :START_YEAR and
     fec_yr.cand_id not in (select distinct cmte_id from unverified_filers_vw where cmte_id similar to '(P|S|H)%')


### PR DESCRIPTION
This fixes #2706 in github which corrects value of candidate_inactive column