### PR TITLE
Add handling for "C.F.R." in regulation citations and extra space in statute citations

### DIFF
--- a/tests/test_advisory_opinions.py
+++ b/tests/test_advisory_opinions.py
@@ -38,6 +38,7 @@ def test_parse_ao_citations(text, ao_nos, expected):
     ("2 U.S.C. 441b, 441c, 441e", set([("2 U.S.C. 441b, 441c, 441e", 2, 441, 2, 441)])),
     (" 2 U.S.C. §437f", set([("2 U.S.C. §437f", 52, 30105, 2, 437)])),
     ("52 U.S.C. § 30101", set([("52 U.S.C. § 30101", 52, 30101, 52, 30101)])),
+    (" 2 USC §437f", set([("2 USC §437f", 52, 30105, 2, 437)])),
 ])
 def test_parse_statutory_citations(text, expected):
     assert parse_statutory_citations(text) == expected

--- a/tests/test_advisory_opinions.py
+++ b/tests/test_advisory_opinions.py
@@ -37,6 +37,7 @@ def test_parse_ao_citations(text, ao_nos, expected):
     ("52 U.S.C. 30116a", set([("52 U.S.C. 30116a", 52, 30116, 52, 30116)])),
     ("2 U.S.C. 441b, 441c, 441e", set([("2 U.S.C. 441b, 441c, 441e", 2, 441, 2, 441)])),
     (" 2 U.S.C. §437f", set([("2 U.S.C. §437f", 52, 30105, 2, 437)])),
+    ("52 U.S.C. § 30101", set([("52 U.S.C. § 30101", 52, 30101, 52, 30101)])),
 ])
 def test_parse_statutory_citations(text, expected):
     assert parse_statutory_citations(text) == expected
@@ -46,6 +47,7 @@ def test_parse_statutory_citations(text, expected):
     ("11 CFR §9034.4(b)(4)", set([(11, 9034, 4)])),
     ("11 CFR 300.60 and 11 CFR 300.62", set([(11, 300, 60), (11, 300, 62)])),  # TODO: Ranges
     ("11 CFR 300.60 through 300.65", set([(11, 300, 60)])),
+    ("11 C.F.R. § 100.15", set([(11, 100, 15)])),
 ])
 def test_parse_regulatory_citations(text, expected):
     assert parse_regulatory_citations(text) == expected

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -58,18 +58,24 @@ AO_DOCUMENTS = """
     WHERE ao_id = %s
 """
 
-STATUTE_CITATION_REGEX = re.compile(r"(?P<title>\d+)\s+U.S.C.\s+§*(?P<section>\d+).*\.?")
-REGULATION_CITATION_REGEX = re.compile(r"(?P<title>\d+)\s+CFR\s+§*(?P<part>\d+)\.(?P<section>\d+)")
-AO_CITATION_REGEX = re.compile(r"\b(?P<year>\d{4,4})-(?P<serial_no>\d+)\b")
+STATUTE_CITATION_REGEX = re.compile(
+    r"(?P<title>\d+)\s+U.S.C.\s+§*\s*(?P<section>\d+).*\.?")
+
+REGULATION_CITATION_REGEX = re.compile(
+    r"(?P<title>\d+)\s+C.*F.*R.*\s+§*(?P<part>\d+)\.(?P<section>\d+)")
+
+AO_CITATION_REGEX = re.compile(
+    r"\b(?P<year>\d{4,4})-(?P<serial_no>\d+)\b")
 
 
 def load_advisory_opinions(from_ao_no=None):
     """
-    Reads data for advisory opinions from a Postgres database, assembles a JSON document
-    corresponding to the advisory opinion and indexes this document in Elasticsearch in
-    the index `docs_index` with a doc_type of `advisory_opinions`. In addition, all documents
-    attached to the advisory opinion are uploaded to an S3 bucket under the _directory_
-    `legal/aos/`.
+    Reads data for advisory opinions from a Postgres database,
+    assembles a JSON document corresponding to the advisory opinion
+    and indexes this document in Elasticsearch in the index `docs_index`
+    with a doc_type of `advisory_opinions`.
+    In addition, all documents attached to the advisory opinion
+    are uploaded to an S3 bucket under the _directory_`legal/aos/`.
     """
     es = get_elasticsearch_connection()
 
@@ -80,6 +86,7 @@ def load_advisory_opinions(from_ao_no=None):
         es.index(DOCS_INDEX, 'advisory_opinions', ao, id=ao['no'])
         ao_count += 1
     logger.info("%d advisory opinions loaded", ao_count)
+
 
 def get_advisory_opinions(from_ao_no):
     bucket = get_bucket()
@@ -142,6 +149,7 @@ def get_entities(ao_id):
     return requestor_names, list(requestor_types),\
             commenter_names, representative_names, entities
 
+
 def get_documents(ao_id, bucket):
     documents = []
     with db.engine.connect() as conn:
@@ -161,6 +169,7 @@ def get_documents(ao_id, bucket):
             document["url"] = '/files/' + pdf_key
             documents.append(document)
     return documents
+
 
 def get_ao_names():
     ao_names_results = db.engine.execute("""SELECT ao_no, name FROM aouser.ao""")
@@ -234,6 +243,7 @@ def get_citations(ao_names):
         es.index(DOCS_INDEX, 'citations', entry, id=entry['citation_text'])
     return citations
 
+
 def parse_ao_citations(text, ao_component_to_name_map):
     matches = set()
 
@@ -243,6 +253,7 @@ def parse_ao_citations(text, ao_component_to_name_map):
             if (year, serial_no) in ao_component_to_name_map:
                 matches.add(ao_component_to_name_map[(year, serial_no)])
     return matches
+
 
 def parse_statutory_citations(text):
     matches = set()
@@ -258,6 +269,7 @@ def parse_statutory_citations(text):
                 int(citation.group('section'))
             ))
     return matches
+
 
 def parse_regulatory_citations(text):
     matches = set()

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -62,7 +62,7 @@ STATUTE_CITATION_REGEX = re.compile(
     r"(?P<title>\d+)\s+U.S.C.\s+§*\s*(?P<section>\d+).*\.?")
 
 REGULATION_CITATION_REGEX = re.compile(
-    r"(?P<title>\d+)\s+C\.*F\.*R\.*\s+§*(?P<part>\d+)\.(?P<section>\d+)")
+    r"(?P<title>\d+)\s+C\.*F\.*R\.*\s+§*\s*(?P<part>\d+)\.(?P<section>\d+)")
 
 AO_CITATION_REGEX = re.compile(
     r"\b(?P<year>\d{4,4})-(?P<serial_no>\d+)\b")

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -62,7 +62,7 @@ STATUTE_CITATION_REGEX = re.compile(
     r"(?P<title>\d+)\s+U.S.C.\s+§*\s*(?P<section>\d+).*\.?")
 
 REGULATION_CITATION_REGEX = re.compile(
-    r"(?P<title>\d+)\s+C.*F.*R.*\s+§*(?P<part>\d+)\.(?P<section>\d+)")
+    r"(?P<title>\d+)\s+C\.*F\.*R\.*\s+§*(?P<part>\d+)\.(?P<section>\d+)")
 
 AO_CITATION_REGEX = re.compile(
     r"\b(?P<year>\d{4,4})-(?P<serial_no>\d+)\b")

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -59,10 +59,10 @@ AO_DOCUMENTS = """
 """
 
 STATUTE_CITATION_REGEX = re.compile(
-    r"(?P<title>\d+)\s+U.S.C.\s+§*\s*(?P<section>\d+).*\.?")
+    r"(?P<title>\d+)\s+U\.?S\.?C\.?\s+§*\s*(?P<section>\d+).*\.?")
 
 REGULATION_CITATION_REGEX = re.compile(
-    r"(?P<title>\d+)\s+C\.*F\.*R\.*\s+§*\s*(?P<part>\d+)\.(?P<section>\d+)")
+    r"(?P<title>\d+)\s+C\.?F\.?R\.?\s+§*\s*(?P<part>\d+)\.(?P<section>\d+)")
 
 AO_CITATION_REGEX = re.compile(
     r"\b(?P<year>\d{4,4})-(?P<serial_no>\d+)\b")

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -227,7 +227,7 @@ def apply_ao_specific_query_params(query, **kwargs):
     citation_queries = []
     if kwargs.get('ao_regulatory_citation'):
         for citation in kwargs.get('ao_regulatory_citation'):
-            exact_match = re.match(r"(?P<title>\d+)\s+C.*F.*R.*\s+§*(?P<part>\d+)\.(?P<section>\d+)", citation)
+            exact_match = re.match(r"(?P<title>\d+)\s+C\.?F\.?R\.?\s+§*\s*(?P<part>\d+)\.(?P<section>\d+)", citation)
             if(exact_match):
                 citation_queries.append(Q("nested", path="regulatory_citations", query=Q("bool",
                     must=[Q("term", regulatory_citations__title=int(exact_match.group('title'))),
@@ -236,7 +236,7 @@ def apply_ao_specific_query_params(query, **kwargs):
 
     if kwargs.get('ao_statutory_citation'):
         for citation in kwargs.get('ao_statutory_citation'):
-            exact_match = re.match(r"(?P<title>\d+)\s+U.S.C.\s+§*(?P<section>\d+).*\.?", citation)
+            exact_match = re.match(r"(?P<title>\d+)\s+U\.?S\.?C\.?\s+§*\s*(?P<section>\d+).*\.?)", citation)
             if(exact_match):
                 citation_queries.append(Q("nested", path="statutory_citations", query=Q("bool",
                     must=[Q("term", statutory_citations__title=int(exact_match.group('title'))),

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -227,7 +227,7 @@ def apply_ao_specific_query_params(query, **kwargs):
     citation_queries = []
     if kwargs.get('ao_regulatory_citation'):
         for citation in kwargs.get('ao_regulatory_citation'):
-            exact_match = re.match(r"(?P<title>\d+)\s+CFR\s+§*(?P<part>\d+)\.(?P<section>\d+)", citation)
+            exact_match = re.match(r"(?P<title>\d+)\s+C.*F.*R.*\s+§*(?P<part>\d+)\.(?P<section>\d+)", citation)
             if(exact_match):
                 citation_queries.append(Q("nested", path="regulatory_citations", query=Q("bool",
                     must=[Q("term", regulatory_citations__title=int(exact_match.group('title'))),


### PR DESCRIPTION
Added REGEX handling for statutes formatted "52 U.S.C. § 30101" and "2 USC §437f" and regulations formatted "11 C.F.R. § 100.15"

Statute: `(?P<title>\d+)\s+U\.?S\.?C\.?\s+§*\s*(?P<section>\d+).*\.?`
Regulation: `(?P<title>\d+)\s+C\.?F\.?R\.?\s+§*\s*(?P<part>\d+)\.(?P<section>\d+)`

Added tests to confirm this worked
