### PR TITLE
[WIP] Add coverage_end_date to elections endpoint

### DIFF
--- a/webservices/common/models/totals.py
+++ b/webservices/common/models/totals.py
@@ -129,6 +129,7 @@ class CommitteeTotalsPresidential(CommitteeTotals):
     cash_on_hand_beginning_period = db.Column(db.Numeric(30, 2))
     net_operating_expenditures = db.Column('last_net_operating_expenditures', db.Numeric(30, 2))
     net_contributions = db.Column('last_net_contributions', db.Numeric(30, 2))
+    coverage_end_date = db.Column(db.DateTime, doc=docs.COVERAGE_END_DATE)
 
 
 class CandidateCommitteeTotalsPresidential(CandidateCommitteeTotals):
@@ -209,6 +210,7 @@ class CommitteeTotalsHouseSenate(CommitteeTotals):
     transfers_from_other_authorized_committee = db.Column(db.Numeric(30, 2))
     transfers_to_other_authorized_committee = db.Column(db.Numeric(30, 2))
     cash_on_hand_beginning_period = db.Column(db.Numeric(30, 2))
+    coverage_end_date = db.Column(db.DateTime, doc=docs.COVERAGE_END_DATE)
 
 
 class CommitteeTotalsIEOnly(BaseModel):

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -908,6 +908,7 @@ class ElectionSchema(ma.Schema):
     cash_on_hand_end_period = ma.fields.Decimal(places=2)
     won = ma.fields.Boolean()
     candidate_election_year = ma.fields.Int()
+    coverage_end_date = ma.fields.Date()
 augment_schemas(ElectionSchema)
 
 class ScheduleABySizeCandidateSchema(ma.Schema):


### PR DESCRIPTION
In order to show coverage end date on pages like https://www.fec.gov/data/elections/house/CO/04/2018/, we need to return coverage_end_date on /elections endoint

For issue: https://github.com/18F/fec-cms/issues/1470 - Add Coverage end date to Source reports column on election pages

WIP PR: https://github.com/18F/fec-cms/pull/1701
