### PR TITLE
Add "exclude" capabilities to filters.py 

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -38,15 +38,18 @@ class CandidateDetailFactory(BaseCandidateFactory):
     class Meta:
         model = models.CandidateDetail
 
+
 class CandidateCommitteeTotalsPresidentialFactory(BaseCandidateFactory):
     class Meta:
         model = models.CandidateCommitteeTotalsPresidential
     cycle = 2016
 
+
 class CandidateCommitteeTotalsHouseSenateFactory(BaseCandidateFactory):
     class Meta:
         model = models.CandidateCommitteeTotalsHouseSenate
     cycle = 2016
+
 
 class CandidateHistoryFactory(BaseCandidateFactory):
     class Meta:
@@ -70,12 +73,14 @@ class CandidateTotalFactory(BaseCandidateFactory):
         model = models.CandidateTotal
     cycle = 2016
 
+
 class CandidateFlagsFactory(BaseFactory):
     class Meta:
         model = models.CandidateFlags
 
     federal_funds_flag = False
     has_raised_funds = True
+
 
 class BaseCommitteeFactory(BaseFactory):
     committee_id = factory.Sequence(lambda n: 'ID{0}'.format(n))
@@ -95,6 +100,7 @@ class CommitteeHistoryFactory(BaseCommitteeFactory):
     class Meta:
         model = models.CommitteeHistory
     cycle = 2016
+
 
 class CommitteeTotalsHouseSenateFactory(BaseCommitteeFactory):
     class Meta:
@@ -134,6 +140,7 @@ class TotalsPacPartyFactory(BaseTotalsFactory):
     class Meta:
         model = models.CommitteeTotalsPacParty
 
+
 class TotalsIEOnlyFactory(BaseFactory):
     class Meta:
         model = models.CommitteeTotalsIEOnly
@@ -157,13 +164,16 @@ class ReportsPacPartyFactory(BaseTotalsFactory):
     class Meta:
         model = models.CommitteeReportsPacParty
 
+
 class EfileReportsPresidentialFactory(BaseFactory):
     class Meta:
         model = models.BaseF3PFiling
 
+
 class EfileReportsPacPartyFactory(BaseFactory):
     class Meta:
         model = models.BaseF3XFiling
+
 
 class EfileReportsHouseSenateFactory(BaseFactory):
     class Meta:
@@ -251,9 +261,11 @@ class EFilingsFactory(BaseFactory):
 class BaseFilingFactory(BaseFactory):
     file_number = factory.Sequence(lambda n: n)
 
+
 class BaseF3PFilingFactory(BaseFilingFactory):
     class Meta:
         model = models.BaseF3PFiling
+
 
 class BaseAggregateFactory(BaseFactory):
     committee_id = factory.Sequence(lambda n: str(n))
@@ -381,6 +393,7 @@ class ScheduleAByStateRecipientTotalsFactory(BaseFactory):
     class Meta:
         model = models.ScheduleAByStateRecipientTotals
     idx = factory.Sequence(lambda n: n)
+
 
 class AuditCaseFactory(BaseFactory):
     class Meta:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -120,7 +120,7 @@ class TestFilter(ApiBaseTest):
         # Filter for multiple string values
         query_committees = filters.filter_multi(
             models.Committee.query,
-            {'designation': ['P','U']},
+            {'designation': ['P', 'U']},
             CommitteeList.filter_multi_fields
         )
         self.assertEqual(
@@ -140,12 +140,32 @@ class TestFilter(ApiBaseTest):
         # Exclude multiple string values
         query_committees = filters.filter_multi(
             models.Committee.query,
-            {'designation': ['-P','-U']},
+            {'designation': ['-P', '-U']},
             CommitteeList.filter_multi_fields
         )
         self.assertEqual(
             set(query_committees.all()),
             set(each for each in self.committees if each.designation not in ['P','U']))
+
+    def test_filter_multi_combo(self):
+        # Exclude/include multiple integer values
+        query_dates = filters.filter_multi(
+            models.CalendarDate.query,
+            {'calendar_category_id': [-1, 3]},
+            CalendarDatesView.filter_multi_fields
+        )
+        self.assertEqual(
+            set(query_dates.all()),
+            set(each for each in self.dates if each.calendar_category_id not in [1] and each.calendar_category_id in [3]))
+        # Exclude/include multiple string values
+        query_committees = filters.filter_multi(
+            models.Committee.query,
+            {'designation': ['-P', 'U']},
+            CommitteeList.filter_multi_fields
+        )
+        self.assertEqual(
+            set(query_committees.all()),
+            set(each for each in self.committees if each.designation not in ['P'] and each.designation in ['U']))
 
     # Note: filter_fulltext is tested in test_itemized
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -3,6 +3,9 @@ from tests.common import ApiBaseTest
 
 from webservices import filters
 from webservices.common import models
+from webservices.resources.dates import CalendarDatesView
+from webservices.resources.committees import CommitteeList
+from webservices.resources.reports import get_match_filters
 
 
 class TestFilter(ApiBaseTest):
@@ -15,6 +18,23 @@ class TestFilter(ApiBaseTest):
             factories.ScheduleAFactory(entity_type='CCM'),
             factories.ScheduleAFactory(entity_type='COM'),
             factories.ScheduleAFactory(entity_type='PAC'),
+        ]
+        self.dates = [
+            factories.CalendarDateFactory(event_id=123, calendar_category_id=1),
+            factories.CalendarDateFactory(event_id=321, calendar_category_id=1),
+            factories.CalendarDateFactory(event_id=111, calendar_category_id=2),
+            factories.CalendarDateFactory(event_id=222, calendar_category_id=2),
+            factories.CalendarDateFactory(event_id=333, calendar_category_id=3),
+        ]
+        self.reports = [
+            factories.ReportsHouseSenateFactory(means_filed='e-file'),
+            factories.ReportsHouseSenateFactory(means_filed='paper'),
+        ]
+        self.committees = [
+            factories.CommitteeFactory(designation='P'),
+            factories.CommitteeFactory(designation='P'),
+            factories.CommitteeFactory(designation='B'),
+            factories.CommitteeFactory(designation='U'),
         ]
 
     def test_filter_contributor_type_individual(self):
@@ -46,3 +66,89 @@ class TestFilter(ApiBaseTest):
             {'contributor_type': ['individual', 'committee']},
         )
         self.assertEqual(set(query.all()), set(self.receipts))
+
+    def test_filter_match(self):
+        # Filter for a single integer value
+        query_dates = filters.filter_match(
+            models.CalendarDate.query,
+            {'event_id': 123},
+            CalendarDatesView.filter_match_fields
+        )
+        self.assertEqual(
+            set(query_dates.all()),
+            set(each for each in self.dates if each.event_id == 123))
+        # Filter for a single string value
+        query_reports = filters.filter_match(
+            models.CommitteeReportsHouseSenate.query,
+            {'filer_type': 'e-file'},
+            get_match_filters()
+        )
+        self.assertEqual(
+            set(query_reports.all()),
+            set(each for each in self.reports if each.means_filed == 'e-file'))
+
+    def test_filter_match_exclude(self):
+        # Exclude a single integer value
+        query_dates = filters.filter_match(
+            models.CalendarDate.query,
+            {'event_id': -321},
+            CalendarDatesView.filter_match_fields
+        )
+        self.assertEqual(
+            set(query_dates.all()),
+            set(each for each in self.dates if each.event_id != 321))
+        # Exclude a single string value
+        query_reports = filters.filter_match(
+            models.CommitteeReportsHouseSenate.query,
+            {'filer_type': '-paper'},
+            get_match_filters()
+        )
+        self.assertEqual(
+            set(query_reports.all()),
+            set(each for each in self.reports if each.means_filed != 'paper'))
+
+    def test_filter_multi(self):
+        # Filter for multiple integer values
+        query_dates = filters.filter_multi(
+            models.CalendarDate.query,
+            {'calendar_category_id': [1, 3]},
+            CalendarDatesView.filter_multi_fields
+        )
+        self.assertEqual(
+            set(query_dates.all()),
+            set(each for each in self.dates if each.calendar_category_id in [1,3]))
+        # Filter for multiple string values
+        query_committees = filters.filter_multi(
+            models.Committee.query,
+            {'designation': ['P','U']},
+            CommitteeList.filter_multi_fields
+        )
+        self.assertEqual(
+            set(query_committees.all()),
+            set(each for each in self.committees if each.designation in ['P','U']))
+
+    def test_filter_multi_exclude(self):
+        # Exclude multiple integer values
+        query_dates = filters.filter_multi(
+            models.CalendarDate.query,
+            {'calendar_category_id': [-1, -3]},
+            CalendarDatesView.filter_multi_fields
+        )
+        self.assertEqual(
+            set(query_dates.all()),
+            set(each for each in self.dates if each.calendar_category_id not in [1,3]))
+        # Exclude multiple string values
+        query_committees = filters.filter_multi(
+            models.Committee.query,
+            {'designation': ['-P','-U']},
+            CommitteeList.filter_multi_fields
+        )
+        self.assertEqual(
+            set(query_committees.all()),
+            set(each for each in self.committees if each.designation not in ['P','U']))
+    '''
+    TODO:
+    test_filter_fulltext_exclude
+
+    # note: filter_fulltext is tested in test_itemized
+    '''

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -20,11 +20,11 @@ class TestFilter(ApiBaseTest):
             factories.ScheduleAFactory(entity_type='PAC'),
         ]
         self.dates = [
-            factories.CalendarDateFactory(event_id=123, calendar_category_id=1),
-            factories.CalendarDateFactory(event_id=321, calendar_category_id=1),
-            factories.CalendarDateFactory(event_id=111, calendar_category_id=2),
-            factories.CalendarDateFactory(event_id=222, calendar_category_id=2),
-            factories.CalendarDateFactory(event_id=333, calendar_category_id=3),
+            factories.CalendarDateFactory(event_id=123, calendar_category_id=1, summary='July Quarterly Report Due'),
+            factories.CalendarDateFactory(event_id=321, calendar_category_id=1, summary='TX Primary Runoff'),
+            factories.CalendarDateFactory(event_id=111, calendar_category_id=2, summary='EC Reporting Period'),
+            factories.CalendarDateFactory(event_id=222, calendar_category_id=2, summary='IE Reporting Period'),
+            factories.CalendarDateFactory(event_id=333, calendar_category_id=3, summary='Executive Session'),
         ]
         self.reports = [
             factories.ReportsHouseSenateFactory(means_filed='e-file'),
@@ -146,9 +146,15 @@ class TestFilter(ApiBaseTest):
         self.assertEqual(
             set(query_committees.all()),
             set(each for each in self.committees if each.designation not in ['P','U']))
-    '''
-    TODO:
-    test_filter_fulltext_exclude
 
-    # note: filter_fulltext is tested in test_itemized
-    '''
+    # Note: filter_fulltext is tested in test_itemized
+
+    def test_filter_fulltext_exclude(self):
+        query_dates = filters.filter_fulltext(
+            models.CalendarDate.query,
+            {'summary': ['Report', '-IE']},
+            CalendarDatesView.filter_fulltext_fields
+        )
+        self.assertEqual(
+            set(query_dates.all()),
+            set(each for each in self.dates if 'Report' in each.summary and 'IE' not in each.summary))

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -126,6 +126,10 @@ class TestItemized(ApiBaseTest):
         self.assertEqual(results[0]['contributor_city'], 'NEW YORK')
 
     def test_filter_fulltext(self):
+        '''
+        Note: this is the only test for filter_fulltext.
+        If this is removed, please add a test to test_filters.py
+        '''
         names = ['David Koch', 'George Soros']
         filings = [
             factories.ScheduleAFactory(contributor_name=name)

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -21,7 +21,6 @@ def parse_exclude_arg(arg):
 def filter_match(query, kwargs, fields):
     for key, column in fields:
         if kwargs.get(key) is not None:
-            # Handle string and int excludes
             if is_exclude_arg(kwargs[key]):
                 query = query.filter(column != parse_exclude_arg(kwargs[key]))
             else:
@@ -32,17 +31,12 @@ def filter_match(query, kwargs, fields):
 def filter_multi(query, kwargs, fields):
     for key, column in fields:
         if kwargs.get(key):
-            #loop through list and exclude or include
-            exclude_list = []
-            include_list = []
-            for value in kwargs[key]:
-                if is_exclude_arg(value):
-                    exclude_list.append(parse_exclude_arg(value))
-                else:
-                    include_list.append(value)
-            if len(exclude_list) > 0:
+            # handle combination exclude/include lists
+            exclude_list = [parse_exclude_arg(value) for value in kwargs[key] if is_exclude_arg(value)]
+            include_list = [value for value in kwargs[key] if not is_exclude_arg(value)]
+            if exclude_list:
                 query = query.filter(column.notin_(exclude_list))
-            if len(include_list) > 0:
+            if include_list:
                 query = query.filter(column.in_(include_list))
     return query
 


### PR DESCRIPTION
Add capability to search for results not matching a certain value

Update `filters.py` : `filter_match`, `filter_multi`, `filter_fulltext` to use `not_in` functionality to exclude results with a certain value when passed `parameter=-value`. I also check for when API is passed "key=A and key!=B" and handled that behavior by splitting out the arguments

- [x] Use list comprehension in `filter_multi`?
- [x] Add automated tests
- [x] Use [instance](https://github.com/18F/openFEC/pull/2937#discussion_r169325116)
- [x] update all filter functions: `filter_fulltext`
- [x] Add combo exclude/include test for `filter_multi`

___
Filters that didn't get updated with exclude capabilities:
`filter_range` exclude - possibly for the future, this hasn't been requested.
`filter_contributor_type`? `filter_election` - not needed
