### PR TITLE
Updated redis-py to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,4 +39,4 @@ smart_open==1.5.3
 # Task queue
 celery==4.1.0
 celery-once==1.2.0
-redis==2.10.5
+redis==2.10.6


### PR DESCRIPTION
Part of #2773

This changeset updates the `redis-py` dependency to the latest version.  We are hoping that by doing this we will see some improvement in our Celery worker stability when it comes to dealing with dropped connections to Redis.