### PR TITLE
[WIP] Use filename to create PDF instead of document_id for AOs and MURs

### DIFF
--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -180,12 +180,27 @@ def get_documents(ao_id, bucket):
                 "text": row["ocrtext"],
                 "date": row["document_date"],
             }
+            # should we instead save the pdf_key in document['pdf_key']??
             pdf_key = "legal/aos/%s.pdf" % row["document_id"]
             logger.debug("S3: Uploading {}".format(pdf_key))
             bucket.put_object(Key=pdf_key, Body=bytes(row["fileimage"]),
                     ContentType="application/pdf", ACL="public-read")
             document["url"] = '/files/' + pdf_key
             documents.append(document)
+
+    # delete PDF's not being linked to (old ID's)
+    # will this be super slow? should we really do this each time we reload?
+    for obj in bucket.objects.filter(Prefix="legal/aos"):
+        # we don't save pdf_key in documents so you need a better way to access it
+        # strip it from obj['key']?
+
+        # key = 'legal/aos/%s.pdf' % row["document_id"]
+        # document['document_id'] = 232435
+        obj_id = int(re.findall('//d+', obj['key']))
+        print(obj_id)
+        if obj != documents['document_id']:
+            obj.delete()
+
     return documents
 
 

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -46,15 +46,18 @@ AO_ENTITIES = """
 
 AO_DOCUMENTS = """
     SELECT
-        document_id,
-        filename,
-        ocrtext,
-        fileimage,
-        description,
-        category,
-        document_date
-    FROM aouser.document
-    WHERE ao_id = %s
+        ao.ao_no,
+        doc.document_id,
+        doc.filename,
+        doc.ocrtext,
+        doc.fileimage,
+        doc.description,
+        doc.category,
+        doc.document_date
+    FROM aouser.document doc
+    INNER JOIN aouser.ao ao
+        ON ao.ao_id = doc.ao_id
+    WHERE doc.ao_id = %s
 """
 
 STATUTE_CITATION_REGEX = re.compile(
@@ -182,22 +185,13 @@ def get_documents(ao_id, bucket):
                 "text": row["ocrtext"],
                 "date": row["document_date"],
             }
-            document['pdf_key'] = "legal/aos/%s" % row["filename"]
-            logger.info("S3: Uploading {}".format(document['pdf_key']))
-            bucket.put_object(Key=document['pdf_key'], Body=bytes(row["fileimage"]),
+            # TODO: Test this in dev - do spaces automatically get swapped with %?
+            pdf_key = "legal/aos/{0}/{1}".format(row['ao_no'], row["filename"])
+            logger.info("S3: Uploading {}".format(pdf_key))
+            bucket.put_object(Key=pdf_key, Body=bytes(row["fileimage"]),
                     ContentType="application/pdf", ACL="public-read")
-            document["url"] = '/files/' + document['pdf_key']
+            document["url"] = '/files/' + pdf_key
             documents.append(document)
-
-    # !NOTE! this isn't working yet. Problem with matching logic.
-    # I think we need a list of all the document pdf_key's and then "obj.key not in"
-    # delete old AO PDF's no longer linked to AOs
-    for obj in bucket.objects.filter(Prefix="legal/aos"):
-        for document in documents:
-            if obj.key != document['pdf_key']:
-                logger.info("S3: Deleting {} - no longer linked.".format(obj.key))
-                # obj.delete()
-                logger.info("Not really, yet")
 
     return documents
 

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -182,18 +182,22 @@ def get_documents(ao_id, bucket):
                 "text": row["ocrtext"],
                 "date": row["document_date"],
             }
-            document['pdf_key'] = "legal/aos/%s.pdf" % row["document_id"]
+            document['pdf_key'] = "legal/aos/%s" % row["filename"]
             logger.info("S3: Uploading {}".format(document['pdf_key']))
             bucket.put_object(Key=document['pdf_key'], Body=bytes(row["fileimage"]),
                     ContentType="application/pdf", ACL="public-read")
             document["url"] = '/files/' + document['pdf_key']
             documents.append(document)
 
+    # !NOTE! this isn't working yet. Problem with matching logic.
+    # I think we need a list of all the document pdf_key's and then "obj.key not in"
     # delete old AO PDF's no longer linked to AOs
     for obj in bucket.objects.filter(Prefix="legal/aos"):
-        if obj['key'] != documents['pdf_key']:
-            logger.info("S3: Deleting {}".format(obj['key']))
-            obj.delete()
+        for document in documents:
+            if obj.key != document['pdf_key']:
+                logger.info("S3: Deleting {} - no longer linked.".format(obj.key))
+                # obj.delete()
+                logger.info("Not really, yet")
 
     return documents
 


### PR DESCRIPTION
Use filename to create AO, MUR document pdfs instead of ID, ensuring we have permalinks. Add AO/MUR number to URL IE `legal/aos/2017-12/201712C_3.pdf`

We'll need to delete PDFs from S3 with old naming conventions.

- [ ] Manually deploy local branch to `dev` and reload all the AO's and MURs and test the new links - do the ones that have filenames with spaces work or do we have to modify them? Should we just go ahead and replace spaces with "_" ? "-"? I think dashes might be better, but the new naming convention has underscores in them so underscores might be more consistent:  "201712C_3.pdf"
 
- [ ] Reload all AOs, MURs with new naming convention in `prod`, `dev`, `stage`
- [ ] Delete all the old, unlinked PDFs from s3 in `prod`, `dev`, `stage`