### PR TITLE
Handle nulls in "exclude" filters, add request_type to filings

### DIFF
--- a/data/migrations/V0063__filings_add_request_type_idx.sql
+++ b/data/migrations/V0063__filings_add_request_type_idx.sql
@@ -1,0 +1,6 @@
+--Create index on new filter field request_type. Should this be COALLATED?
+
+CREATE INDEX ofec_filings_all_mv_request_type_idx1
+  ON public.ofec_filings_all_mv
+  USING btree
+  (request_type);

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -8,10 +8,155 @@ from webservices.resources.committees import CommitteeList
 from webservices.resources.reports import get_match_filters
 
 
-class TestFilter(ApiBaseTest):
+class TestFilterMatch(ApiBaseTest):
 
     def setUp(self):
-        super(TestFilter, self).setUp()
+        super(TestFilterMatch, self).setUp()
+        self.dates = [
+            factories.CalendarDateFactory(event_id=123, calendar_category_id=1, summary='July Quarterly Report Due'),
+            factories.CalendarDateFactory(event_id=321, calendar_category_id=1, summary='TX Primary Runoff'),
+            factories.CalendarDateFactory(event_id=111, calendar_category_id=2, summary='EC Reporting Period'),
+            factories.CalendarDateFactory(event_id=222, calendar_category_id=2, summary='IE Reporting Period'),
+            factories.CalendarDateFactory(event_id=333, calendar_category_id=3, summary='Executive Session'),
+            factories.CalendarDateFactory(calendar_category_id=3, summary='Missing ID'),
+        ]
+        self.reports = [
+            factories.ReportsHouseSenateFactory(means_filed='e-file'),
+            factories.ReportsHouseSenateFactory(means_filed='paper'),
+            factories.ReportsHouseSenateFactory(),
+        ]
+
+    def test_filter_match(self):
+        # Filter for a single integer value
+        query_dates = filters.filter_match(
+            models.CalendarDate.query,
+            {'event_id': 123},
+            CalendarDatesView.filter_match_fields
+        )
+        self.assertEqual(
+            set(query_dates.all()),
+            set(each for each in self.dates if each.event_id == 123))
+
+        # Filter for a single string value
+        query_reports = filters.filter_match(
+            models.CommitteeReportsHouseSenate.query,
+            {'filer_type': 'e-file'},
+            get_match_filters()
+        )
+        self.assertEqual(
+            set(query_reports.all()),
+            set(each for each in self.reports if each.means_filed == 'e-file'))
+
+    def test_filter_match_exclude(self):
+        # Exclude a single integer value
+        query_dates = filters.filter_match(
+            models.CalendarDate.query,
+            {'event_id': -321},
+            CalendarDatesView.filter_match_fields
+        )
+        self.assertEqual(
+            set(query_dates.all()),
+            set(each for each in self.dates if each.event_id != 321 or each.event_id is None))
+
+        # Exclude a single string value
+        query_reports = filters.filter_match(
+            models.CommitteeReportsHouseSenate.query,
+            {'filer_type': '-paper'},
+            get_match_filters()
+        )
+        self.assertEqual(
+            set(query_reports.all()),
+            set(each for each in self.reports if each.means_filed != 'paper'))
+
+
+class TestFilterMulti(ApiBaseTest):
+
+    def setUp(self):
+        super(TestFilterMulti, self).setUp()
+        self.dates = [
+            factories.CalendarDateFactory(event_id=123, calendar_category_id=1, summary='July Quarterly Report Due'),
+            factories.CalendarDateFactory(event_id=321, calendar_category_id=1, summary='TX Primary Runoff'),
+            factories.CalendarDateFactory(event_id=111, calendar_category_id=2, summary='EC Reporting Period'),
+            factories.CalendarDateFactory(event_id=222, calendar_category_id=2, summary='IE Reporting Period'),
+            factories.CalendarDateFactory(event_id=333, calendar_category_id=3, summary='Executive Session'),
+            factories.CalendarDateFactory(calendar_category_id=3, summary='Missing ID'),
+        ]
+        self.committees = [
+            factories.CommitteeFactory(name='Candidate 1 for Prez', designation='P'),
+            factories.CommitteeFactory(name='Candidate 2 for Prez', designation='P'),
+            factories.CommitteeFactory(name='B-type committee', designation='B'),
+            factories.CommitteeFactory(name='U-type committee', designation='U'),
+            factories.CommitteeFactory(name='None-type committee'),
+        ]
+
+    def test_filter_multi(self):
+        # Filter for multiple integer values
+        query_dates = filters.filter_multi(
+            models.CalendarDate.query,
+            {'calendar_category_id': [1, 3]},
+            CalendarDatesView.filter_multi_fields
+        )
+        self.assertEqual(
+            set(query_dates.all()),
+            set(each for each in self.dates if each.calendar_category_id in [1,3]))
+
+        # Filter for multiple string values
+        query_committees = filters.filter_multi(
+            models.Committee.query,
+            {'designation': ['P', 'U']},
+            CommitteeList.filter_multi_fields
+        )
+        self.assertEqual(
+            set(query_committees.all()),
+            set(each for each in self.committees if each.designation in ['P','U']))
+
+    def test_filter_multi_exclude(self):
+        # Exclude multiple integer values
+        query_dates = filters.filter_multi(
+            models.CalendarDate.query,
+            {'calendar_category_id': [-1, -3]},
+            CalendarDatesView.filter_multi_fields
+        )
+        self.assertEqual(
+            set(query_dates.all()),
+            set(each for each in self.dates if each.calendar_category_id not in [1,3]))
+
+        # Exclude multiple string values
+        query_committees = filters.filter_multi(
+            models.Committee.query,
+            {'designation': ['-P', '-U']},
+            CommitteeList.filter_multi_fields
+        )
+        self.assertEqual(
+            set(query_committees.all()),
+            set(each for each in self.committees if each.designation not in ['P','U'] or each.designation is None))
+
+    def test_filter_multi_combo(self):
+        # Exclude/include multiple integer values
+        query_dates = filters.filter_multi(
+            models.CalendarDate.query,
+            {'calendar_category_id': [-1, 3]},
+            CalendarDatesView.filter_multi_fields
+        )
+        self.assertEqual(
+            set(query_dates.all()),
+            set(each for each in self.dates if each.calendar_category_id not in [1] and each.calendar_category_id in [3]))
+
+        # Exclude/include multiple string values
+        query_committees = filters.filter_multi(
+            models.Committee.query,
+            {'designation': ['-P', 'U']},
+            CommitteeList.filter_multi_fields
+        )
+        self.assertEqual(
+            set(query_committees.all()),
+            set(each for each in self.committees if each.designation not in ['P'] and each.designation in ['U']))
+
+
+class TestFilterOther(ApiBaseTest):
+
+    def setUp(self):
+        super(TestFilterOther, self).setUp()
         self.receipts = [
             factories.ScheduleAFactory(entity_type=None),
             factories.ScheduleAFactory(entity_type='IND'),
@@ -25,16 +170,6 @@ class TestFilter(ApiBaseTest):
             factories.CalendarDateFactory(event_id=111, calendar_category_id=2, summary='EC Reporting Period'),
             factories.CalendarDateFactory(event_id=222, calendar_category_id=2, summary='IE Reporting Period'),
             factories.CalendarDateFactory(event_id=333, calendar_category_id=3, summary='Executive Session'),
-        ]
-        self.reports = [
-            factories.ReportsHouseSenateFactory(means_filed='e-file'),
-            factories.ReportsHouseSenateFactory(means_filed='paper'),
-        ]
-        self.committees = [
-            factories.CommitteeFactory(designation='P'),
-            factories.CommitteeFactory(designation='P'),
-            factories.CommitteeFactory(designation='B'),
-            factories.CommitteeFactory(designation='U'),
         ]
 
     def test_filter_contributor_type_individual(self):
@@ -66,106 +201,6 @@ class TestFilter(ApiBaseTest):
             {'contributor_type': ['individual', 'committee']},
         )
         self.assertEqual(set(query.all()), set(self.receipts))
-
-    def test_filter_match(self):
-        # Filter for a single integer value
-        query_dates = filters.filter_match(
-            models.CalendarDate.query,
-            {'event_id': 123},
-            CalendarDatesView.filter_match_fields
-        )
-        self.assertEqual(
-            set(query_dates.all()),
-            set(each for each in self.dates if each.event_id == 123))
-        # Filter for a single string value
-        query_reports = filters.filter_match(
-            models.CommitteeReportsHouseSenate.query,
-            {'filer_type': 'e-file'},
-            get_match_filters()
-        )
-        self.assertEqual(
-            set(query_reports.all()),
-            set(each for each in self.reports if each.means_filed == 'e-file'))
-
-    def test_filter_match_exclude(self):
-        # Exclude a single integer value
-        query_dates = filters.filter_match(
-            models.CalendarDate.query,
-            {'event_id': -321},
-            CalendarDatesView.filter_match_fields
-        )
-        self.assertEqual(
-            set(query_dates.all()),
-            set(each for each in self.dates if each.event_id != 321))
-        # Exclude a single string value
-        query_reports = filters.filter_match(
-            models.CommitteeReportsHouseSenate.query,
-            {'filer_type': '-paper'},
-            get_match_filters()
-        )
-        self.assertEqual(
-            set(query_reports.all()),
-            set(each for each in self.reports if each.means_filed != 'paper'))
-
-    def test_filter_multi(self):
-        # Filter for multiple integer values
-        query_dates = filters.filter_multi(
-            models.CalendarDate.query,
-            {'calendar_category_id': [1, 3]},
-            CalendarDatesView.filter_multi_fields
-        )
-        self.assertEqual(
-            set(query_dates.all()),
-            set(each for each in self.dates if each.calendar_category_id in [1,3]))
-        # Filter for multiple string values
-        query_committees = filters.filter_multi(
-            models.Committee.query,
-            {'designation': ['P', 'U']},
-            CommitteeList.filter_multi_fields
-        )
-        self.assertEqual(
-            set(query_committees.all()),
-            set(each for each in self.committees if each.designation in ['P','U']))
-
-    def test_filter_multi_exclude(self):
-        # Exclude multiple integer values
-        query_dates = filters.filter_multi(
-            models.CalendarDate.query,
-            {'calendar_category_id': [-1, -3]},
-            CalendarDatesView.filter_multi_fields
-        )
-        self.assertEqual(
-            set(query_dates.all()),
-            set(each for each in self.dates if each.calendar_category_id not in [1,3]))
-        # Exclude multiple string values
-        query_committees = filters.filter_multi(
-            models.Committee.query,
-            {'designation': ['-P', '-U']},
-            CommitteeList.filter_multi_fields
-        )
-        self.assertEqual(
-            set(query_committees.all()),
-            set(each for each in self.committees if each.designation not in ['P','U']))
-
-    def test_filter_multi_combo(self):
-        # Exclude/include multiple integer values
-        query_dates = filters.filter_multi(
-            models.CalendarDate.query,
-            {'calendar_category_id': [-1, 3]},
-            CalendarDatesView.filter_multi_fields
-        )
-        self.assertEqual(
-            set(query_dates.all()),
-            set(each for each in self.dates if each.calendar_category_id not in [1] and each.calendar_category_id in [3]))
-        # Exclude/include multiple string values
-        query_committees = filters.filter_multi(
-            models.Committee.query,
-            {'designation': ['-P', 'U']},
-            CommitteeList.filter_multi_fields
-        )
-        self.assertEqual(
-            set(query_committees.all()),
-            set(each for each in self.committees if each.designation not in ['P'] and each.designation in ['U']))
 
     # Note: filter_fulltext is tested in test_itemized
 

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -260,6 +260,7 @@ filings = {
     'is_amended': fields.Bool(description='Filing has been amended'),
     'most_recent': fields.Bool(description='Filing is either new or is the most-recently filed amendment'),
     'report_type': fields.List(IStr, description=docs.REPORT_TYPE),
+    'request_type': fields.List(IStr, description=docs.REQUEST_TYPE),
     'document_type': fields.List(IStr, description=docs.DOC_TYPE),
     'beginning_image_number': fields.List(fields.Str, description=docs.BEGINNING_IMAGE_NUMBER),
     'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -797,7 +797,26 @@ REPORT_TYPE = 'Name of report where the underlying data comes from:\n\
          (YE)\n\
 '
 
-REQUEST_TYPE = 'RFAI types. For example, form 1 RFAI is equal to 1. Ex: request_type=1'
+REQUEST_TYPE = 'Requests for additional information (RFAIs)\n\
+sent to filers.\n\
+The request type is based on\n\
+the type of document filed:\n\
+    - 1 Statement of \n\
+        Organization\n\
+    - 2 Report of Receipts\n\
+        and Expenditures\n\
+        (Form 3 and 3X)\n\
+    - 3 Second Notice - Reports\n\
+    - 4 Request for\n\
+        Additional Information\n\
+    - 5 Informational - Reports\n\
+    - 6 Second Notice -\n\
+        Statement of Organization\n\
+    - 7 Failure to File\n\
+    - 8 From Public Disclosure\n\
+    - 9 From Multi\n\
+        Candidate Status\n\
+'
 
 REPORT_TYPE_W_EXCLUDE = 'Report type; prefix with "-" to exclude. '+REPORT_TYPE
 

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -796,6 +796,9 @@ REPORT_TYPE = 'Name of report where the underlying data comes from:\n\
     - MSY Monthly Semi-Annual\n\
          (YE)\n\
 '
+
+REQUEST_TYPE = 'RFAI types. For example, form 1 RFAI is equal to 1. Ex: request_type=1'
+
 REPORT_TYPE_W_EXCLUDE = 'Report type; prefix with "-" to exclude. '+REPORT_TYPE
 
 RECEIPT_DATE = 'Date the FEC received the electronic or paper record'

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -11,7 +11,7 @@ def is_exclude_arg(arg):
 
 
 def parse_exclude_arg(arg):
-    # Integers will come in as negative and strings will start with -
+    # Integers will come in as negative and strings will start with "-""
     if isinstance(arg, int):
         return abs(arg)
     else:
@@ -22,7 +22,8 @@ def filter_match(query, kwargs, fields):
     for key, column in fields:
         if kwargs.get(key) is not None:
             if is_exclude_arg(kwargs[key]):
-                query = query.filter(column != parse_exclude_arg(kwargs[key]))
+                query = query.filter(sa.or_(column != parse_exclude_arg(kwargs[key]),
+                                            column == None))
             else:
                 query = query.filter(column == kwargs[key])
     return query
@@ -35,7 +36,8 @@ def filter_multi(query, kwargs, fields):
             exclude_list = [parse_exclude_arg(value) for value in kwargs[key] if is_exclude_arg(value)]
             include_list = [value for value in kwargs[key] if not is_exclude_arg(value)]
             if exclude_list:
-                query = query.filter(column.notin_(exclude_list))
+                query = query.filter(sa.or_(column.notin_(exclude_list),
+                                            column == None))
             if include_list:
                 query = query.filter(column.in_(include_list))
     return query

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -29,6 +29,7 @@ class BaseFilings(views.ApiResource):
         ('document_type', models.Filings.document_type),
         ('report_year', models.Filings.report_year),
         ('form_type', models.Filings.form_type),
+        ('request_type', models.Filings.request_type),
         ('file_number', models.Filings.file_number),
         ('primary_general_indicator', models.Filings.primary_general_indicator),
         ('amendment_indicator', models.Filings.amendment_indicator),


### PR DESCRIPTION
**Update exclude logic**
- Change "exclude" filter logic in API to return null values. When searching for "not value A" it should return all values not matching A **as well as** null values for that parameter.
- Update automated tests for new logic. Separate tests into different classes to preserve scope. (`ReportsHouseSenateFactory` creates committees too)

**Add request type**
- Add `request_type` filter to /filings/ endpoint (Thanks @patphongs!)
- Add index to the `request_type` column to `public.ofec_filings_all_mv` 

https://github.com/18F/fec-cms/issues/1760