### PR TITLE
[MERGE WITH GIT FLOW] Hotfix: Filter `RECENTLY_MODIFIED_STARTING_MUR` query to filter for just `case_type='MUR'`

### DIFF
--- a/webservices/tasks/legal_docs.py
+++ b/webservices/tasks/legal_docs.py
@@ -21,6 +21,7 @@ RECENTLY_MODIFIED_STARTING_MUR = """
     SELECT case_no, pg_date
     FROM fecmur.cases_with_parsed_case_serial_numbers
     WHERE pg_date >= NOW() - '1 day'::INTERVAL
+    AND case_type = 'MUR'
     ORDER BY case_serial
     LIMIT 1;
 """


### PR DESCRIPTION
Celery-worker checks every 15 minutes to see if there are any MURs modified in the past day. However, the query for modified MURs wasn't properly filtering for just MURs. As a result, when AF/ADR cases were updated, MURs were reloaded starting with that number. When it was a low number, *all* MURs ended up getting reloaded, causing significant resource problems.

This PR updates the `RECENTLY_MODIFIED_STARTING_MUR` query to filter for just `case_type='MUR'`