### PR TITLE
Add coverage end date to /elections/endpoint

### DIFF
--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -908,6 +908,7 @@ class ElectionSchema(ma.Schema):
     cash_on_hand_end_period = ma.fields.Decimal(places=2)
     won = ma.fields.Boolean()
     candidate_election_year = ma.fields.Int()
+    coverage_end_date = ma.fields.Date()
 augment_schemas(ElectionSchema)
 
 class ScheduleABySizeCandidateSchema(ma.Schema):


### PR DESCRIPTION
In order to show coverage end date on pages like https://www.fec.gov/data/elections/house/CO/04/2018/, we need to return `coverage_end_date` on `/elections/` endpoint

**This PR unblocks:** https://github.com/18F/fec-cms/issues/1470 - Add Coverage end date to Source reports column on election pages which has a WIP PR: https://github.com/18F/fec-cms/pull/1701

Local test URL: http://127.0.0.1:5000/v1/elections/?page=1&office=house&sort=-total_receipts&state=VA&district=01&per_page=20&cycle=2018

## Screenshot
![image](https://user-images.githubusercontent.com/31420082/35653311-9db21c8e-06b5-11e8-8b35-157c929f4761.png)

