### PR TITLE
Remove unused ApiResource function, refactor /reports/ "exclude" report_type 

### DIFF
--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -52,12 +52,6 @@ class ApiResource(utils.Resource):
             query = query.options(*self.query_options)
         return query
 
-    def filter_fulltext(self, query, kwargs):
-        for key, column in self.filter_fulltext_fields:
-            if kwargs.get(key):
-                query = utils.search_text(query, column, kwargs[key])
-        return query
-
 
 class ItemizedResource(ApiResource):
 


### PR DESCRIPTION
Addresses https://github.com/18F/openFEC/issues/2953
Followup work from issue https://github.com/18F/openFEC/issues/2897

- Removes unused `filter_fulltext` function in `ApiResource` 
- Refactors `reports.py` to use "exclude" functionality added to `filter_multi` in`filters.py`
