### PR TITLE
Add multi-column sort to /elections/search/ endpoint, fix default sort order

### DIFF
--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -16,7 +16,9 @@ class TestElectionSearch(ApiBaseTest):
         factories.ElectionsListFactory(office='S', state='NJ', district='00', incumbent_id='SNJ123')
         factories.ElectionsListFactory(office='H', state='NJ', district='09', incumbent_id='HNJ123')
         factories.ElectionsListFactory(office='S', state='VA', district='00', incumbent_id='SVA123')
+        factories.ElectionsListFactory(office='H', state='VA', district='04', incumbent_id='HVA121')
         factories.ElectionsListFactory(office='H', state='VA', district='05', incumbent_id='HVA123')
+        factories.ElectionsListFactory(office='H', state='VA', district='06', incumbent_id='HVA124')
         factories.ElectionsListFactory(office='S', state='GA', district='00', incumbent_id='SGA123')
 
     def test_search_district(self):
@@ -38,7 +40,6 @@ class TestElectionSearch(ApiBaseTest):
         self.assertTrue(all([each['office'] == 'S' for each in results]))
 
     def test_search_zip(self):
-
         factories.ZipsDistrictsFactory(district='05', zip_code='22902', state_abbrevation='VA')
 
         results = self._results(api.url_for(ElectionsListView, zip='22902'))
@@ -52,6 +53,21 @@ class TestElectionSearch(ApiBaseTest):
         footer_count = response['pagination']['count']
         results_count = len(response['results'])
         self.assertEqual(footer_count, results_count)
+
+    def test_search_sort_default(self):
+        results = self._results(api.url_for(ElectionsListView, state='VA'))
+        self.assertEqual(results[0]['office'], 'P')
+        self.assertEqual(results[1]['office'], 'S')
+        self.assertEqual(results[2]['district'], '04')
+        self.assertEqual(results[3]['district'], '05')
+        self.assertEqual(results[4]['district'], '06')
+
+    def test_search_sort_state(self):
+        results = self._results(api.url_for(ElectionsListView))
+        self.assertTrue(
+            [each['state'] for each in results],
+            ['GA', 'NJ', 'NJ', 'US', 'VA', 'VA', 'VA', 'VA']
+        )
 
 
 class TestElections(ApiBaseTest):

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -52,11 +52,11 @@ class ElectionsListView(utils.Resource):
 
     @use_kwargs(args.paging)
     @use_kwargs(args.elections_list)
-    @use_kwargs(args.make_sort_args('sort_order'))
+    @use_kwargs(args.make_multi_sort_args(default=['sort_order', 'district',]))
     @marshal_with(schemas.ElectionsListPageSchema())
     def get(self, **kwargs):
         query = self._get_elections(kwargs)
-        return utils.fetch_page(query, kwargs)
+        return utils.fetch_page(query, kwargs, model=ElectionsList, multi=True)
 
     def _get_elections(self, kwargs):
         """Get elections from ElectionsList model."""


### PR DESCRIPTION
The `elections/search` endpoint should default to sort first by `sort_order` (P, S, H) and then `district` ascending.  This PR adds multi-sort capability to the endpoint and changes the default sort order to `sort_order`, `district`. In addition, I added tests for default and specified sort order for this endpoint.

Local test URL: http://localhost:5000/v1/elections/search/?per_page=100&cycle=2016&state=AZ

Expected behavior: P, S, H01, H02, etc sort order