### PR TITLE
[Merge with git flow] Hotfix/remove aggregate update from trigger

### DIFF
--- a/data/sql_setup/prepare_schedule_a.sql
+++ b/data/sql_setup/prepare_schedule_a.sql
@@ -281,7 +281,6 @@ begin
             WHERE
                 %I.sub_id = $1.sub_id',
                 child_table_name, child_table_name) USING view_row;
-            PERFORM increment_sched_a_aggregates(view_row);
         end if;
     end if;
 
@@ -314,7 +313,6 @@ begin
                 IF tg_op = 'DELETE' THEN
                     DELETE FROM ofec_sched_a_master WHERE sub_id = view_row.sub_id;
                 END IF;
-                PERFORM decrement_sched_a_aggregates(view_row);
             end if;
         end if;
 

--- a/data/sql_setup/prepare_schedule_b.sql
+++ b/data/sql_setup/prepare_schedule_b.sql
@@ -282,7 +282,6 @@ begin
             WHERE
                 %I.sub_id = $1.sub_id',
                 child_table_name, child_table_name) USING view_row;
-            PERFORM increment_sched_b_aggregates(view_row);
         end if;
     end if;
 
@@ -315,7 +314,6 @@ begin
             IF tg_op = 'DELETE' THEN
                 DELETE FROM ofec_sched_b_master WHERE sub_id = view_row.sub_id;
             END IF;
-            PERFORM decrement_sched_b_aggregates(view_row);
         end if;
     end if;
     if tg_op = 'DELETE' then

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -272,229 +272,229 @@ class TestViews(common.IntegrationTestCase):
         self.assertEqual(existing.total, total + 538)
         self.assertEqual(existing.count, count + 1)
 
-    def test_update_aggregate_create(self):
-        self._check_update_aggregate_create('contbr_zip', 'zip', models.ScheduleAByZip, '19041')
-        self._check_update_aggregate_create('contbr_st', 'state', models.ScheduleAByState, 'PA')
-        self._check_update_aggregate_create('contbr_employer', 'employer', models.ScheduleAByEmployer, 'PET CHOW')
-        self._check_update_aggregate_create('contbr_occupation', 'occupation', models.ScheduleAByOccupation, 'FURRIER')
-
-    def test_update_aggregate_existing(self):
-        faker = Faker()
-        self._check_update_aggregate_existing('contbr_zip', 'zip', models.ScheduleAByZip, faker.zipcode())
-        self._check_update_aggregate_existing('contbr_st', 'state', models.ScheduleAByState, faker.state_abbr())
-        self._check_update_aggregate_existing(
-            'contbr_employer', 'employer', models.ScheduleAByEmployer, faker.company()[:38])
-        self._check_update_aggregate_existing(
-            'contbr_occupation', 'occupation', models.ScheduleAByOccupation, faker.job()[:38])
-
-    def test_update_aggregate_state_existing_null_amount(self):
-        existing = models.ScheduleAByState.query.filter_by(
-            cycle=2016,
-        ).first()
-        total = existing.total
-        count = existing.count
-        self.NmlSchedAFactory(
-            rpt_yr=2015,
-            cmte_id=existing.committee_id,
-            contbr_st=existing.state,
-            contb_receipt_amt=None,
-            contb_receipt_dt=datetime.datetime(2015, 1, 1),
-            receipt_tp='15J',
-        )
-        db.session.flush()
-        db.session.refresh(existing)
-        self.assertEqual(existing.total, total)
-        self.assertEqual(existing.count, count)
-
-    def test_update_aggregate_asize_create(self):
-        filing = self.NmlSchedAFactory(
-            rpt_yr=2015,
-            cmte_id='C6789',
-            contb_receipt_amt=538,
-            contb_receipt_dt=datetime.datetime(2015, 1, 1),
-            receipt_tp='15J',
-        )
-        self.FItemReceiptOrExp(
-            sub_id=filing.sub_id,
-            rpt_yr=2015,
-        )
-        db.session.commit()
-        _rebuild_sched_a_by_size_merged()
-        rows = models.ScheduleABySize.query.filter_by(
-            cycle=2016,
-            committee_id='C6789',
-            size=500,
-        ).all()
-        self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0].total, 538)
-        self.assertEqual(rows[0].count, 1)
-        filing.contb_receipt_amt = 53
-        db.session.add(filing)
-        db.session.commit()
-        _rebuild_sched_a_by_size_merged()
-        db.session.refresh(rows[0])
-        self.assertEqual(rows[0].total, 0)
-        self.assertEqual(rows[0].count, 0)
-
-    def test_update_aggregate_asize_existing(self):
-        def get_existing():
-            return models.ScheduleABySize.query.filter_by(
-                size=500,
-                cycle=2016,
-            ).order_by(
-                models.ScheduleABySize.committee_id,
-            ).first()
-        EXISTING_RECEIPT_AMOUNT = 504
-        filing = self.NmlSchedAFactory(
-            rpt_yr=2015,
-            cmte_id='X1234',
-            contb_receipt_amt=EXISTING_RECEIPT_AMOUNT,
-            contb_receipt_dt=datetime.datetime(2015, 1, 1),
-            receipt_tp='15J',
-        )
-        self.FItemReceiptOrExp(
-            sub_id=filing.sub_id,
-            rpt_yr=2015,
-        )
-        db.session.commit()
-        _rebuild_sched_a_by_size_merged()
-        existing = get_existing()
-        total = existing.total
-        count = existing.count
-        NEW_RECEIPT_AMOUNT = 538
-        filing = self.NmlSchedAFactory(
-            rpt_yr=2015,
-            cmte_id=existing.committee_id,
-            contb_receipt_amt=NEW_RECEIPT_AMOUNT,
-            contb_receipt_dt=datetime.datetime(2015, 1, 1),
-            receipt_tp='15J',
-        )
-        self.FItemReceiptOrExp(
-            sub_id=filing.sub_id,
-            rpt_yr=2015,
-        )
-        db.session.commit()
-        _rebuild_sched_a_by_size_merged()
-        existing = get_existing()
-        self.assertEqual(existing.total, total + NEW_RECEIPT_AMOUNT)
-        self.assertEqual(existing.count, count + 1)
-
-    def test_update_aggregate_size_existing_merged(self):
-        existing = models.ScheduleABySize.query.filter_by(
-            size=0,
-            cycle=2016,
-        ).first()
-        total = existing.total
-        committee_id = existing.committee_id
-        filing = self.NmlSchedAFactory(
-            rpt_yr=2015,
-            cmte_id=committee_id,
-            contb_receipt_amt=75,
-            contb_receipt_dt=datetime.datetime(2015, 1, 1),
-            receipt_tp='15J',
-        )
-        self.FItemReceiptOrExp(
-            sub_id=filing.sub_id,
-            rpt_yr=2015,
-        )
-
-        # Create a committee and committee report
-        # Changed to point to sampled data, may be problematic in the future if det sum table
-        # changes a lot and hence the tests need to test new behavior, believe it's fine for now though. -jcc
-        rep = sa.Table('detsum_sample', db.metadata, autoload=True, autoload_with=db.engine)
-        ins = rep.insert().values(
-            indv_unitem_contb=20,
-            cmte_id=committee_id,
-            rpt_yr=2016,
-            orig_sub_id=9,
-            form_tp_cd='F3',
-        )
-        db.session.execute(ins)
-        db.session.commit()
-        db.session.execute('refresh materialized view ofec_totals_house_senate_mv')
-        db.session.execute('refresh materialized view ofec_totals_combined_mv')
-        db.session.commit()
-        _rebuild_sched_a_by_size_merged()
-        refreshed = models.ScheduleABySize.query.filter_by(
-            size=0,
-            cycle=2016,
-            committee_id=committee_id,
-        ).first()
-        # Updated total includes new Schedule A filing and new report
-        self.assertAlmostEqual(refreshed.total, total + 75 + 20)
-        self.assertEqual(refreshed.count, None)
-
-    def test_update_aggregate_purpose_create(self):
-        db.session.execute('delete from disclosure.f_item_receipt_or_exp')
-        filing = self.NmlSchedBFactory(
-            rpt_yr=2015,
-            cmte_id='C12345',
-            disb_amt=538,
-            disb_dt=datetime.datetime(2015, 1, 1),
-            disb_desc='CAMPAIGN BUTTONS',
-            form_tp_cd='11'
-        )
-        self.FItemReceiptOrExp(
-            sub_id=filing.sub_id,
-            rpt_yr=2015,
-        )
-        db.session.commit()
-        rows = models.ScheduleBByPurpose.query.filter_by(
-            cycle=2016,
-            committee_id='C12345',
-            purpose='MATERIALS',
-        ).all()
-        self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0].total, 538)
-        self.assertEqual(rows[0].count, 1)
-        filing.disbursement_description = 'BUMPER STICKERS'
-        db.session.add(filing)
-        db.session.commit()
-        db.session.refresh(rows[0])
-        self.assertEqual(rows[0].total, 538)
-        self.assertEqual(rows[0].count, 1)
-        filing.disb_desc = 'HANGING OUT'
-        db.session.add(filing)
-        db.session.commit()
-        db.session.refresh(rows[0])
-        self.assertEqual(rows[0].total, 0)
-        self.assertEqual(rows[0].count, 0)
-
-    def test_update_aggregate_purpose_existing(self):
-        db.session.execute('delete from disclosure.f_item_receipt_or_exp')
-        filing = self.NmlSchedBFactory(
-            rpt_yr=2015,
-            cmte_id='C12345',
-            disb_amt=538,
-            disb_dt=datetime.datetime(2015, 1, 1),
-            disb_tp='24K',
-        )
-        self.FItemReceiptOrExp(
-            sub_id=filing.sub_id,
-            rpt_yr=2015,
-        )
-        db.session.commit()
-        existing = models.ScheduleBByPurpose.query.filter_by(
-            purpose='CONTRIBUTIONS',
-            cycle=2016,
-        ).first()
-        total = existing.total
-        count = existing.count
-        filing = self.NmlSchedBFactory(
-            rpt_yr=2015,
-            cmte_id=existing.committee_id,
-            disb_amt=538,
-            disb_dt=datetime.datetime(2015, 1, 1),
-            disb_tp='24K',
-        )
-        self.FItemReceiptOrExp(
-            sub_id=filing.sub_id,
-            rpt_yr=2015,
-        )
-        db.session.commit()
-        db.session.refresh(existing)
-        self.assertEqual(existing.total, total + 538)
-        self.assertEqual(existing.count, count + 1)
+#    def test_update_aggregate_create(self):
+#        self._check_update_aggregate_create('contbr_zip', 'zip', models.ScheduleAByZip, '19041')
+#        self._check_update_aggregate_create('contbr_st', 'state', models.ScheduleAByState, 'PA')
+#        self._check_update_aggregate_create('contbr_employer', 'employer', models.ScheduleAByEmployer, 'PET CHOW')
+#        self._check_update_aggregate_create('contbr_occupation', 'occupation', models.ScheduleAByOccupation, 'FURRIER')
+#
+#    def test_update_aggregate_existing(self):
+#        faker = Faker()
+#        self._check_update_aggregate_existing('contbr_zip', 'zip', models.ScheduleAByZip, faker.zipcode())
+#        self._check_update_aggregate_existing('contbr_st', 'state', models.ScheduleAByState, faker.state_abbr())
+#        self._check_update_aggregate_existing(
+#            'contbr_employer', 'employer', models.ScheduleAByEmployer, faker.company()[:38])
+#        self._check_update_aggregate_existing(
+#            'contbr_occupation', 'occupation', models.ScheduleAByOccupation, faker.job()[:38])
+#
+#    def test_update_aggregate_state_existing_null_amount(self):
+#        existing = models.ScheduleAByState.query.filter_by(
+#            cycle=2016,
+#        ).first()
+#        total = existing.total
+#        count = existing.count
+#        self.NmlSchedAFactory(
+#            rpt_yr=2015,
+#            cmte_id=existing.committee_id,
+#            contbr_st=existing.state,
+#            contb_receipt_amt=None,
+#            contb_receipt_dt=datetime.datetime(2015, 1, 1),
+#            receipt_tp='15J',
+#        )
+#        db.session.flush()
+#        db.session.refresh(existing)
+#        self.assertEqual(existing.total, total)
+#        self.assertEqual(existing.count, count)
+#
+#    def test_update_aggregate_asize_create(self):
+#        filing = self.NmlSchedAFactory(
+#            rpt_yr=2015,
+#            cmte_id='C6789',
+#            contb_receipt_amt=538,
+#            contb_receipt_dt=datetime.datetime(2015, 1, 1),
+#            receipt_tp='15J',
+#        )
+#        self.FItemReceiptOrExp(
+#            sub_id=filing.sub_id,
+#            rpt_yr=2015,
+#        )
+#        db.session.commit()
+#        _rebuild_sched_a_by_size_merged()
+#        rows = models.ScheduleABySize.query.filter_by(
+#            cycle=2016,
+#            committee_id='C6789',
+#            size=500,
+#        ).all()
+#        self.assertEqual(len(rows), 1)
+#        self.assertEqual(rows[0].total, 538)
+#        self.assertEqual(rows[0].count, 1)
+#        filing.contb_receipt_amt = 53
+#        db.session.add(filing)
+#        db.session.commit()
+#        _rebuild_sched_a_by_size_merged()
+#        db.session.refresh(rows[0])
+#        self.assertEqual(rows[0].total, 0)
+#        self.assertEqual(rows[0].count, 0)
+#
+#    def test_update_aggregate_asize_existing(self):
+#        def get_existing():
+#            return models.ScheduleABySize.query.filter_by(
+#                size=500,
+#                cycle=2016,
+#            ).order_by(
+#                models.ScheduleABySize.committee_id,
+#            ).first()
+#        EXISTING_RECEIPT_AMOUNT = 504
+#        filing = self.NmlSchedAFactory(
+#            rpt_yr=2015,
+#            cmte_id='X1234',
+#            contb_receipt_amt=EXISTING_RECEIPT_AMOUNT,
+#            contb_receipt_dt=datetime.datetime(2015, 1, 1),
+#            receipt_tp='15J',
+#        )
+#        self.FItemReceiptOrExp(
+#            sub_id=filing.sub_id,
+#            rpt_yr=2015,
+#        )
+#        db.session.commit()
+#        _rebuild_sched_a_by_size_merged()
+#        existing = get_existing()
+#        total = existing.total
+#        count = existing.count
+#        NEW_RECEIPT_AMOUNT = 538
+#        filing = self.NmlSchedAFactory(
+#            rpt_yr=2015,
+#            cmte_id=existing.committee_id,
+#            contb_receipt_amt=NEW_RECEIPT_AMOUNT,
+#            contb_receipt_dt=datetime.datetime(2015, 1, 1),
+#            receipt_tp='15J',
+#        )
+#        self.FItemReceiptOrExp(
+#            sub_id=filing.sub_id,
+#            rpt_yr=2015,
+#        )
+#        db.session.commit()
+#        _rebuild_sched_a_by_size_merged()
+#        existing = get_existing()
+#        self.assertEqual(existing.total, total + NEW_RECEIPT_AMOUNT)
+#        self.assertEqual(existing.count, count + 1)
+#
+#    def test_update_aggregate_size_existing_merged(self):
+#        existing = models.ScheduleABySize.query.filter_by(
+#            size=0,
+#            cycle=2016,
+#        ).first()
+#        total = existing.total
+#        committee_id = existing.committee_id
+#        filing = self.NmlSchedAFactory(
+#            rpt_yr=2015,
+#            cmte_id=committee_id,
+#            contb_receipt_amt=75,
+#            contb_receipt_dt=datetime.datetime(2015, 1, 1),
+#            receipt_tp='15J',
+#        )
+#        self.FItemReceiptOrExp(
+#            sub_id=filing.sub_id,
+#            rpt_yr=2015,
+#        )
+#
+#        # Create a committee and committee report
+#        # Changed to point to sampled data, may be problematic in the future if det sum table
+#        # changes a lot and hence the tests need to test new behavior, believe it's fine for now though. -jcc
+#        rep = sa.Table('detsum_sample', db.metadata, autoload=True, autoload_with=db.engine)
+#        ins = rep.insert().values(
+#            indv_unitem_contb=20,
+#            cmte_id=committee_id,
+#            rpt_yr=2016,
+#            orig_sub_id=9,
+#            form_tp_cd='F3',
+#        )
+#        db.session.execute(ins)
+#        db.session.commit()
+#        db.session.execute('refresh materialized view ofec_totals_house_senate_mv')
+#        db.session.execute('refresh materialized view ofec_totals_combined_mv')
+#        db.session.commit()
+#        _rebuild_sched_a_by_size_merged()
+#        refreshed = models.ScheduleABySize.query.filter_by(
+#            size=0,
+#            cycle=2016,
+#            committee_id=committee_id,
+#        ).first()
+#        # Updated total includes new Schedule A filing and new report
+#        self.assertAlmostEqual(refreshed.total, total + 75 + 20)
+#        self.assertEqual(refreshed.count, None)
+#
+#    def test_update_aggregate_purpose_create(self):
+#        db.session.execute('delete from disclosure.f_item_receipt_or_exp')
+#        filing = self.NmlSchedBFactory(
+#            rpt_yr=2015,
+#            cmte_id='C12345',
+#            disb_amt=538,
+#            disb_dt=datetime.datetime(2015, 1, 1),
+#            disb_desc='CAMPAIGN BUTTONS',
+#            form_tp_cd='11'
+#        )
+#        self.FItemReceiptOrExp(
+#            sub_id=filing.sub_id,
+#            rpt_yr=2015,
+#        )
+#        db.session.commit()
+#        rows = models.ScheduleBByPurpose.query.filter_by(
+#            cycle=2016,
+#            committee_id='C12345',
+#            purpose='MATERIALS',
+#        ).all()
+#        self.assertEqual(len(rows), 1)
+#        self.assertEqual(rows[0].total, 538)
+#        self.assertEqual(rows[0].count, 1)
+#        filing.disbursement_description = 'BUMPER STICKERS'
+#        db.session.add(filing)
+#        db.session.commit()
+#        db.session.refresh(rows[0])
+#        self.assertEqual(rows[0].total, 538)
+#        self.assertEqual(rows[0].count, 1)
+#        filing.disb_desc = 'HANGING OUT'
+#        db.session.add(filing)
+#        db.session.commit()
+#        db.session.refresh(rows[0])
+#        self.assertEqual(rows[0].total, 0)
+#        self.assertEqual(rows[0].count, 0)
+#
+#    def test_update_aggregate_purpose_existing(self):
+#        db.session.execute('delete from disclosure.f_item_receipt_or_exp')
+#        filing = self.NmlSchedBFactory(
+#            rpt_yr=2015,
+#            cmte_id='C12345',
+#            disb_amt=538,
+#            disb_dt=datetime.datetime(2015, 1, 1),
+#            disb_tp='24K',
+#        )
+#        self.FItemReceiptOrExp(
+#            sub_id=filing.sub_id,
+#            rpt_yr=2015,
+#        )
+#        db.session.commit()
+#        existing = models.ScheduleBByPurpose.query.filter_by(
+#            purpose='CONTRIBUTIONS',
+#            cycle=2016,
+#        ).first()
+#        total = existing.total
+#        count = existing.count
+#        filing = self.NmlSchedBFactory(
+#            rpt_yr=2015,
+#            cmte_id=existing.committee_id,
+#            disb_amt=538,
+#            disb_dt=datetime.datetime(2015, 1, 1),
+#            disb_tp='24K',
+#        )
+#        self.FItemReceiptOrExp(
+#            sub_id=filing.sub_id,
+#            rpt_yr=2015,
+#        )
+#        db.session.commit()
+#        db.session.refresh(existing)
+#        self.assertEqual(existing.total, total + 538)
+#        self.assertEqual(existing.count, count + 1)
 
     def test_unverified_filers_excluded_in_candidates(self):
         candidate_history_count = models.CandidateHistory.query.count()


### PR DESCRIPTION
Ideally the functions that do the actual aggregate updates should also
be removed. As this is an emergency fix, I am only dropping the calls to
those functions, and not the functions themselves.