### PR TITLE
New migration: modify ofec_elections_list_mv to handle multiple incumbents

### DIFF
--- a/data/migrations/V0050__add_ref_zip_to_district.sql
+++ b/data/migrations/V0050__add_ref_zip_to_district.sql
@@ -1,0 +1,24 @@
+-- This table added with issue #2876
+
+CREATE TABLE staging.ref_zip_to_district
+(
+ zip_district_id	numeric(17,0)	
+ ,state_abbrevation	varchar(2)	NOT NULL
+ ,state_name	varchar(24)	NOT NULL
+ ,fips_state_code	varchar(2)	NOT NULL
+ ,district	varchar(2)	NOT NULL
+ ,zip_code	varchar(5)	NOT NULL
+ ,active	varchar(1)	
+ ,census_year	numeric(4,0)	NOT NULL
+ ,redistricted_election_year	numeric(4,0)	NOT NULL
+ ,update_date	timestamp	NOT NULL
+ ,notes	varchar(200)	
+ ,pg_date	timestamp without time zone DEFAULT now()
+)
+WITH (OIDS=FALSE);
+
+
+ALTER TABLE staging.ref_zip_to_district OWNER TO fec;
+GRANT ALL ON TABLE staging.ref_zip_to_district TO fec;
+GRANT SELECT ON TABLE staging.ref_zip_to_district TO fec_read;
+GRANT SELECT ON TABLE staging.ref_zip_to_district TO openfec_read;

--- a/data/migrations/V0051__alter_ofec_elections_list_mv.sql
+++ b/data/migrations/V0051__alter_ofec_elections_list_mv.sql
@@ -63,7 +63,10 @@ CREATE INDEX ON ofec_elections_list_mv_TMP(cycle);
 CREATE INDEX ON ofec_elections_list_mv_TMP(incumbent_id);
 CREATE INDEX ON ofec_elections_list_mv_TMP(incumbent_name);
 
--- ------------------------------------------------------
+--------------------------------------------------------
+
 DROP MATERIALIZED VIEW IF EXISTS ofec_elections_list_mv;
 
 ALTER MATERIALIZED VIEW IF EXISTS ofec_elections_list_mv_TMP RENAME TO ofec_elections_list_mv;
+
+SELECT rename_indexes('ofec_elections_list_mv');

--- a/data/migrations/V0051__alter_ofec_elections_list_mv.sql
+++ b/data/migrations/V0051__alter_ofec_elections_list_mv.sql
@@ -1,8 +1,8 @@
 SET search_path = public, pg_catalog;
 
-DROP MATERIALIZED VIEW IF EXISTS ofec_elections_list_mv_TMP;
+DROP MATERIALIZED VIEW IF EXISTS ofec_elections_list_mv_tmp;
 
-CREATE MATERIALIZED VIEW ofec_elections_list_mv_TMP AS
+CREATE MATERIALIZED VIEW ofec_elections_list_mv_tmp AS
 
 WITH incumbents AS (
 --So we don't show duplicate elections
@@ -49,24 +49,24 @@ LEFT JOIN incumbents
 ORDER BY district ASC
 ;
 
-ALTER TABLE ofec_elections_list_mv_TMP OWNER TO fec;
-GRANT ALL ON TABLE ofec_elections_list_mv_TMP TO fec;
-GRANT SELECT ON TABLE ofec_elections_list_mv_TMP TO fec_read;
-GRANT SELECT ON TABLE ofec_elections_list_mv_TMP TO openfec_read;
+ALTER TABLE ofec_elections_list_mv_tmp OWNER TO fec;
+GRANT ALL ON TABLE ofec_elections_list_mv_tmp TO fec;
+GRANT SELECT ON TABLE ofec_elections_list_mv_tmp TO fec_read;
+GRANT SELECT ON TABLE ofec_elections_list_mv_tmp TO openfec_read;
 
-CREATE INDEX ON ofec_elections_list_mv_TMP(idx);
-CREATE INDEX ON ofec_elections_list_mv_TMP(election_yr);
-CREATE INDEX ON ofec_elections_list_mv_TMP(office);
-CREATE INDEX ON ofec_elections_list_mv_TMP(state);
-CREATE INDEX ON ofec_elections_list_mv_TMP(district);
-CREATE INDEX ON ofec_elections_list_mv_TMP(cycle);
-CREATE INDEX ON ofec_elections_list_mv_TMP(incumbent_id);
-CREATE INDEX ON ofec_elections_list_mv_TMP(incumbent_name);
+CREATE INDEX ON ofec_elections_list_mv_tmp(idx);
+CREATE INDEX ON ofec_elections_list_mv_tmp(election_yr);
+CREATE INDEX ON ofec_elections_list_mv_tmp(office);
+CREATE INDEX ON ofec_elections_list_mv_tmp(state);
+CREATE INDEX ON ofec_elections_list_mv_tmp(district);
+CREATE INDEX ON ofec_elections_list_mv_tmp(cycle);
+CREATE INDEX ON ofec_elections_list_mv_tmp(incumbent_id);
+CREATE INDEX ON ofec_elections_list_mv_tmp(incumbent_name);
 
 --------------------------------------------------------
 
 DROP MATERIALIZED VIEW IF EXISTS ofec_elections_list_mv;
 
-ALTER MATERIALIZED VIEW IF EXISTS ofec_elections_list_mv_TMP RENAME TO ofec_elections_list_mv;
+ALTER MATERIALIZED VIEW IF EXISTS ofec_elections_list_mv_tmp RENAME TO ofec_elections_list_mv;
 
 SELECT rename_indexes('ofec_elections_list_mv');

--- a/data/migrations/V0051__alter_ofec_elections_list_mv.sql
+++ b/data/migrations/V0051__alter_ofec_elections_list_mv.sql
@@ -1,0 +1,69 @@
+SET search_path = public, pg_catalog;
+
+DROP MATERIALIZED VIEW IF EXISTS ofec_elections_list_mv_TMP;
+
+CREATE MATERIALIZED VIEW ofec_elections_list_mv_TMP AS
+
+WITH incumbents AS (
+--So we don't show duplicate elections
+    SELECT DISTINCT ON (
+            race_pk) --sometimes more than one incumbent
+        race_pk,
+        cand_id,
+        cand_name,
+        lst_updt_dt
+    FROM disclosure.cand_valid_fec_yr
+    WHERE cand_ici = 'I'
+    --Where there are multiple entries, choose the most recent
+    ORDER BY race_pk, lst_updt_dt DESC
+), filtered_race AS (
+-- Only one row per office/district/cycle
+    SELECT DISTINCT ON (
+            office,
+            state,
+            district,
+            get_cycle(election_yr))
+        office,
+        state,
+        district,
+        election_yr,
+        get_cycle(election_yr) AS cycle,
+        race_pk
+    FROM disclosure.dim_race_inf
+        --to break a tie, show most recent?
+        --ORDER BY get_cycle(election_yr) DESC
+)
+SELECT
+    row_number() OVER () AS idx,
+    CAST (election_yr AS INTEGER),
+    CASE office WHEN 'P' THEN 0 WHEN 'S' THEN 1 ELSE 2 END AS sort_order,
+    office,
+    state,
+    district,
+    cycle,
+    cand_id AS incumbent_id,
+    cand_name AS incumbent_name
+FROM filtered_race
+LEFT JOIN incumbents
+    ON filtered_race.race_pk = incumbents.race_pk
+ORDER BY district ASC
+;
+
+ALTER TABLE ofec_elections_list_mv_TMP OWNER TO fec;
+GRANT ALL ON TABLE ofec_elections_list_mv_TMP TO fec;
+GRANT SELECT ON TABLE ofec_elections_list_mv_TMP TO fec_read;
+GRANT SELECT ON TABLE ofec_elections_list_mv_TMP TO openfec_read;
+
+CREATE INDEX ON ofec_elections_list_mv_TMP(idx);
+CREATE INDEX ON ofec_elections_list_mv_TMP(election_yr);
+CREATE INDEX ON ofec_elections_list_mv_TMP(office);
+CREATE INDEX ON ofec_elections_list_mv_TMP(state);
+CREATE INDEX ON ofec_elections_list_mv_TMP(district);
+CREATE INDEX ON ofec_elections_list_mv_TMP(cycle);
+CREATE INDEX ON ofec_elections_list_mv_TMP(incumbent_id);
+CREATE INDEX ON ofec_elections_list_mv_TMP(incumbent_name);
+
+-- ------------------------------------------------------
+DROP MATERIALIZED VIEW IF EXISTS ofec_elections_list_mv;
+
+ALTER MATERIALIZED VIEW IF EXISTS ofec_elections_list_mv_TMP RENAME TO ofec_elections_list_mv;

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -171,6 +171,7 @@ class TestCandidateAggregates(ApiBaseTest):
         self.candidate = factories.CandidateHistoryFactory(
             candidate_id='S123',
             two_year_period=2012,
+            candidate_election_year=2012,
         )
         self.committees = [
             factories.CommitteeHistoryFactory(cycle=2012, designation='P'),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -55,8 +55,8 @@ class TestSort(ApiBaseTest):
 
         ]
         candidateHistory = [
-            factories.CandidateHistoryFactory(candidate_id='C1234', two_year_period=2016, election_years=[2016], cycles=[2016]),
-            factories.CandidateHistoryFactory(candidate_id='C5678', two_year_period=2016, election_years=[2016], cycles=[2016])
+            factories.CandidateHistoryFactory(candidate_id='C1234', two_year_period=2016, election_years=[2016], cycles=[2016],candidate_election_year=2016),
+            factories.CandidateHistoryFactory(candidate_id='C5678', two_year_period=2016, election_years=[2016], cycles=[2016],candidate_election_year=2016)
         ]
         candidateTotals = [
             factories.CandidateTotalFactory(candidate_id='C1234', is_election=False, cycle=2016),

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -170,6 +170,7 @@ class TotalsCandidateView(ApiResource):
             sa.and_(
                 history.candidate_id == models.CandidateTotal.candidate_id,
                 year_column == models.CandidateTotal.cycle,
+                history.candidate_election_year == models.CandidateTotal.cycle,
             )
         ).join(
             models.Candidate,


### PR DESCRIPTION
Fixes bad join in materialized view causing some districts to repeat: https://www.fec.gov/data/elections/?cycle=2018&state=KS&district=4

Add new SQL migration file to remove the DISTINCT on cand_id for incumbents - some races have more than one incumbent where there was a special. 

Districts that probably have this issue are: CA-34, GA-06, KS-04, MT-00, SC-05 and UT-03. All these districts had members that resigned  and now have a new incumbent.

![1-25-2018 12-56-47 pm](https://user-images.githubusercontent.com/31420082/35403930-4e444234-01cf-11e8-89a6-fea852d1b459.jpg)

