### PR TITLE
Remove duplicate AO statute citations

### DIFF
--- a/tests/test_advisory_opinions.py
+++ b/tests/test_advisory_opinions.py
@@ -41,6 +41,7 @@ def test_parse_ao_citations(text, ao_nos, expected):
     (" 2 U.S.C. §437f", set([(52, 30105)])),
     ("52 U.S.C. § 30101", set([(52, 30101)])),
     (" 2 USC §437f", set([(52, 30105)])),
+    ("52 U.S.C. § 30101, 52 U.S.C. § 30101", set([(52, 30101)])),
 ])
 def test_parse_statutory_citations(text, expected):
     assert parse_statutory_citations(text) == expected
@@ -52,6 +53,7 @@ def test_parse_statutory_citations(text, expected):
     ("11 CFR 300.60 and 11 CFR 300.62", set([(11, 300, 60), (11, 300, 62)])),  # TODO: Ranges
     ("11 CFR 300.60 through 300.65", set([(11, 300, 60)])),
     ("11 C.F.R. § 100.15", set([(11, 100, 15)])),
+    ("11 C.F.R. § 100.15, 11 C.F.R. § 100.15", set([(11, 100, 15)])),
 ])
 def test_parse_regulatory_citations(text, expected):
     assert parse_regulatory_citations(text) == expected

--- a/tests/test_advisory_opinions.py
+++ b/tests/test_advisory_opinions.py
@@ -16,6 +16,7 @@ from webservices.legal_docs.advisory_opinions import (
 
 EMPTY_SET = set()
 
+
 @pytest.mark.parametrize("text,ao_nos,expected", [
     ("1994-01", {"1994-01"}, {"1994-01"}),
     ("Nothing here", {"1994-01"}, EMPTY_SET),
@@ -32,16 +33,18 @@ def test_parse_ao_citations(text, ao_nos, expected):
     ao_component_to_name_map = {tuple(map(int, a.split('-'))): a for a in ao_nos}
     assert parse_ao_citations(text, ao_component_to_name_map) == expected
 
+
 @pytest.mark.parametrize("text,expected", [
-    ("2 U.S.C. 432h", set([("2 U.S.C. 432h", 52, 30102, 2, 432)])),
-    ("52 U.S.C. 30116a", set([("52 U.S.C. 30116a", 52, 30116, 52, 30116)])),
-    ("2 U.S.C. 441b, 441c, 441e", set([("2 U.S.C. 441b, 441c, 441e", 2, 441, 2, 441)])),
-    (" 2 U.S.C. §437f", set([("2 U.S.C. §437f", 52, 30105, 2, 437)])),
-    ("52 U.S.C. § 30101", set([("52 U.S.C. § 30101", 52, 30101, 52, 30101)])),
-    (" 2 USC §437f", set([("2 USC §437f", 52, 30105, 2, 437)])),
+    ("2 U.S.C. 432h", set([(52, 30102)])),
+    ("52 U.S.C. 30116a", set([(52, 30116)])),
+    ("2 U.S.C. 441b, 441c, 441e", set([(2, 441)])),
+    (" 2 U.S.C. §437f", set([(52, 30105)])),
+    ("52 U.S.C. § 30101", set([(52, 30101)])),
+    (" 2 USC §437f", set([(52, 30105)])),
 ])
 def test_parse_statutory_citations(text, expected):
     assert parse_statutory_citations(text) == expected
+
 
 @pytest.mark.parametrize("text,expected", [
     ("11 CFR 113.2", set([(11, 113, 2)])),
@@ -52,6 +55,7 @@ def test_parse_statutory_citations(text, expected):
 ])
 def test_parse_regulatory_citations(text, expected):
     assert parse_regulatory_citations(text) == expected
+
 
 class TestLoadAdvisoryOpinions(BaseTestCase):
     @classmethod
@@ -82,7 +86,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             "summary": "An AO summary",
             "request_date": datetime.date(2016, 6, 10),
             "issue_date": datetime.date(2016, 12, 15),
-            "is_pending" : True,
+            "is_pending": True,
             "status": "Pending",
             "ao_citations": [],
             "statutory_citations": [],
@@ -245,8 +249,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
 
         actual_ao = next(get_advisory_opinions(None))
 
-        assert actual_ao["statutory_citations"] == [{'title': 52, 'section': 30101,
-            'former_title': 2, 'former_section': 431, 'text': '2 U.S.C. 431 and some text'}]
+        assert actual_ao["statutory_citations"] == [{'title': 52, 'section': 30101}]
 
     @patch("webservices.legal_docs.advisory_opinions.get_bucket")
     @patch("webservices.legal_docs.advisory_opinions.get_elasticsearch_connection")

--- a/tests/test_advisory_opinions.py
+++ b/tests/test_advisory_opinions.py
@@ -40,8 +40,8 @@ def test_parse_ao_citations(text, ao_nos, expected):
     ("2 U.S.C. 441b, 441c, 441e", set([(2, 441)])),
     (" 2 U.S.C. §437f", set([(52, 30105)])),
     ("52 U.S.C. § 30101", set([(52, 30101)])),
-    (" 2 USC §437f", set([(52, 30105)])),
-    ("52 U.S.C. § 30101, 52 U.S.C. § 30101", set([(52, 30101)])),
+    (" 2 USC §437f **test with no . in USC**", set([(52, 30105)])),
+
 ])
 def test_parse_statutory_citations(text, expected):
     assert parse_statutory_citations(text) == expected

--- a/tests/test_advisory_opinions.py
+++ b/tests/test_advisory_opinions.py
@@ -41,7 +41,7 @@ def test_parse_ao_citations(text, ao_nos, expected):
     (" 2 U.S.C. §437f", set([(52, 30105)])),
     ("52 U.S.C. § 30101", set([(52, 30101)])),
     (" 2 USC §437f **test with no . in USC**", set([(52, 30105)])),
-
+    ("52 U.S.C. § 30101 **newline needed to ensure two entries**,\n 52 USC. § 30101 other words", set([(52, 30101)])),
 ])
 def test_parse_statutory_citations(text, expected):
     assert parse_statutory_citations(text) == expected
@@ -53,7 +53,7 @@ def test_parse_statutory_citations(text, expected):
     ("11 CFR 300.60 and 11 CFR 300.62", set([(11, 300, 60), (11, 300, 62)])),  # TODO: Ranges
     ("11 CFR 300.60 through 300.65", set([(11, 300, 60)])),
     ("11 C.F.R. § 100.15", set([(11, 100, 15)])),
-    ("11 C.F.R. § 100.15, 11 C.F.R. § 100.15", set([(11, 100, 15)])),
+    ("11 C.F.R. § 100.15 **newline needed to ensure two entries**,\n 11 C.F.R. § 100.15", set([(11, 100, 15)])),
 ])
 def test_parse_regulatory_citations(text, expected):
     assert parse_regulatory_citations(text) == expected

--- a/webservices/legal_docs/__init__.py
+++ b/webservices/legal_docs/__init__.py
@@ -41,6 +41,7 @@ def load_all_legal_docs():
 def reinitialize_all_legal_docs():
     """
     Creates the Elasticsearch index and loads all the different types of legal documents.
+    This would lead to a brief outage while the docs are reloaded.
     """
     initialize_legal_docs()
     load_all_legal_docs()

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -237,8 +237,7 @@ def get_citations(ao_names):
             {"no": c, "name": ao_names[c]}
             for c in raw_citations[ao]["aos_cited_by"]], key=lambda d: d["no"])
         citations[ao]["statutes"] = sorted([
-            # Comment for testing: {"text": c[0], "title": c[1], "section": c[2], "former_title": c[3], "former_section": c[4]}
-            {"title": c[0], "section": c[1]}#, "former_title": c[2], "former_section": c[3]}
+            {"title": c[0], "section": c[1]}
             for c in raw_citations[ao]["statutes"]], key=lambda d: (d["title"], d["section"]))
         citations[ao]["regulations"] = sorted([
             {"title": c[0], "part": c[1], "section": c[2]}
@@ -247,17 +246,11 @@ def get_citations(ao_names):
     es = get_elasticsearch_connection()
 
     for citation in all_regulatory_citations:
-        entry = {
-            'citation_text': '%d CFR §%d.%d' % (citation[0], citation[1], citation[2]),
-            'citation_type': 'regulation'}
+        entry = {'citation_text': '%d CFR §%d.%d'
+                 % (citation[0], citation[1], citation[2]),'citation_type': 'regulation'}
         es.index(DOCS_INDEX, 'citations', entry, id=entry['citation_text'])
 
     for citation in all_statutory_citations:
-        # if citation[3] != citation[1]:
-        #     entry = {'citation_text': '%s U.S.C. §%s' %
-        #              (citation[1], citation[2]),
-        #              'formerly': '%d U.S.C. §%d' % (citation[3], citation[4])}
-        # else:
         entry = {'citation_text': '%d U.S.C. §%d'
                  % (citation[0], citation[1]), 'citation_type': 'statute'}
         es.index(DOCS_INDEX, 'citations', entry, id=entry['citation_text'])
@@ -282,11 +275,8 @@ def parse_statutory_citations(text):
             new_title, new_section = reclassify_archived_mur_statutory_citation(
                 citation.group('title'), citation.group('section'))
             matches.add((
-                # citation.group(0), #remove full text
                 int(new_title),
-                int(new_section),
-                # int(citation.group('title')), # take these out too?
-                # int(citation.group('section')) # take these out too?
+                int(new_section)
             ))
     return matches
 

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -237,7 +237,8 @@ def get_citations(ao_names):
             {"no": c, "name": ao_names[c]}
             for c in raw_citations[ao]["aos_cited_by"]], key=lambda d: d["no"])
         citations[ao]["statutes"] = sorted([
-            {"text": c[0], "title": c[1], "section": c[2], "former_title": c[3], "former_section": c[4]}
+            # Comment for testing: {"text": c[0], "title": c[1], "section": c[2], "former_title": c[3], "former_section": c[4]}
+            {"title": c[0], "section": c[1]}#, "former_title": c[2], "former_section": c[3]}
             for c in raw_citations[ao]["statutes"]], key=lambda d: (d["title"], d["section"]))
         citations[ao]["regulations"] = sorted([
             {"title": c[0], "part": c[1], "section": c[2]}
@@ -252,12 +253,13 @@ def get_citations(ao_names):
         es.index(DOCS_INDEX, 'citations', entry, id=entry['citation_text'])
 
     for citation in all_statutory_citations:
-        if citation[3] != citation[1]:
-            entry = {'citation_text': '%s U.S.C. §%s' % (citation[1], citation[2]),
-                'formerly': '%d U.S.C. §%d' % (citation[3], citation[4]),
-                'citation_type': 'statute'}
-        else:
-            entry = {'citation_text': '%d U.S.C. §%d' % (citation[1], citation[2]), 'citation_type': 'statute'}
+        # if citation[3] != citation[1]:
+        #     entry = {'citation_text': '%s U.S.C. §%s' %
+        #              (citation[1], citation[2]),
+        #              'formerly': '%d U.S.C. §%d' % (citation[3], citation[4])}
+        # else:
+        entry = {'citation_text': '%d U.S.C. §%d'
+                 % (citation[0], citation[1]), 'citation_type': 'statute'}
         es.index(DOCS_INDEX, 'citations', entry, id=entry['citation_text'])
     return citations
 
@@ -280,11 +282,11 @@ def parse_statutory_citations(text):
             new_title, new_section = reclassify_archived_mur_statutory_citation(
                 citation.group('title'), citation.group('section'))
             matches.add((
-                citation.group(0),
+                # citation.group(0), #remove full text
                 int(new_title),
                 int(new_section),
-                int(citation.group('title')),
-                int(citation.group('section'))
+                # int(citation.group('title')), # take these out too?
+                # int(citation.group('section')) # take these out too?
             ))
     return matches
 


### PR DESCRIPTION
Addresses https://github.com/18F/openFEC/issues/2762

For AO statute citations, prior citations and additional text were being added to the matches set [here](https://github.com/18F/openFEC/pull/2781/files#diff-324d3f17f824202b1e914e4bedbc79b5R271). These fields weren't being used and were creating duplicate statute citations for AO's.

AO 2012-36 [local link](http://127.0.0.1:8000/data/legal/advisory-opinions/2012-36/) now only showing the 2 citations. 

## Before
![image](https://user-images.githubusercontent.com/31420082/33855289-780f4268-de92-11e7-8cd5-1a89cb7d4c85.png)


## After
![image.png](https://images.zenhubusercontent.com/59a579f28f62dc7798c47359/83b66c8f-9a50-432b-8240-4d8146e29436)

- [x] Verify that we don't need AO statute citation former title/section anywhere else in the app
- [x] If we verify that we don't need them, remove statute text and former title/section from our `test_advisory_opinions.py` tests
- [x] Add tests for duplicate citations (regs and statutes)

Discovered bug with 2 USC mapping with letters, got most the way done with it, then it proved to be complicated, so rolled back and split up the work into a two issues - see https://github.com/18F/openFEC/issues/2803