### PR TITLE
changed transation to transaction in docs.py

### DIFF
--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -258,7 +258,7 @@ This is a two-year period that is derived from the year a transaction took place
 Itemized Schedule A and Schedule B tables. In cases where we have the date of the transaction
 (contribution_receipt_date in schedules/schedule_a, disbursement_date in schedules/schedule_b)
 the two_year_transaction_period is named after the ending, even-numbered year. If we do not
-have the date  of the transation, we fall back to using the report year (report_year in both
+have the date  of the transaction, we fall back to using the report year (report_year in both
 tables) instead,  making the same cycle adjustment as necessary. If no transaction year is
 specified, the results default to the most current cycle.
 '''


### PR DESCRIPTION
Fix misspelling in   /schedules/schedule_b/{sub_id}/ two_year_transaction_period description.

It looks like in [this PR](small definition tweak #1723) some changes were made and a word was misspelled, so this PR fixes that. 
