### PR TITLE
Add swagger-tools installation back to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,12 @@ Use `npm` to install JavaScript dependencies:
 
 ```
 nvm use --lts
+npm install -g swagger-tools
 npm install
 npm run build
 ```
+
+*Note: `swagger-tools` is required for testing the API documentation via the automated tests and must be installed globally as shown above.*
 
 ##### Git hooks
 This repo includes optional post-merge and post-checkout hooks to ensure that


### PR DESCRIPTION
Fixes #2795

This changeset adds the line to install `swagger-tools` back into the README.md file after we had inadvertently taken it out.  These tools are required in order to run one of the automated tests we have that tests to ensure the API documention is generated correctly.  I have included an extra note in the README about this requirement so folks know why it is there and what purpose it serves.