### PR TITLE
[WIP] Add request_type parameter

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -259,6 +259,7 @@ filings = {
     'is_amended': fields.Bool(description='Filing has been amended'),
     'most_recent': fields.Bool(description='Filing is either new or is the most-recently filed amendment'),
     'report_type': fields.List(IStr, description=docs.REPORT_TYPE),
+    'request_type': fields.List(IStr, description=docs.REQUEST_TYPE),
     'document_type': fields.List(IStr, description=docs.DOC_TYPE),
     'beginning_image_number': fields.List(fields.Str, description=docs.BEGINNING_IMAGE_NUMBER),
     'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -797,7 +797,26 @@ REPORT_TYPE = 'Name of report where the underlying data comes from:\n\
          (YE)\n\
 '
 
-REQUEST_TYPE = 'RFAI types. For example, form 1 RFAI is equal to 1. Ex: request_type=1'
+REQUEST_TYPE = 'Requests for additional information (RFAIs)\n\
+sent to filers.\n\
+The request type is based on\n\
+the type of document filed:\n\
+    - 1 Statement of \n\
+        Organization\n\
+    - 2 Report of Receipts\n\
+        and Expenditures\n\
+        (Form 3 and 3X)\n\
+    - 3 Second Notice - Reports\n\
+    - 4 Request for\n\
+        Additional Information\n\
+    - 5 Informational - Reports\n\
+    - 6 Second Notice -\n\
+        Statement of Organization\n\
+    - 7 Failure to File\n\
+    - 8 From Public Disclosure\n\
+    - 9 From Multi\n\
+        Candidate Status\n\
+'
 
 REPORT_TYPE_W_EXCLUDE = 'Report type; prefix with "-" to exclude. '+REPORT_TYPE
 

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -796,6 +796,9 @@ REPORT_TYPE = 'Name of report where the underlying data comes from:\n\
     - MSY Monthly Semi-Annual\n\
          (YE)\n\
 '
+
+REQUEST_TYPE = 'RFAI types. For example, form 1 RFAI is equal to 1. Ex: request_type=1'
+
 REPORT_TYPE_W_EXCLUDE = 'Report type; prefix with "-" to exclude. '+REPORT_TYPE
 
 RECEIPT_DATE = 'Date the FEC received the electronic or paper record'

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -29,6 +29,7 @@ class BaseFilings(views.ApiResource):
         ('document_type', models.Filings.document_type),
         ('report_year', models.Filings.report_year),
         ('form_type', models.Filings.form_type),
+        ('request_type', models.Filings.request_type),
         ('file_number', models.Filings.file_number),
         ('primary_general_indicator', models.Filings.primary_general_indicator),
         ('amendment_indicator', models.Filings.amendment_indicator),


### PR DESCRIPTION
## Summary

- Addresses # https://github.com/18F/fec-cms/issues/1663
In order to filter by form 1 RFAI, the request_type parameter was needed in the API. This will allow filtering for these types of RFAI's within the Statement of organization filings datatable on the committee page.

## To do:
- [ ] Need RAD to help with the API documentation for this additional parameter. They are working on some wording.

## Impacted areas of the application
List general components of the application that this PR will affect:
-  /filings/ API endpoint

## Related PRs
TBD