### PR TITLE
Add support for expression-based sorts in API

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -343,6 +343,178 @@ class TestItemized(ApiBaseTest):
         )
         self.assertEqual(response.status_code, 422)
 
+    def test_pagination_with_sort_expression(self):
+        filings = [
+            factories.ScheduleBFactory()
+            for _ in range(30)
+        ]
+        page1 = self._results(api.url_for(ScheduleBView, **self.kwargs))
+        self.assertEqual(len(page1), 20)
+        self.assertEqual(
+            [int(each['sub_id']) for each in page1],
+            [each.sub_id for each in filings[:20]],
+        )
+        page2 = self._results(api.url_for(ScheduleBView, last_index=page1[-1]['sub_id'], **self.kwargs))
+        self.assertEqual(len(page2), 10)
+        self.assertEqual(
+            [int(each['sub_id']) for each in page2],
+            [each.sub_id for each in filings[20:]],
+        )
+
+    def test_pagination_with_null_sort_column_values_with_sort_expression(self):
+        filings = [
+            factories.ScheduleBFactory(disbursement_date=None)
+            for _ in range(5)
+        ]
+        filings = filings + [
+            factories.ScheduleBFactory(
+                disbursement_date=datetime.date(2016, 1, 1)
+            )
+            for _ in range(25)
+        ]
+        page1 = self._results(api.url_for(
+            ScheduleBView,
+            sort='disbursement_date',
+            **self.kwargs
+        ))
+        self.assertEqual(len(page1), 20)
+        self.assertEqual(
+            [int(each['sub_id']) for each in page1],
+            [each.sub_id for each in filings[5:25]],
+        )
+        self.assertEqual(
+            [each['disbursement_date'] for each in page1],
+            [each.disbursement_date.strftime('%Y-%m-%d') if each.disbursement_date else None for each in filings[5:25]]
+        )
+        page2 = self._results(
+            api.url_for(
+                ScheduleBView,
+                last_index=page1[-1]['sub_id'],
+                sort='disbursement_date',
+                **self.kwargs
+        ))
+        self.assertEqual(len(page2), 5)
+        self.assertEqual(
+            [int(each['sub_id']) for each in page2],
+            [each.sub_id for each in filings[25:]],
+        )
+        self.assertEqual(
+            [each['disbursement_date'] for each in page2],
+            [each.disbursement_date.strftime('%Y-%m-%d') if each.disbursement_date else None for each in filings[25:]]
+        )
+
+    def test_null_pagination_with_null_sort_column_values_descending_with_sort_expression(self):
+        filings = [
+            factories.ScheduleBFactory(disbursement_date=None)
+            #this range should ensure the page has a null transition
+            for _ in range(10)
+        ]
+        filings = filings + [
+            factories.ScheduleBFactory(
+                disbursement_date=datetime.date(2016, 1, 1)
+            )
+            for _ in range(15)
+        ]
+
+        page1 = self._results(api.url_for(
+            ScheduleBView,
+            sort='-disbursement_date',
+            sort_reverse_nulls='true',
+            **self.kwargs
+        ))
+
+        self.assertEqual(len(page1), 20)
+
+        top_reversed_from_middle = filings[9::-1]
+        reversed_from_bottom_to_middle = filings[-1:14:-1]
+        top_reversed_from_middle.extend(reversed_from_bottom_to_middle)
+        self.assertEqual(
+            [int(each['sub_id']) for each in page1],
+            [each.sub_id for each in top_reversed_from_middle],
+        )
+        self.assertEqual(
+            [each['disbursement_date'] for each in page1],
+            [each.disbursement_date.strftime('%Y-%m-%d') if each.disbursement_date else None for each in top_reversed_from_middle]
+        )
+        page2 = self._results(api.url_for(
+            ScheduleBView,
+            last_index=page1[-1]['sub_id'],
+            last_disbursement_date=page1[-1]['disbursement_date'],
+            sort='-disbursement_date',
+            **self.kwargs
+        ))
+        self.assertEqual(len(page2), 5)
+        self.assertEqual(
+            [int(each['sub_id']) for each in page2],
+            [each.sub_id for each in filings[14:9:-1]],
+        )
+        self.assertEqual(
+            [each['disbursement_date'] for each in page2],
+            [each.disbursement_date.strftime('%Y-%m-%d') if each.disbursement_date else None for each in filings[14:9:-1]]
+        )
+
+    def test_null_pagination_with_null_sort_column_values_ascending_with_sort_expression(self):
+        filings = [
+            factories.ScheduleBFactory(disbursement_date=None)
+            # this range should ensure the page has a null transition
+            for _ in range(10)
+            ]
+        filings = filings + [
+            factories.ScheduleBFactory(
+                disbursement_date=datetime.date(2016, 1, 1)
+            )
+            for _ in range(15)
+            ]
+
+        page1 = self._results(api.url_for(
+            ScheduleBView,
+            sort='disbursement_date',
+            sort_reverse_nulls='true',
+            **self.kwargs
+        ))
+
+        self.assertEqual(len(page1), 20)
+
+        top_reversed_from_middle = filings[10::]
+        reversed_from_bottom_to_middle = filings[0:5:]
+        top_reversed_from_middle.extend(reversed_from_bottom_to_middle)
+        self.assertEqual(
+            [int(each['sub_id']) for each in page1],
+            [each.sub_id for each in top_reversed_from_middle],
+        )
+        self.assertEqual(
+            [each['disbursement_date'] for each in page1],
+            [each.disbursement_date.strftime('%Y-%m-%d') if each.disbursement_date else None for each in
+             top_reversed_from_middle]
+        )
+        page2 = self._results(api.url_for(
+            ScheduleBView,
+            last_index=page1[-1]['sub_id'],
+            sort_null_only=True,
+            sort='disbursement_date',
+            **self.kwargs
+        ))
+        self.assertEqual(len(page2), 5)
+        self.assertEqual(
+            [int(each['sub_id']) for each in page2],
+            [each.sub_id for each in filings[5:10:]],
+        )
+        self.assertEqual(
+            [each['disbursement_date'] for each in page2],
+            [each.disbursement_date.strftime('%Y-%m-%d') if each.disbursement_date else None for each in
+             filings[5:10:]]
+        )
+
+    def test_pagination_with_null_sort_column_parameter_with_sort_expression(self):
+        response = self.app.get(
+            api.url_for(
+                ScheduleBView,
+                sort='disbursement_date',
+                last_disbursement_date='null'
+            )
+        )
+        self.assertEqual(response.status_code, 422)
+
     def test_pagination_bad_per_page(self):
         response = self.app.get(api.url_for(ScheduleAView, per_page=999))
         self.assertEqual(response.status_code, 422)

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -344,6 +344,10 @@ class TestItemized(ApiBaseTest):
         self.assertEqual(response.status_code, 422)
 
     def test_pagination_with_sort_expression(self):
+        # NOTE:  Schedule B is sorted by disbursement date with the expression
+        # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
+        # by default, so we must account for that with the results and slice
+        # the baseline list of objects accordingly!
         filings = [
             factories.ScheduleBFactory()
             for _ in range(30)
@@ -352,16 +356,20 @@ class TestItemized(ApiBaseTest):
         self.assertEqual(len(page1), 20)
         self.assertEqual(
             [int(each['sub_id']) for each in page1],
-            [each.sub_id for each in filings[:20]],
+            [each.sub_id for each in filings[:-21:-1]],
         )
         page2 = self._results(api.url_for(ScheduleBView, last_index=page1[-1]['sub_id'], **self.kwargs))
         self.assertEqual(len(page2), 10)
         self.assertEqual(
             [int(each['sub_id']) for each in page2],
-            [each.sub_id for each in filings[20:]],
+            [each.sub_id for each in filings[9::-1]],
         )
 
     def test_pagination_with_null_sort_column_values_with_sort_expression(self):
+        # NOTE:  Schedule B is sorted by disbursement date with the expression
+        # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
+        # by default, so we must account for that with the results and slice
+        # the baseline list of objects accordingly!
         filings = [
             factories.ScheduleBFactory(disbursement_date=None)
             for _ in range(5)
@@ -404,6 +412,10 @@ class TestItemized(ApiBaseTest):
         )
 
     def test_null_pagination_with_null_sort_column_values_descending_with_sort_expression(self):
+        # NOTE:  Schedule B is sorted by disbursement date with the expression
+        # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
+        # by default, so we must account for that with the results and slice
+        # the baseline list of objects accordingly!
         filings = [
             factories.ScheduleBFactory(disbursement_date=None)
             #this range should ensure the page has a null transition
@@ -454,6 +466,10 @@ class TestItemized(ApiBaseTest):
         )
 
     def test_null_pagination_with_null_sort_column_values_ascending_with_sort_expression(self):
+        # NOTE:  Schedule B is sorted by disbursement date with the expression
+        # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
+        # by default, so we must account for that with the results and slice
+        # the baseline list of objects accordingly!
         filings = [
             factories.ScheduleBFactory(disbursement_date=None)
             # this range should ensure the page has a null transition
@@ -506,6 +522,10 @@ class TestItemized(ApiBaseTest):
         )
 
     def test_pagination_with_null_sort_column_parameter_with_sort_expression(self):
+        # NOTE:  Schedule B is sorted by disbursement date with the expression
+        # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
+        # by default, so we must account for that with the results and slice
+        # the baseline list of objects accordingly!
         response = self.app.get(
             api.url_for(
                 ScheduleBView,

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -346,8 +346,8 @@ class TestItemized(ApiBaseTest):
     def test_pagination_with_sort_expression(self):
         # NOTE:  Schedule B is sorted by disbursement date with the expression
         # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
-        # by default, so we must account for that with the results and slice
-        # the baseline list of objects accordingly!
+        # by default (in descending order), so we must account for that with the
+        # results and slice the baseline list of objects accordingly!
         filings = [
             factories.ScheduleBFactory()
             for _ in range(30)
@@ -368,8 +368,8 @@ class TestItemized(ApiBaseTest):
     def test_pagination_with_null_sort_column_values_with_sort_expression(self):
         # NOTE:  Schedule B is sorted by disbursement date with the expression
         # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
-        # by default, so we must account for that with the results and slice
-        # the baseline list of objects accordingly!
+        # by default (in descending order), so we must account for that with the
+        # results and slice the baseline list of objects accordingly!
         filings = [
             factories.ScheduleBFactory(disbursement_date=None)
             for _ in range(5)
@@ -414,8 +414,8 @@ class TestItemized(ApiBaseTest):
     def test_null_pagination_with_null_sort_column_values_descending_with_sort_expression(self):
         # NOTE:  Schedule B is sorted by disbursement date with the expression
         # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
-        # by default, so we must account for that with the results and slice
-        # the baseline list of objects accordingly!
+        # by default (in descending order), so we must account for that with the
+        # results and slice the baseline list of objects accordingly!
         filings = [
             factories.ScheduleBFactory(disbursement_date=None)
             #this range should ensure the page has a null transition
@@ -468,8 +468,8 @@ class TestItemized(ApiBaseTest):
     def test_null_pagination_with_null_sort_column_values_ascending_with_sort_expression(self):
         # NOTE:  Schedule B is sorted by disbursement date with the expression
         # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
-        # by default, so we must account for that with the results and slice
-        # the baseline list of objects accordingly!
+        # by default (in descending order), so we must account for that with the
+        # results and slice the baseline list of objects accordingly!
         filings = [
             factories.ScheduleBFactory(disbursement_date=None)
             # this range should ensure the page has a null transition
@@ -524,8 +524,8 @@ class TestItemized(ApiBaseTest):
     def test_pagination_with_null_sort_column_parameter_with_sort_expression(self):
         # NOTE:  Schedule B is sorted by disbursement date with the expression
         # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
-        # by default, so we must account for that with the results and slice
-        # the baseline list of objects accordingly!
+        # by default (in descending order), so we must account for that with the
+        # results and slice the baseline list of objects accordingly!
         response = self.app.get(
             api.url_for(
                 ScheduleBView,

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -1,3 +1,4 @@
+import marshmallow as ma
 import sqlalchemy as sa
 
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -341,10 +342,14 @@ class ScheduleB(BaseItemized):
     @hybrid_property
     def sort_expressions(self):
         return {
-            'disbursement_date': sa.func.coalesce(
-                self.disbursement_date,
-                sa.cast('9999-12-31', sa.Date)
-            )
+            'disbursement_date': {
+                'expression': sa.func.coalesce(
+                    self.disbursement_date,
+                    sa.cast('9999-12-31', sa.Date)
+                ),
+                'field': ma.fields.Date,
+                'type': 'date',
+            },
         }
 
 

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -1,3 +1,5 @@
+import sqlalchemy as sa
+
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.dialects.postgresql import TSVECTOR
 
@@ -335,6 +337,16 @@ class ScheduleB(BaseItemized):
     comm_dt = db.Column('comm_dt', db.Date)
     cycle = db.Column('election_cycle', db.Integer)
     timestamp = db.Column('timestamp', db.DateTime)
+
+    @hybrid_property
+    def sort_expressions(self):
+        return {
+            'disbursement_date': sa.func.coalesce(
+                self.disbursement_date,
+                sa.cast('9999-12-31', sa.Date)
+            )
+        }
+
 
 class ScheduleBEfile(BaseRawItemized):
     __tablename__ = 'real_efile_sb4'

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -349,6 +349,7 @@ class ScheduleB(BaseItemized):
                 ),
                 'field': ma.fields.Date,
                 'type': 'date',
+                'null_sort': self.disbursement_date,
             },
         }
 

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -57,7 +57,7 @@ class ScheduleBView(ItemizedResource):
             args.make_sort_args(
                 default='-disbursement_date',
                 validator=args.OptionValidator(['disbursement_date', 'disbursement_amount']),
-            ),
+            )
         )
 
     def build_query(self, **kwargs):
@@ -77,7 +77,7 @@ class ScheduleBView(ItemizedResource):
 
 @doc(
     tags=['disbursements'],
-    description=docs.EFILING_TAG,
+    description=docs.EFILING_TAG
 )
 class ScheduleBEfileView(views.ApiResource):
     model = models.ScheduleBEfile

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -641,6 +641,7 @@ ScheduleBSchema = make_schema(
             'disbursement_description_text',
             'recipient_street_1',
             'recipient_street_2',
+            'sort_expressions',
         ),
         'relationships': [
             Relationship(

--- a/webservices/sorting.py
+++ b/webservices/sorting.py
@@ -68,6 +68,7 @@ def sort(query, key, model, aliases=None, join_columns=None, clear=False,
     is_expression = False
     expression_field = None
     expression_type = None
+    null_sort = None
 
     if clear:
         query = query.order_by(False)
@@ -103,6 +104,10 @@ def sort(query, key, model, aliases=None, join_columns=None, clear=False,
             column = model.sort_expressions[column_name]['expression']
             expression_field = model.sort_expressions[column_name]['field']
             expression_type = model.sort_expressions[column_name]['type']
+            null_sort = model.sort_expressions[column_name].get(
+                'null_sort',
+                model.sort_expressions[column_name]['expression']
+            )
             is_expression = True
 
     sort_column = order(column)
@@ -120,4 +125,5 @@ def sort(query, key, model, aliases=None, join_columns=None, clear=False,
         is_expression,
         expression_field,
         expression_type,
+        null_sort,
     )

--- a/webservices/sorting.py
+++ b/webservices/sorting.py
@@ -62,6 +62,13 @@ def sort(query, key, model, aliases=None, join_columns=None, clear=False,
     :param reverse_nulls: Swap order of null values on sorted column(s) in results;
         Ignored if hide_null is True
     """
+
+    # Start off assuming we are dealing with a sort column, not a sort
+    # expression.
+    is_expression = False
+    expression_field = None
+    expression_type = None
+
     if clear:
         query = query.order_by(False)
     # If the query contains multiple entities (i.e., isn't a simple query on a
@@ -93,7 +100,10 @@ def sort(query, key, model, aliases=None, join_columns=None, clear=False,
         # If the model has this and there is a matching expression for the
         # column, use the expression instead.
         if hasattr(model, 'sort_expressions') and column_name in model.sort_expressions:
-            column = model.sort_expressions[column_name]
+            column = model.sort_expressions[column_name]['expression']
+            expression_field = model.sort_expressions[column_name]['field']
+            expression_type = model.sort_expressions[column_name]['type']
+            is_expression = True
 
     sort_column = order(column)
     query = query.order_by(sort_column)
@@ -103,4 +113,11 @@ def sort(query, key, model, aliases=None, join_columns=None, clear=False,
     if hide_null:
         query = query.filter(column != None)  # noqa
 
-    return query, (column, order, column_name)
+    return query, (
+        column,
+        order,
+        column_name,
+        is_expression,
+        expression_field,
+        expression_type,
+    )

--- a/webservices/sorting.py
+++ b/webservices/sorting.py
@@ -82,15 +82,18 @@ def sort(query, key, model, aliases=None, join_columns=None, clear=False,
 
     # Store the text representation (name) of the sorting column in case we
     # swap it for an expression instead.
-    label = column.key
+    if hasattr(column, 'key'):
+        column_name = column.key
+    else:
+        column_name = column
 
     if model:
         # Check to see if the model has a sort_expressions attribute on it,
         # which contains a dictionary of column mappings to SQL expressions.
         # If the model has this and there is a matching expression for the
         # column, use the expression instead.
-        if hasattr(model, 'sort_expressions') and column.key in model.sort_expressions:
-            column = model.sort_expressions[column.key]
+        if hasattr(model, 'sort_expressions') and column_name in model.sort_expressions:
+            column = model.sort_expressions[column_name]
 
     sort_column = order(column)
     query = query.order_by(sort_column)
@@ -100,4 +103,4 @@ def sort(query, key, model, aliases=None, join_columns=None, clear=False,
     if hide_null:
         query = query.filter(column != None)  # noqa
 
-    return query, (column, order, label)
+    return query, (column, order, column_name)

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -122,7 +122,7 @@ class SeekCoalescePaginator(paginators.SeekPaginator):
         """
         ret = {'last_index': str(paginators.convert_value(result, self.index_column))}
         if self.sort_column:
-            key = 'last_{0}'.format(self.sort_column[0].key)
+            key = 'last_{0}'.format(self.sort_column[2])
             ret[key] = paginators.convert_value(result, self.sort_column[0])
             if ret[key] is None:
                 ret.pop(key)
@@ -133,7 +133,7 @@ class SeekCoalescePaginator(paginators.SeekPaginator):
 def fetch_seek_page(query, kwargs, index_column, clear=False, count=None, cap=100, eager=True):
     paginator = fetch_seek_paginator(query, kwargs, index_column, clear=clear, count=count, cap=cap)
     if paginator.sort_column is not None:
-        sort_index = kwargs['last_{0}'.format(paginator.sort_column[0].key)]
+        sort_index = kwargs['last_{0}'.format(paginator.sort_column[2])]
         if not sort_index and kwargs['sort_null_only'] and paginator.sort_column[1] == sa.asc:
             sort_index = None
             query = query.filter(paginator.sort_column[0] == None)

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -191,12 +191,21 @@ def fetch_seek_page(query, kwargs, index_column, clear=False, count=None, cap=10
     paginator = fetch_seek_paginator(query, kwargs, index_column, clear=clear, count=count, cap=cap)
     if paginator.sort_column is not None:
         sort_index = kwargs['last_{0}'.format(paginator.sort_column[2])]
+        null_sort_by = paginator.sort_column[0]
+
+        # Check to see if we are sorting by an expression.  If we are, we need
+        # to account for an alternative way to sort and page by null values.
+        if paginator.sort_column[3]:
+            null_sort_by = paginator.sort_column[6]
+
         if not sort_index and kwargs['sort_null_only'] and paginator.sort_column[1] == sa.asc:
+            print('In fetch_seek_page method')
             sort_index = None
-            query = query.filter(paginator.sort_column[0] == None)
+            query = query.filter(null_sort_by == None)
             paginator.cursor = query
     else:
         sort_index = None
+
     return paginator.get_page(last_index=kwargs['last_index'], sort_index=sort_index, eager=eager)
 
 


### PR DESCRIPTION
Addresses #2791

This changeset adds support for expression-based sorts in API queries, meaning that instead of sorting on a specific column we can choose to sort on an expression.  This is useful if an expression needs to be used to provide the desired value as opposed to what is stored in the column itself, especially if that expression is also used in the `WHERE` clause of the query.  Furthermore, this allows us to leverage expression-based indexes properly to ensure that the API queries are performant.

To create expression-based sorting options, you can follow the pattern developed for the `sort_expressions` hybrid property on the model in this PR, or followed a more [detailed set of instructions](https://github.com/18F/openFEC/wiki/Enabling-an-expression-based-sort) in the wiki.