### PR TITLE
Fix elasticsearch reindex timeouts, revert global connection setting

### DIFF
--- a/webservices/legal_docs/index_management.py
+++ b/webservices/legal_docs/index_management.py
@@ -458,7 +458,7 @@ def restore_from_staging_index():
         "index": "docs"
       }
     }
-    es.reindex(body=body, wait_for_completion=True, timeout='5m')
+    es.reindex(body=body, wait_for_completion=True, request_timeout=1500)
 
     logger.info("Move aliases 'docs_index' and 'docs_search' to point to 'docs'")
     es.indices.update_aliases(body={"actions": [
@@ -496,4 +496,4 @@ def move_archived_murs():
         }
 
     logger.info("Copy archived MURs from 'docs' index to 'archived_murs' index")
-    es.reindex(body=body, wait_for_completion=True, timeout='5m')
+    es.reindex(body=body, wait_for_completion=True, request_timeout=1500)

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -330,7 +330,7 @@ def get_elasticsearch_connection():
         url = es_conn.get_url(url='uri')
     else:
         url = 'http://localhost:9200'
-    es = Elasticsearch(url, timeout=30, max_retries=10, retry_on_timeout=True)
+    es = Elasticsearch(url)
 
     return es
 


### PR DESCRIPTION
Elasticsearch was timing out on [restore_from_staging_index](https://github.com/18F/openFEC/blob/develop/webservices/legal_docs/index_management.py#L461) and [move_archived_murs](https://github.com/18F/openFEC/blob/develop/webservices/legal_docs/index_management.py#L474) on `reindex` commands, which was messing with our ability to restore from a staging index. (Needed for management command `refresh_current_legal_docs_zero_downtime`)

This PR reverts the global elasticsearch connection settings, and passes the proper parameter to the elasticsearch `reindex` command to allow the resource-heavy task to finish.

[Elasticsearch 2.4 API docs on timeout](http://elasticsearch-py.readthedocs.io/en/2.4.0/api.html#timeout)
"Global timeout can be set when constructing the client (see Connection‘s `timeout` parameter) or on a per-request basis using `request_timeout` (float value in seconds) as part of any API call"