### PR TITLE
[MERGE WITH GIT FLOW] (Hotfix) Fix the committe_id filter for /efile/reports/ endpoint

### DIFF
--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -92,7 +92,9 @@ class TestDownloadTask(ApiBaseTest):
             filings.FilingsView,
             reports.ReportsView,
             reports.CommitteeReportsView,
-            reports.EFilingSummaryView,
+            reports.EFilingHouseSenateSummaryView,
+            reports.EFilingPresidentialSummaryView,
+            reports.EFilingPacPartySummaryView,
             sched_a.ScheduleAView,
             sched_a.ScheduleAEfileView,
             sched_b.ScheduleBView,
@@ -104,7 +106,7 @@ class TestDownloadTask(ApiBaseTest):
         }
 
         for view in RESOURCE_WHITELIST:
-            if view.endpoint in ['reportsview', 'efilingsummaryview',]:
+            if view.endpoint in ['reportsview']:
                 url = api.url_for(
                     view,
                     committee_type=committee.committee_type

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -292,8 +292,18 @@ api.add_resource(
 )
 
 api.add_resource(
-    reports.EFilingSummaryView,
-    '/efile/reports/<string:committee_type>/',
+    reports.EFilingHouseSenateSummaryView,
+    '/efile/reports/house-senate/',
+)
+
+api.add_resource(
+    reports.EFilingPresidentialSummaryView,
+    '/efile/reports/presidential/',
+)
+
+api.add_resource(
+    reports.EFilingPacPartySummaryView,
+    '/efile/reports/pac-party/',
 )
 
 api.add_resource(filings.FilingsList, '/filings/')
@@ -322,7 +332,9 @@ apidoc.register(committees.CommitteeList, blueprint='v1')
 apidoc.register(committees.CommitteeHistoryView, blueprint='v1')
 apidoc.register(reports.ReportsView, blueprint='v1')
 apidoc.register(reports.CommitteeReportsView, blueprint='v1')
-apidoc.register(reports.EFilingSummaryView, blueprint='v1')
+apidoc.register(reports.EFilingHouseSenateSummaryView, blueprint='v1')
+apidoc.register(reports.EFilingPresidentialSummaryView, blueprint='v1')
+apidoc.register(reports.EFilingPacPartySummaryView, blueprint='v1')
 apidoc.register(totals.TotalsView, blueprint='v1')
 apidoc.register(totals.CandidateTotalsView, blueprint='v1')
 apidoc.register(sched_a.ScheduleAView, blueprint='v1')


### PR DESCRIPTION
## Summary 
So that the processed/raw toggle button maintains filters, fix the committee_id filter for the `/efile/reports/` endpoint

<img src="https://user-images.githubusercontent.com/31420082/35756278-a8f052d0-0838-11e8-82e9-7a998a2b15ce.png" width="150">

[Example of not filtering URL](https://api.open.fec.gov/v1/efile/reports/house-senate/?api_key=DEMO_KEY&sort_hide_null=true&committee_id=C00558627&sort=-receipt_date&per_page=30&page=1)

## Impacted areas of application
The dynamically changing models/schemas based off committee types was proving problematic for debugging and writing tests. I split the efile/reports into 3 different views: house-senate, presidentials, and pac-party, which made for a much simpler implementation at the expense of a bit of redundancy. 

Remaining items
- [x] Check prez/house-senate/pac-party
- [x] Add automated test(s)
- [x] redo PR as hotfix

cc: @PaulClark2 