### PR TITLE
Update nvm and Node.js setup in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,14 +42,14 @@ jobs:
       - run:
           name: Install node dependencies
           command: |
-            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.4/install.sh | bash
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
             echo ". ~/.nvm/nvm.sh" >> $BASH_ENV
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-            nvm install 8.6.0
-            nvm use 8.6.0
-            nvm alias default 8.6.0
+            nvm install 8.9.1
+            nvm use 8.9.1
+            nvm alias default 8.9.1
             npm install -g npm swagger-tools
             npm install
             npm run build

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "mkdir -p static/swagger-ui && cp -R node_modules/swagger-ui/dist static/swagger-ui/"
   },
   "engines": {
-    "node": "8.6.0",
-    "npm": "5.4.2"
+    "node": "8.9.1",
+    "npm": "5.5.1"
   }
 }


### PR DESCRIPTION
This changeset updates the nvm and Node.js setup to use the latest versions of each. Node.js has a new LTS version that we are now leveraging, so we want to make sure CircleCI is using it as well in our builds. At the time of this PR, that is version 8.9.1 (Carbon).