### PR TITLE
Attempt to fix Redis connection retries

### DIFF
--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -26,13 +26,27 @@ if env.app.get('space_name', 'unknown-space').lower() != 'feature':
 
 def redis_url():
     app_space = env.get_credential('space_name')
-    if app_space:
-        redis = env.get_service(label='redis32')
-        while redis is None:
+
+    if app_space is not None:
+        logger.info('Running in a cloud.gov space.')
+
+        while True:
+            logger.info('Attempting to connect to Redis...')
             redis = env.get_service(label='redis32')
-            logger.error('Connecting to Redis.....')
+
+            if redis is not None:
+                logger.info('Successfully connected to Redis.')
+                break
+            else:
+                logger.error('Could not connect to Redis, retrying...')
+
         url = redis.get_url(host='hostname', password='password', port='port')
         return 'redis://{}'.format(url)
+    else:
+        logger.debug(
+            'Not running in a cloud.gov space, attempting to connect locally.'
+        )
+
     return env.get_credential('FEC_REDIS_URL', 'redis://localhost:6379/0')
 
 app = celery.Celery('openfec')

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -28,7 +28,9 @@ def redis_url():
     app_space = env.get_credential('space_name')
 
     if app_space is not None:
-        logger.info('Running in a cloud.gov space.')
+        logger.info(
+            'Running in the {0} space in cloud.gov.'.format(app_space)
+        )
 
         while True:
             logger.info('Attempting to connect to Redis...')


### PR DESCRIPTION
This changeset attempts to fix an issue we are running into with our Redis connection retry adjustment.  At the very least it provides more logging to give insight into where the breakdown might be (or could be in the future), but a couple of the checks have been adjusted to be more explicit and might help alleviate the issue as well.  If not, we will continue to monitor and adjust, but we will need to get this running in the cloud.gov environment to see.